### PR TITLE
[EASI-2023] Plan collaborator simplifications

### DIFF
--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -58,17 +58,12 @@ type PlanBasicsInput struct {
 	Status         *models.TaskStatus `json:"status"`
 }
 
-// PlanCollaboratorInput represents the data required to create, modify, or delete a collaborator on a plan
-type PlanCollaboratorInput struct {
-	ID          *uuid.UUID      `json:"id"`
+// PlanCollaboratorCreateInput represents the data required to create a collaborator on a plan
+type PlanCollaboratorCreateInput struct {
 	ModelPlanID uuid.UUID       `json:"modelPlanID"`
 	EuaUserID   string          `json:"euaUserID"`
 	FullName    string          `json:"fullName"`
 	TeamRole    models.TeamRole `json:"teamRole"`
-	CreatedBy   *string         `json:"createdBy"`
-	CreatedDts  *time.Time      `json:"createdDts"`
-	ModifiedBy  *string         `json:"modifiedBy"`
-	ModifiedDts *time.Time      `json:"modifiedDts"`
 }
 
 // PlanDiscussionCreateInput represents the necessary fields to create a plan discussion

--- a/pkg/graph/resolvers/model_plan.go
+++ b/pkg/graph/resolvers/model_plan.go
@@ -34,7 +34,6 @@ func ModelPlanCreate(logger *zap.Logger, modelName string, store *storage.Store,
 		CreatedBy:   &principalInfo.EuaUserID,
 		ModifiedBy:  &principalInfo.EuaUserID,
 	}
-	// _, err = store.planCreatePlanCollaborator(logger, collabInput, principalInfo.EuaUserID, store)
 	_, err = store.PlanCollaboratorCreate(logger, collab)
 	if err != nil {
 		return nil, err

--- a/pkg/graph/resolvers/model_plan.go
+++ b/pkg/graph/resolvers/model_plan.go
@@ -4,7 +4,6 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
-	"github.com/cmsgov/mint-app/pkg/graph/model"
 	"github.com/cmsgov/mint-app/pkg/models"
 	"github.com/cmsgov/mint-app/pkg/storage"
 )
@@ -27,13 +26,16 @@ func ModelPlanCreate(logger *zap.Logger, modelName string, store *storage.Store,
 	  - this could be in a combined store for collaborator / plan
 	- we could also address this directly in SQL, create the plan and collaborator at the same time.
 	*/
-	collabInput := &model.PlanCollaboratorCreateInput{
+	collab := &models.PlanCollaborator{
 		ModelPlanID: createdPlan.ID,
-		EuaUserID:   principalInfo.EuaUserID,
+		EUAUserID:   principalInfo.EuaUserID,
 		FullName:    principalInfo.CommonName,
 		TeamRole:    models.TeamRoleModelLead,
+		CreatedBy:   &principalInfo.EuaUserID,
+		ModifiedBy:  &principalInfo.EuaUserID,
 	}
-	_, err = CreatePlanCollaborator(logger, collabInput, principalInfo.EuaUserID, store)
+	// _, err = store.planCreatePlanCollaborator(logger, collabInput, principalInfo.EuaUserID, store)
+	_, err = store.PlanCollaboratorCreate(logger, collab)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/graph/resolvers/model_plan.go
+++ b/pkg/graph/resolvers/model_plan.go
@@ -4,6 +4,7 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/cmsgov/mint-app/pkg/graph/model"
 	"github.com/cmsgov/mint-app/pkg/models"
 	"github.com/cmsgov/mint-app/pkg/storage"
 )
@@ -26,14 +27,16 @@ func ModelPlanCreate(logger *zap.Logger, modelName string, store *storage.Store,
 	  - this could be in a combined store for collaborator / plan
 	- we could also address this directly in SQL, create the plan and collaborator at the same time.
 	*/
-
-	colab := models.PlanCollaborator{
-		EUAUserID:   *createdPlan.CreatedBy,
+	collabInput := &model.PlanCollaboratorCreateInput{
 		ModelPlanID: createdPlan.ID,
-		TeamRole:    models.TeamRoleModelLead,
+		EuaUserID:   principalInfo.EuaUserID,
 		FullName:    principalInfo.CommonName,
+		TeamRole:    models.TeamRoleModelLead,
 	}
-	_, _ = CreatePlanCollaborator(logger, &colab, createdPlan.CreatedBy, store)
+	_, err = CreatePlanCollaborator(logger, collabInput, principalInfo.EuaUserID, store)
+	if err != nil {
+		return nil, err
+	}
 
 	return createdPlan, err
 }

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -78,18 +78,13 @@ type PlanCollaborator {
 }
 
 """
-PlanCollaboratorInput represents the data required to create, modify, or delete a collaborator on a plan
+PlanCollaboratorCreateInput represents the data required to create a collaborator on a plan
 """
-input PlanCollaboratorInput {
-  id: UUID
+input PlanCollaboratorCreateInput {
   modelPlanID: UUID!
   euaUserID: String!
   fullName: String!
   teamRole: TeamRole!
-  createdBy: String
-  createdDts: Time
-  modifiedBy: String
-  modifiedDts: Time
 }
 
 """
@@ -401,13 +396,13 @@ createModelPlan(modelName: String!):ModelPlan
 updateModelPlan(id: UUID!, changes: ModelPlanChanges!): ModelPlan
 @hasRole(role: MINT_BASE_USER)
 
-createPlanCollaborator(input: PlanCollaboratorInput!): PlanCollaborator
+createPlanCollaborator(input: PlanCollaboratorCreateInput!): PlanCollaborator
 @hasRole(role: MINT_BASE_USER)
 
-updatePlanCollaborator(input: PlanCollaboratorInput!): PlanCollaborator
+updatePlanCollaborator(id: UUID!, newRole: TeamRole!): PlanCollaborator
 @hasRole(role: MINT_BASE_USER)
 
-deletePlanCollaborator(input: PlanCollaboratorInput!): PlanCollaborator
+deletePlanCollaborator(id: UUID!): PlanCollaborator
 @hasRole(role: MINT_BASE_USER)
 
 createPlanBasics(input: PlanBasicsInput!):PlanBasics

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -96,28 +96,25 @@ func (r *mutationResolver) UpdateModelPlan(ctx context.Context, id uuid.UUID, ch
 	return resolvers.ModelPlanUpdate(logger, id, changes, &principal, r.store)
 }
 
-func (r *mutationResolver) CreatePlanCollaborator(ctx context.Context, input model.PlanCollaboratorInput) (*models.PlanCollaborator, error) {
-	collaborator := ConvertToPlanCollaborator(&input)
+func (r *mutationResolver) CreatePlanCollaborator(ctx context.Context, input model.PlanCollaboratorCreateInput) (*models.PlanCollaborator, error) {
 	principal := appcontext.Principal(ctx).ID()
 	logger := appcontext.ZLogger(ctx)
 
-	return resolvers.CreatePlanCollaborator(logger, collaborator, &principal, r.store)
+	return resolvers.CreatePlanCollaborator(logger, &input, principal, r.store)
 }
 
-func (r *mutationResolver) UpdatePlanCollaborator(ctx context.Context, input model.PlanCollaboratorInput) (*models.PlanCollaborator, error) {
-	collaborator := ConvertToPlanCollaborator(&input)
+func (r *mutationResolver) UpdatePlanCollaborator(ctx context.Context, id uuid.UUID, newRole models.TeamRole) (*models.PlanCollaborator, error) {
 	principal := appcontext.Principal(ctx).ID()
 	logger := appcontext.ZLogger(ctx)
 
-	return resolvers.UpdatePlanCollaborator(logger, collaborator, &principal, r.store)
+	return resolvers.UpdatePlanCollaborator(logger, id, newRole, principal, r.store)
 }
 
-func (r *mutationResolver) DeletePlanCollaborator(ctx context.Context, input model.PlanCollaboratorInput) (*models.PlanCollaborator, error) {
-	collaborator := ConvertToPlanCollaborator(&input)
+func (r *mutationResolver) DeletePlanCollaborator(ctx context.Context, id uuid.UUID) (*models.PlanCollaborator, error) {
 	principal := appcontext.Principal(ctx).ID()
 	logger := appcontext.ZLogger(ctx)
 
-	return resolvers.DeletePlanCollaborator(logger, collaborator, &principal, r.store)
+	return resolvers.DeletePlanCollaborator(logger, id, principal, r.store)
 }
 
 func (r *mutationResolver) CreatePlanBasics(ctx context.Context, input model.PlanBasicsInput) (*models.PlanBasics, error) {

--- a/pkg/graph/schema.resolvers_helpers.go
+++ b/pkg/graph/schema.resolvers_helpers.go
@@ -98,23 +98,3 @@ func ConvertToPlanDocumentModel(input *model.PlanDocumentInput) *models.PlanDocu
 
 	return &documentModel
 }
-
-// ConvertToPlanCollaborator takes an auto-generated plan collaborator input and converts it to a hand-written one
-func ConvertToPlanCollaborator(pci *model.PlanCollaboratorInput) *models.PlanCollaborator {
-	collaborator := models.PlanCollaborator{
-		ModelPlanID: pci.ModelPlanID,
-		EUAUserID:   pci.EuaUserID,
-		FullName:    pci.FullName,
-		TeamRole:    pci.TeamRole,
-		CreatedBy:   pci.CreatedBy,
-		CreatedDts:  pci.CreatedDts,
-		ModifiedBy:  pci.ModifiedBy,
-		ModifiedDts: pci.ModifiedDts,
-	}
-
-	if pci.ID != nil {
-		collaborator.ID = *pci.ID
-	}
-	return &collaborator
-
-}

--- a/pkg/storage/plan_collaboratorStore.go
+++ b/pkg/storage/plan_collaboratorStore.go
@@ -63,13 +63,14 @@ func (s *Store) PlanCollaboratorUpdate(_ *zap.Logger, collaborator *models.PlanC
 }
 
 // PlanCollaboratorDelete deletes the plan collaborator for a given id
-func (s *Store) PlanCollaboratorDelete(_ *zap.Logger, collaborator *models.PlanCollaborator) (*models.PlanCollaborator, error) {
+func (s *Store) PlanCollaboratorDelete(_ *zap.Logger, id uuid.UUID) (*models.PlanCollaborator, error) {
 	statement, err := s.db.PrepareNamed(planCollaboratorDeleteSQL)
 	if err != nil {
 		return nil, err
 	}
 
-	err = statement.Get(collaborator, collaborator)
+	collaborator := &models.PlanCollaborator{}
+	err = statement.Get(collaborator, utilitySQL.CreateIDQueryMap(id))
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/dev
+++ b/scripts/dev
@@ -415,7 +415,7 @@ namespace :test do
 
   desc "Run JS tests (pass path to scope to that location)"
   task :js => :consume_args do |t, args|
-    sh "yarn", "run", "craco", "test", "--u", "--watchAll=false", *args
+    sh "yarn", "run", "craco", "test", "--watchAll=false", *args
   end
   namespace :js do
     desc "Run JS tests with a matching name (pass needle as additional option)"

--- a/src/queries/CreateModelPlanCollaborator.ts
+++ b/src/queries/CreateModelPlanCollaborator.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
 export default gql`
-  mutation CreateModelPlanCollaborator($input: PlanCollaboratorInput!) {
+  mutation CreateModelPlanCollaborator($input: PlanCollaboratorCreateInput!) {
     createPlanCollaborator(input: $input) {
       fullName
       teamRole

--- a/src/queries/DeleteModelPlanCollaborator.ts
+++ b/src/queries/DeleteModelPlanCollaborator.ts
@@ -3,6 +3,7 @@ import { gql } from '@apollo/client';
 export default gql`
   mutation DeleteModelPlanCollaborator($id: UUID!) {
     deletePlanCollaborator(id: $id) {
+      id
       fullName
       teamRole
       euaUserID

--- a/src/queries/DeleteModelPlanCollaborator.ts
+++ b/src/queries/DeleteModelPlanCollaborator.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 export default gql`
-  mutation DeleteModelPlanCollaborator($input: PlanCollaboratorInput!) {
-    deletePlanCollaborator(input: $input) {
+  mutation DeleteModelPlanCollaborator($id: UUID!) {
+    deletePlanCollaborator(id: $id) {
       fullName
       teamRole
       euaUserID

--- a/src/queries/UpdateModelPlanCollaborator.ts
+++ b/src/queries/UpdateModelPlanCollaborator.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 export default gql`
-  mutation UpdateModelPlanCollaborator($input: PlanCollaboratorInput!) {
-    updatePlanCollaborator(input: $input) {
+  mutation UpdateModelPlanCollaborator($id: UUID!, $newRole: TeamRole!) {
+    updatePlanCollaborator(id: $id, newRole: $newRole) {
       fullName
       teamRole
       euaUserID

--- a/src/queries/types/CreateModelPlanCollaborator.ts
+++ b/src/queries/types/CreateModelPlanCollaborator.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { PlanCollaboratorInput, TeamRole } from "./../../types/graphql-global-types";
+import { PlanCollaboratorCreateInput, TeamRole } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL mutation operation: CreateModelPlanCollaborator
@@ -22,5 +22,5 @@ export interface CreateModelPlanCollaborator {
 }
 
 export interface CreateModelPlanCollaboratorVariables {
-  input: PlanCollaboratorInput;
+  input: PlanCollaboratorCreateInput;
 }

--- a/src/queries/types/DeleteModelPlanCollaborator.ts
+++ b/src/queries/types/DeleteModelPlanCollaborator.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { PlanCollaboratorInput, TeamRole } from "./../../types/graphql-global-types";
+import { TeamRole } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL mutation operation: DeleteModelPlanCollaborator
@@ -22,5 +22,5 @@ export interface DeleteModelPlanCollaborator {
 }
 
 export interface DeleteModelPlanCollaboratorVariables {
-  input: PlanCollaboratorInput;
+  id: UUID;
 }

--- a/src/queries/types/DeleteModelPlanCollaborator.ts
+++ b/src/queries/types/DeleteModelPlanCollaborator.ts
@@ -11,6 +11,7 @@ import { TeamRole } from "./../../types/graphql-global-types";
 
 export interface DeleteModelPlanCollaborator_deletePlanCollaborator {
   __typename: "PlanCollaborator";
+  id: UUID;
   fullName: string;
   teamRole: TeamRole;
   euaUserID: string;

--- a/src/queries/types/UpdateModelPlanCollaborator.ts
+++ b/src/queries/types/UpdateModelPlanCollaborator.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { PlanCollaboratorInput, TeamRole } from "./../../types/graphql-global-types";
+import { TeamRole } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL mutation operation: UpdateModelPlanCollaborator
@@ -22,5 +22,6 @@ export interface UpdateModelPlanCollaborator {
 }
 
 export interface UpdateModelPlanCollaboratorVariables {
-  input: PlanCollaboratorInput;
+  id: UUID;
+  newRole: TeamRole;
 }

--- a/src/types/graphql-global-types.ts
+++ b/src/types/graphql-global-types.ts
@@ -79,18 +79,13 @@ export interface ModelPlanChanges {
 }
 
 /**
- * PlanCollaboratorInput represents the data required to create, modify, or delete a collaborator on a plan
+ * PlanCollaboratorCreateInput represents the data required to create a collaborator on a plan
  */
-export interface PlanCollaboratorInput {
-  id?: UUID | null;
+export interface PlanCollaboratorCreateInput {
   modelPlanID: UUID;
   euaUserID: string;
   fullName: string;
   teamRole: TeamRole;
-  createdBy?: string | null;
-  createdDts?: Time | null;
-  modifiedBy?: string | null;
-  modifiedDts?: Time | null;
 }
 
 //==============================================================

--- a/src/views/ModelPlan/Collaborators/AddCollaborator/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/Collaborators/AddCollaborator/__snapshots__/index.test.tsx.snap
@@ -77,7 +77,6 @@ exports[`Adding a collaborator page matches snapshot 1`] = `
             >
               <option
                 disabled=""
-                value=""
               >
                 -Select-
               </option>

--- a/src/views/ModelPlan/Collaborators/AddCollaborator/index.tsx
+++ b/src/views/ModelPlan/Collaborators/AddCollaborator/index.tsx
@@ -73,13 +73,8 @@ const Collaborators = () => {
     if (collaboratorId) {
       update({
         variables: {
-          input: {
-            id: collaboratorId,
-            fullName,
-            teamRole,
-            euaUserID,
-            modelPlanID: modelId
-          }
+          id: collaboratorId,
+          newRole: teamRole
         }
       })
         .then(response => {
@@ -139,7 +134,7 @@ const Collaborators = () => {
               formikProps: FormikProps<{
                 euaUserId: string;
                 fullName: string;
-                teamRole: string;
+                teamRole: string | null;
               }>
             ) => {
               const {
@@ -256,7 +251,7 @@ const Collaborators = () => {
                           setFieldValue('teamRole', e.target.value);
                         }}
                       >
-                        <option value="" key="default-select" disabled>
+                        <option key="default-select" disabled selected>
                           {`-${h('select')}-`}
                         </option>
                         {Object.keys(teamRoles).map(role => {

--- a/src/views/ModelPlan/Collaborators/index.tsx
+++ b/src/views/ModelPlan/Collaborators/index.tsx
@@ -73,7 +73,7 @@ const Collaborators = () => {
   ) => {
     mutate({
       variables: {
-        input: collaborator
+        id: collaborator.id
       }
     })
       .then(response => {


### PR DESCRIPTION
# EASI-2023

## Changes and Description

- Simplifications to create, update, and delete plan collaborator mutations.

## How to test this change

```gql
mutation createModelPlan {
  createModelPlan(modelName: "My Custom Model") {
    id
  }
}
```

```gql
mutation createPlanCollab {
  createPlanCollaborator(input: {
    modelPlanID: "<ID>"
    euaUserID: "BC0V"
    fullName: "Clay Boy"
    teamRole: EVALUATION
  }) {
    id
  }
}
```

```gql
mutation updateCollab {
  updatePlanCollaborator(id: "<ID>", newRole: MODEL_LEAD) {
    id
    modifiedDts
  }
}
```

```gql
mutation deleteCollab {
  deletePlanCollaborator(id: "<ID>") {
    id
  }
}
```

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
