### PR TITLE
[NOREF] Added args and exclude statement to go-fmt-import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,13 @@ repos:
     rev: c3086eea8af86847dbdff2e46b85a5fe3c9d9656
     hooks:
       - id: go-fmt-import
+        args: ['-local', 'github.com/cmsgov/mint-app']
+        exclude: >
+          (?x)^(
+            .*gen/.*|
+            .*generated/.*|
+            .*models_gen.go|
+          )$
 
   - repo: https://github.com/golangci/golangci-lint
     rev: v1.41.1


### PR DESCRIPTION
# No Ticket

## Changes and Description

I'm sure you've all seen it, but sometimes the [go-fmt-import](https://github.com/CMSgov/mint-app/blob/d389bbbbaad710cbfd4e2f7b79c209beb5e6c933/.pre-commit-config.yaml#L28-L31) statement would complain that the "file was not 'goimport'ed with -local". This should fix that by introducing the `-local` flag to the linting step that was complaining about it. Not really sure why this wasn't there before! (Perhaps some folks editors did this automatically?)

<!-- Put a description here! -->

## How to test this change

1. Open a .go file that imports packages from `mint-app` and other sources (like `/pkg/server/config.go`)
2. Edit the file to put some `mint-app` imports between others, like so
```go
import (
	"fmt"
	"github.com/cmsgov/mint-app/pkg/appconfig"
	"github.com/cmsgov/mint-app/pkg/appses"
	"github.com/cmsgov/mint-app/pkg/email"
	"github.com/cmsgov/mint-app/pkg/flags"
	"time"
	"github.com/cmsgov/mint-app/pkg/storage"
	"github.com/cmsgov/mint-app/pkg/upload"
)
```
3. Save the file
4. Run `scripts/dev lint` and see that the file imports are restored to have the `mint-app` imports separated.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
