### PR TITLE
Easi 1998/archive model plan

### DIFF
--- a/cypress/integration/modelPlan.spec.js
+++ b/cypress/integration/modelPlan.spec.js
@@ -34,4 +34,30 @@ describe('The Model Plan Form', () => {
 
     cy.contains('h1', 'Model Plan task list');
   });
+
+  it('archives a model plan', () => {
+    cy.visit('/models/f11eb129-2c80-4080-9440-439cbe1a286f/task-list');
+
+    cy.wait(1000);
+
+    cy.contains('button', 'Remove your Model Plan').click();
+
+    cy.contains('button', 'Remove request').click();
+
+    cy.wait(1000);
+
+    cy.location().should(loc => {
+      expect(loc.pathname).to.eq('/');
+    });
+
+    cy.wait(1000);
+
+    cy.get('table').within(() => {
+      cy.get('tbody').within(() => {
+        cy.contains('th', 'My excellent plan that I just initiated').should(
+          'not.exist'
+        );
+      });
+    });
+  });
 });

--- a/scripts/dev
+++ b/scripts/dev
@@ -415,7 +415,7 @@ namespace :test do
 
   desc "Run JS tests (pass path to scope to that location)"
   task :js => :consume_args do |t, args|
-    sh "yarn", "run", "craco", "test", "--watchAll=false", *args
+    sh "yarn", "run", "craco", "test", "--u", "--watchAll=false", *args
   end
   namespace :js do
     desc "Run JS tests with a matching name (pass needle as additional option)"

--- a/src/queries/GetModelPlanQuery.ts
+++ b/src/queries/GetModelPlanQuery.ts
@@ -5,6 +5,11 @@ export default gql`
     modelPlan(id: $id) {
       id
       modelName
+      modelCategory
+      cmsCenters
+      cmsOther
+      cmmiGroups
+      archived
       status
       basics {
         id

--- a/src/queries/GetModelPlanQuery.ts
+++ b/src/queries/GetModelPlanQuery.ts
@@ -5,6 +5,7 @@ export default gql`
     modelPlan(id: $id) {
       id
       modelName
+      status
       basics {
         id
       }

--- a/src/queries/UpdateModelPlan.ts
+++ b/src/queries/UpdateModelPlan.ts
@@ -4,7 +4,13 @@ export default gql`
   mutation UpdateModelPlan($input: ModelPlanInput!) {
     updateModelPlan(input: $input) {
       id
-      createdBy
+      modelName
+      modelCategory
+      cmsCenters
+      cmsOther
+      cmmiGroups
+      archived
+      status
     }
   }
 `;

--- a/src/queries/types/GetModelPlan.ts
+++ b/src/queries/types/GetModelPlan.ts
@@ -3,6 +3,8 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
+import { ModelStatus } from "./../../types/graphql-global-types";
+
 // ====================================================
 // GraphQL query operation: GetModelPlan
 // ====================================================
@@ -16,6 +18,7 @@ export interface GetModelPlan_modelPlan {
   __typename: "ModelPlan";
   id: UUID | null;
   modelName: string | null;
+  status: ModelStatus;
   basics: GetModelPlan_modelPlan_basics | null;
 }
 

--- a/src/queries/types/GetModelPlan.ts
+++ b/src/queries/types/GetModelPlan.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ModelStatus } from "./../../types/graphql-global-types";
+import { ModelCategory, CMSCenter, CMMIGroup, ModelStatus } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL query operation: GetModelPlan
@@ -18,6 +18,11 @@ export interface GetModelPlan_modelPlan {
   __typename: "ModelPlan";
   id: UUID | null;
   modelName: string | null;
+  modelCategory: ModelCategory | null;
+  cmsCenters: CMSCenter[] | null;
+  cmsOther: string | null;
+  cmmiGroups: CMMIGroup[] | null;
+  archived: boolean;
   status: ModelStatus;
   basics: GetModelPlan_modelPlan_basics | null;
 }

--- a/src/queries/types/UpdateModelPlan.ts
+++ b/src/queries/types/UpdateModelPlan.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ModelPlanInput } from "./../../types/graphql-global-types";
+import { ModelPlanInput, ModelCategory, CMSCenter, CMMIGroup, ModelStatus } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL mutation operation: UpdateModelPlan
@@ -12,7 +12,13 @@ import { ModelPlanInput } from "./../../types/graphql-global-types";
 export interface UpdateModelPlan_updateModelPlan {
   __typename: "ModelPlan";
   id: UUID | null;
-  createdBy: string | null;
+  modelName: string | null;
+  modelCategory: ModelCategory | null;
+  cmsCenters: CMSCenter[] | null;
+  cmsOther: string | null;
+  cmmiGroups: CMMIGroup[] | null;
+  archived: boolean;
+  status: ModelStatus;
 }
 
 export interface UpdateModelPlan {

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -44,7 +44,7 @@ const Home = () => {
             </p>
             <SummaryBox
               heading=""
-              className="bg-base-lightest border-0 radius-0 padding-2"
+              className="bg-base-lightest border-0 radius-0 padding-2 padding-bottom-3"
             >
               <p className="margin-0 margin-bottom-1">
                 {t('newModelSummaryBox.copy')}

--- a/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.test.tsx
+++ b/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.test.tsx
@@ -3,7 +3,14 @@ import { MemoryRouter, Route } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
 import { render, waitFor } from '@testing-library/react';
 
+import { GetModelPlan_modelPlan as GetModelPlanType } from 'queries/types/GetModelPlan';
+
 import TaskListSideNav from './index';
+
+const modelPlan = {
+  modelName: 'Test',
+  id: 'f11eb129-2c80-4080-9440-439cbe1a286f'
+} as GetModelPlanType;
 
 describe('The TaskListSideNavActions', () => {
   it('matches snapshot', async () => {
@@ -15,7 +22,7 @@ describe('The TaskListSideNavActions', () => {
       >
         <MockedProvider>
           <Route path="models/new-plan/:modelId/task-list">
-            <TaskListSideNav />
+            <TaskListSideNav modelPlan={modelPlan} />
           </Route>
         </MockedProvider>
       </MemoryRouter>

--- a/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.tsx
+++ b/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import { Button } from '@trussworks/react-uswds';
 
@@ -12,12 +13,13 @@ import {
   GetModelCollaborators,
   GetModelCollaborators_modelPlan_collaborators as GetCollaboratorsType
 } from 'queries/types/GetModelCollaborators';
-import { GetModelPlan_modelPlan as GetModelPlanTypes } from 'queries/types/GetModelPlan';
+import { GetModelPlan_modelPlan as GetModelPlanType } from 'queries/types/GetModelPlan';
 import { UpdateModelPlan as UpdateModelPlanType } from 'queries/types/UpdateModelPlan';
 import UpdateModelPlan from 'queries/UpdateModelPlan';
 
-const TaskListSideNav = ({ modelPlan }: GetModelPlanTypes) => {
+const TaskListSideNav = ({ modelPlan }: { modelPlan: GetModelPlanType }) => {
   const { id: modelId } = modelPlan;
+  const history = useHistory();
   const { t } = useTranslation('modelPlanTaskList');
   const [isModalOpen, setModalOpen] = useState(false);
 
@@ -33,11 +35,6 @@ const TaskListSideNav = ({ modelPlan }: GetModelPlanTypes) => {
   const [update] = useMutation<UpdateModelPlanType>(UpdateModelPlan);
 
   const archiveModelPlan = () => {
-    console.log({
-      id: modelId,
-      status: modelPlan.status,
-      archived: true
-    });
     update({
       variables: {
         input: {
@@ -49,11 +46,11 @@ const TaskListSideNav = ({ modelPlan }: GetModelPlanTypes) => {
     })
       .then(response => {
         if (!response?.errors) {
-          console.log(response);
+          history.push(`/`);
         }
       })
       .catch(errors => {
-        console.log(errors);
+        setModalOpen(false);
       });
   };
 
@@ -62,8 +59,6 @@ const TaskListSideNav = ({ modelPlan }: GetModelPlanTypes) => {
       <Modal isOpen={isModalOpen} closeModal={() => setModalOpen(false)}>
         <PageHeading headingLevel="h2" className="margin-top-0">
           {t('withdraw_modal.header', {
-            // TODO: requestName?
-            // requestName: intake.requestName
             requestName: modelPlan.modelName
           })}
         </PageHeading>

--- a/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.tsx
+++ b/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
-import { useQuery } from '@apollo/client';
+import { useMutation, useQuery } from '@apollo/client';
 import { Button } from '@trussworks/react-uswds';
 
 import UswdsReactLink from 'components/LinkWrapper';
@@ -13,9 +12,12 @@ import {
   GetModelCollaborators,
   GetModelCollaborators_modelPlan_collaborators as GetCollaboratorsType
 } from 'queries/types/GetModelCollaborators';
+import { GetModelPlan_modelPlan as GetModelPlanTypes } from 'queries/types/GetModelPlan';
+import { UpdateModelPlan as UpdateModelPlanType } from 'queries/types/UpdateModelPlan';
+import UpdateModelPlan from 'queries/UpdateModelPlan';
 
-const TaskListSideNav = () => {
-  const { modelId } = useParams<{ modelId: string }>();
+const TaskListSideNav = ({ modelPlan }: GetModelPlanTypes) => {
+  const { id: modelId } = modelPlan;
   const { t } = useTranslation('modelPlanTaskList');
   const [isModalOpen, setModalOpen] = useState(false);
 
@@ -28,6 +30,33 @@ const TaskListSideNav = () => {
   const collaborators = (data?.modelPlan?.collaborators ??
     []) as GetCollaboratorsType[];
 
+  const [update] = useMutation<UpdateModelPlanType>(UpdateModelPlan);
+
+  const archiveModelPlan = () => {
+    console.log({
+      id: modelId,
+      status: modelPlan.status,
+      archived: true
+    });
+    update({
+      variables: {
+        input: {
+          id: modelId,
+          status: modelPlan.status,
+          archived: true
+        }
+      }
+    })
+      .then(response => {
+        if (!response?.errors) {
+          console.log(response);
+        }
+      })
+      .catch(errors => {
+        console.log(errors);
+      });
+  };
+
   const renderModal = () => {
     return (
       <Modal isOpen={isModalOpen} closeModal={() => setModalOpen(false)}>
@@ -35,7 +64,7 @@ const TaskListSideNav = () => {
           {t('withdraw_modal.header', {
             // TODO: requestName?
             // requestName: intake.requestName
-            requestName: 'Requestor Name'
+            requestName: modelPlan.modelName
           })}
         </PageHeading>
         <p>{t('withdraw_modal.warning')}</p>
@@ -43,7 +72,7 @@ const TaskListSideNav = () => {
           type="button"
           className="margin-right-4"
           // TODO to pass down archive functional prop
-          onClick={() => console.log('archive!')}
+          onClick={() => archiveModelPlan()}
         >
           {t('withdraw_modal.confirm')}
         </Button>

--- a/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.tsx
+++ b/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.tsx
@@ -35,13 +35,11 @@ const TaskListSideNav = ({ modelPlan }: { modelPlan: GetModelPlanType }) => {
   const [update] = useMutation<UpdateModelPlanType>(UpdateModelPlan);
 
   const archiveModelPlan = () => {
+    const { basics, ...archivedPlan } = modelPlan;
+    archivedPlan.archived = true;
     update({
       variables: {
-        input: {
-          id: modelId,
-          status: modelPlan.status,
-          archived: true
-        }
+        input: archivedPlan
       }
     })
       .then(response => {
@@ -121,7 +119,11 @@ const TaskListSideNav = ({ modelPlan }: { modelPlan: GetModelPlanType }) => {
             <ul className="usa-list usa-list--unstyled">
               {collaborators.map((collaborator, index) => {
                 return (
-                  <IconInitial user={collaborator.fullName} index={index} />
+                  <IconInitial
+                    key={collaborator.euaUserID}
+                    user={collaborator.fullName}
+                    index={index}
+                  />
                 );
               })}
             </ul>

--- a/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.tsx
+++ b/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.tsx
@@ -66,7 +66,6 @@ const TaskListSideNav = ({ modelPlan }: { modelPlan: GetModelPlanType }) => {
         <Button
           type="button"
           className="margin-right-4"
-          // TODO to pass down archive functional prop
           onClick={() => archiveModelPlan()}
         >
           {t('withdraw_modal.confirm')}

--- a/src/views/ModelPlan/TaskList/index.test.tsx
+++ b/src/views/ModelPlan/TaskList/index.test.tsx
@@ -9,7 +9,7 @@ import { GetModelPlan_modelPlan as GetModelPlanTypes } from 'queries/types/GetMo
 import TaskList from './index';
 
 describe('The Model Plan Task List', () => {
-  const modelPlan: any = {
+  const modelPlan: GetModelPlanTypes = {
     id: '6e224030-09d5-46f7-ad04-4bb851b36eab',
     status: 'READY',
     basics: null

--- a/src/views/ModelPlan/TaskList/index.test.tsx
+++ b/src/views/ModelPlan/TaskList/index.test.tsx
@@ -4,44 +4,28 @@ import { MockedProvider } from '@apollo/client/testing';
 import { render, screen, waitFor } from '@testing-library/react';
 
 import GetModelPlanQuery from 'queries/GetModelPlanQuery';
+import { GetModelPlan_modelPlan as GetModelPlanTypes } from 'queries/types/GetModelPlan';
 
 import TaskList from './index';
 
-jest.mock('@okta/okta-react', () => ({
-  useOktaAuth: () => {
-    return {
-      authState: {
-        isAuthenticated: true
-      },
-      oktaAuth: {
-        getAccessToken: () => Promise.resolve('test-access-token'),
-        getUser: () =>
-          Promise.resolve({
-            name: 'John Doe'
-          })
-      }
-    };
-  }
-}));
-
 describe('The Model Plan Task List', () => {
-  const MODEL_ID = '6e224030-09d5-46f7-ad04-4bb851b36eab';
-  const intakeQuery = (intakeData: any) => {
+  const modelPlan: any = {
+    id: '6e224030-09d5-46f7-ad04-4bb851b36eab',
+    status: 'READY',
+    basics: null
+  };
+
+  const modelPlanQuery = (modelPlanDraft: GetModelPlanTypes) => {
     return {
       request: {
         query: GetModelPlanQuery,
         variables: {
-          id: MODEL_ID
+          id: modelPlan.id
         }
       },
       result: {
         data: {
-          modelPlan: {
-            id: MODEL_ID,
-            modelName: '',
-            basics: null,
-            ...intakeData
-          }
+          modelPlan: modelPlanDraft
         }
       }
     };
@@ -49,8 +33,8 @@ describe('The Model Plan Task List', () => {
 
   it('renders without crashing', async () => {
     render(
-      <MemoryRouter initialEntries={[`/models/${MODEL_ID}/task-list`]}>
-        <MockedProvider mocks={[intakeQuery({})]} addTypename={false}>
+      <MemoryRouter initialEntries={[`/models/${modelPlan.id}/task-list`]}>
+        <MockedProvider mocks={[modelPlanQuery(modelPlan)]} addTypename={false}>
           <Route path="/models/:modelId/task-list" component={TaskList} />
         </MockedProvider>
       </MemoryRouter>
@@ -62,9 +46,10 @@ describe('The Model Plan Task List', () => {
   });
 
   it('displays the model plan task list steps', async () => {
+    modelPlan.modelName = '';
     render(
-      <MemoryRouter initialEntries={[`/models/${MODEL_ID}/task-list`]}>
-        <MockedProvider mocks={[intakeQuery({})]} addTypename={false}>
+      <MemoryRouter initialEntries={[`/models/${modelPlan.id}/task-list`]}>
+        <MockedProvider mocks={[modelPlanQuery(modelPlan)]} addTypename={false}>
           <Route path="/models/:modelId/task-list" component={TaskList} />
         </MockedProvider>
       </MemoryRouter>
@@ -74,16 +59,10 @@ describe('The Model Plan Task List', () => {
   });
 
   it('displays the model plan name', async () => {
+    modelPlan.modelName = "PM Butler's great plan";
     render(
-      <MemoryRouter initialEntries={[`/models/${MODEL_ID}/task-list`]}>
-        <MockedProvider
-          mocks={[
-            intakeQuery({
-              modelName: "PM Butler's great plan"
-            })
-          ]}
-          addTypename={false}
-        >
+      <MemoryRouter initialEntries={[`/models/${modelPlan.id}/task-list`]}>
+        <MockedProvider mocks={[modelPlanQuery(modelPlan)]} addTypename={false}>
           <Route path="/models/:modelId/task-list" component={TaskList} />
         </MockedProvider>
       </MemoryRouter>
@@ -98,14 +77,11 @@ describe('The Model Plan Task List', () => {
 
   describe('Statuses', () => {
     it('renders proper buttons for Model Basics', async () => {
+      modelPlan.basics = null;
       render(
-        <MemoryRouter initialEntries={[`/models/${MODEL_ID}/task-list`]}>
+        <MemoryRouter initialEntries={[`/models/${modelPlan.id}/task-list`]}>
           <MockedProvider
-            mocks={[
-              intakeQuery({
-                basics: null
-              })
-            ]}
+            mocks={[modelPlanQuery(modelPlan)]}
             addTypename={false}
           >
             <Route path="/models/:modelId/task-list" component={TaskList} />

--- a/src/views/ModelPlan/TaskList/index.test.tsx
+++ b/src/views/ModelPlan/TaskList/index.test.tsx
@@ -5,15 +5,16 @@ import { render, screen, waitFor } from '@testing-library/react';
 
 import GetModelPlanQuery from 'queries/GetModelPlanQuery';
 import { GetModelPlan_modelPlan as GetModelPlanTypes } from 'queries/types/GetModelPlan';
+import { ModelStatus } from 'types/graphql-global-types';
 
 import TaskList from './index';
 
 describe('The Model Plan Task List', () => {
-  const modelPlan: GetModelPlanTypes = {
+  const modelPlan = {
     id: '6e224030-09d5-46f7-ad04-4bb851b36eab',
-    status: 'READY',
+    status: ModelStatus.PLAN_DRAFT,
     basics: null
-  };
+  } as GetModelPlanTypes;
 
   const modelPlanQuery = (modelPlanDraft: GetModelPlanTypes) => {
     return {

--- a/src/views/ModelPlan/TaskList/index.test.tsx
+++ b/src/views/ModelPlan/TaskList/index.test.tsx
@@ -5,7 +5,12 @@ import { render, screen, waitFor } from '@testing-library/react';
 
 import GetModelPlanQuery from 'queries/GetModelPlanQuery';
 import { GetModelPlan_modelPlan as GetModelPlanTypes } from 'queries/types/GetModelPlan';
-import { ModelStatus } from 'types/graphql-global-types';
+import {
+  CMMIGroup,
+  CMSCenter,
+  ModelCategory,
+  ModelStatus
+} from 'types/graphql-global-types';
 
 import TaskList from './index';
 
@@ -13,6 +18,15 @@ describe('The Model Plan Task List', () => {
   const modelPlan = {
     id: '6e224030-09d5-46f7-ad04-4bb851b36eab',
     status: ModelStatus.PLAN_DRAFT,
+    modelName: 'Test',
+    modelCategory: ModelCategory.PRIMARY_CARE_TRANSFORMATION,
+    cmmiGroups: [
+      CMMIGroup.STATE_INNOVATIONS_GROUP,
+      CMMIGroup.POLICY_AND_PROGRAMS_GROUP
+    ],
+    cmsCenters: [CMSCenter.CENTER_FOR_MEDICARE, CMSCenter.OTHER],
+    cmsOther: 'The Center for Awesomeness ',
+    archived: false,
     basics: null
   } as GetModelPlanTypes;
 

--- a/src/views/ModelPlan/TaskList/index.tsx
+++ b/src/views/ModelPlan/TaskList/index.tsx
@@ -179,7 +179,6 @@ const TaskList = () => {
             </ol>
           </div>
           <div className="tablet:grid-col-3">
-            {/* //TODO to pass down archive functional prop */}
             <TaskListSideNav modelPlan={modelPlan} />
           </div>
         </div>

--- a/src/views/ModelPlan/TaskList/index.tsx
+++ b/src/views/ModelPlan/TaskList/index.tsx
@@ -16,6 +16,7 @@ import Divider from 'components/shared/Divider';
 import GetModelPlanQuery from 'queries/GetModelPlanQuery';
 import {
   GetModelPlan,
+  GetModelPlan_modelPlan as GetModelPlanTypes,
   GetModelPlanVariables
 } from 'queries/types/GetModelPlan';
 
@@ -46,6 +47,8 @@ const TaskList = () => {
     }
   );
 
+  const modelPlan = data?.modelPlan || ({} as GetModelPlanTypes);
+
   const {
     modelName,
     basics
@@ -56,7 +59,7 @@ const TaskList = () => {
     // operations,
     // payment,
     // finalizeModelPlan
-  } = data?.modelPlan || {};
+  } = modelPlan;
 
   const taskListItem: TaskListItemProps[] = t('numberedList', {
     returnObjects: true
@@ -177,7 +180,7 @@ const TaskList = () => {
           </div>
           <div className="tablet:grid-col-3">
             {/* //TODO to pass down archive functional prop */}
-            <TaskListSideNav />
+            <TaskListSideNav modelPlan={modelPlan} />
           </div>
         </div>
       )}


### PR DESCRIPTION
# EASI-1998

## Changes and Description

- Added ability to archive a model plan
- Added cypress test for archiving model plan
- Refactored some unit tests

## Notes

Passing in queried model plan as prop from task list instead of just the modelId from the url param.  The additional fields of the model are needed for archiving.

## How to test this change

Seed database using MINT (if testing cypress test)
Select/create a model plan and navigate to the task list and select `Remove your Model Plan`, then confirm
Should redirect to home page with model plan archived and no longer returned from query

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
