### PR TITLE
EASI-1832 - Added sign in page for MINT

### DIFF
--- a/src/i18n/en-US/home.ts
+++ b/src/i18n/en-US/home.ts
@@ -1,6 +1,12 @@
 const home = {
   title: 'Welcome to MINT',
-  signIn: 'Sign in to start'
+  signIn: 'Sign in to start',
+  mintPurpose: 'You can use MINT to:',
+  startNow: 'Start a draft model plan',
+  mintTasks: [
+    'collaborate on requirements for new CMMI models and demonstrations',
+    'access resources to help you complete your model plans'
+  ]
 };
 
 export default home;

--- a/src/views/Home/WelcomeText.tsx
+++ b/src/views/Home/WelcomeText.tsx
@@ -9,13 +9,33 @@ const WelcomeText = () => {
   const { t } = useTranslation('home');
   const { authState } = useOktaAuth();
 
+  const mintTasks: string[] = t('mintTasks', {
+    returnObjects: true
+  });
+
   return (
     <div className="tablet:grid-col-9">
       <PageHeading>{t('home:title')}</PageHeading>
+      <p>{t('mintPurpose')}</p>
+      <ul className="line-height-body-5 margin-bottom-4">
+        {mintTasks.map(task => (
+          <li key={task}>{task}</li>
+        ))}
+      </ul>
       {authState?.isAuthenticated ? (
-        <></>
+        <UswdsReactLink
+          className="usa-button"
+          variant="unstyled"
+          to="/models/new-plan"
+        >
+          {t('startNow')}
+        </UswdsReactLink>
       ) : (
-        <UswdsReactLink className="usa-button" variant="unstyled" to="/signin">
+        <UswdsReactLink
+          className="usa-button width-auto"
+          variant="unstyled"
+          to="/signin"
+        >
           {t('signIn')}
         </UswdsReactLink>
       )}


### PR DESCRIPTION
# EASI-1832

## Changes and Description

- Added text changes for sign in page

## How to test this change

Navigatie to localhost:3005
Compare to [Figma](https://www.figma.com/file/M72DReE73SSXMN48WZfaKN/Model-Intake?node-id=532%3A54220)

![Screen Shot 2022-04-01 at 2 34 24 PM](https://user-images.githubusercontent.com/95709965/161322117-d9173b14-02ca-4479-8c50-1afad2a7d18f.png)

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
