### PR TITLE
 update CMSCenters resolver to return CMS centers instead of CMMI groups

### DIFF
--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -18,13 +18,13 @@ import (
 
 func (r *modelPlanResolver) CmsCenters(ctx context.Context, obj *models.ModelPlan) ([]models.CMSCenter, error) {
 	// TODO: We should probably have a better way to handle enum arrays
-	var cmsGroups []models.CMSCenter
+	var cmsCenters []models.CMSCenter
 
-	for _, item := range obj.CMMIGroups {
-		cmsGroups = append(cmsGroups, models.CMSCenter(item))
+	for _, item := range obj.CMSCenters {
+		cmsCenters = append(cmsCenters, models.CMSCenter(item))
 	}
 
-	return cmsGroups, nil
+	return cmsCenters, nil
 }
 
 func (r *modelPlanResolver) CmmiGroups(ctx context.Context, obj *models.ModelPlan) ([]model.CMMIGroup, error) {


### PR DESCRIPTION
# No Ref

## Changes and Description

- CMSCenters resolver to return CMS centers instead of CMMI groups
- Was set incorrectly

<!-- Put a description here! -->

## How to test this change

Create and Update a model plan

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
