### PR TITLE
[NOREF] Improved backend tests

### DIFF
--- a/pkg/graph/resolvers/plan_basics_test.go
+++ b/pkg/graph/resolvers/plan_basics_test.go
@@ -10,10 +10,10 @@ func (suite *ResolverSuite) TestPlanBasicsGetByModelPlanID() {
 	basics, err := PlanBasicsGetByModelPlanID(suite.testConfigs.Logger, &suite.testConfigs.UserInfo.EuaUserID, plan.ID, suite.testConfigs.Store)
 
 	suite.NoError(err)
-	suite.EqualValues(basics.ModelPlanID, plan.ID)
-	suite.EqualValues(basics.Status, models.TaskReady)
-	suite.EqualValues(*basics.CreatedBy, suite.testConfigs.UserInfo.EuaUserID)
-	suite.EqualValues(*basics.ModifiedBy, suite.testConfigs.UserInfo.EuaUserID)
+	suite.EqualValues(plan.ID, basics.ModelPlanID)
+	suite.EqualValues(models.TaskReady, basics.Status)
+	suite.EqualValues(suite.testConfigs.UserInfo.EuaUserID, *basics.CreatedBy)
+	suite.EqualValues(suite.testConfigs.UserInfo.EuaUserID, *basics.ModifiedBy)
 
 	// Many of the fields are nil upon creation
 	suite.Nil(basics.ModelType)

--- a/pkg/graph/resolvers/plan_collaborator_test.go
+++ b/pkg/graph/resolvers/plan_collaborator_test.go
@@ -1,78 +1,103 @@
 package resolvers
 
-// import (
-// 	"testing"
+import (
+	"github.com/cmsgov/mint-app/pkg/graph/model"
+	"github.com/cmsgov/mint-app/pkg/models"
+)
 
-// 	"github.com/cmsgov/mint-app/pkg/models"
+func (suite *ResolverSuite) TestCreatePlanCollaborator() {
+	plan := suite.createModelPlan("Plan For Milestones")
 
-// 	"github.com/google/uuid"
-// 	_ "github.com/lib/pq" // required for postgres driver in sql
-// 	"github.com/stretchr/testify/assert"
-// )
+	collaboratorInput := &model.PlanCollaboratorCreateInput{
+		ModelPlanID: plan.ID,
+		EuaUserID:   "CLAB",
+		FullName:    "Clab O' Rater",
+		TeamRole:    models.TeamRoleLeadership,
+	}
+	collaborator, err := CreatePlanCollaborator(suite.testConfigs.Logger, collaboratorInput, suite.testConfigs.UserInfo.EuaUserID, suite.testConfigs.Store)
 
-// func makeTestCollaborator() models.PlanCollaborator {
-// 	return models.PlanCollaborator{
-// 		FullName:    "Fake name",
-// 		EUAUserID:   "FAKE",
-// 		CreatedBy:   models.StringPointer("FAKE"),
-// 		ModifiedBy:  models.StringPointer("FAKE"),
-// 		ID:          uuid.MustParse("f85c15cd-f920-4080-bdeb-e79b3d8f056a"),
-// 		ModelPlanID: uuid.MustParse("85b3ff03-1be2-4870-b02f-55c764500e48"),
-// 		TeamRole:    models.TeamRoleLearning,
-// 	}
-// }
-// func TestCreatePlanCollaborator(t *testing.T) {
-// 	tc := GetDefaultTestConfigs()
-// 	colab := makeTestCollaborator()
+	suite.NoError(err)
+	suite.EqualValues(plan.ID, collaborator.ModelPlanID)
+	suite.EqualValues("CLAB", collaborator.EUAUserID)
+	suite.EqualValues("Clab O' Rater", collaborator.FullName)
+	suite.EqualValues(models.TeamRoleLeadership, collaborator.TeamRole)
+	suite.EqualValues(suite.testConfigs.UserInfo.EuaUserID, *collaborator.ModifiedBy)
+	suite.EqualValues(suite.testConfigs.UserInfo.EuaUserID, *collaborator.CreatedBy)
+}
 
-// 	result, err := CreatePlanCollaborator(tc.Logger, &colab, colab.CreatedBy, tc.Store)
-// 	assert.NoError(t, err)
-// 	assert.NotNil(t, result.ID)
-// }
+func (suite *ResolverSuite) TestUpdatePlanCollaborator() {
+	plan := suite.createModelPlan("Plan For Milestones")
+	collaborator := suite.createPlanCollaborator(plan, "CLAB", "Clab O' Rater", models.TeamRoleLeadership)
 
-// func TestUpdatePlanCollaborator(t *testing.T) {
-// 	tc := GetDefaultTestConfigs()
-// 	colab := makeTestCollaborator()
-// 	colab.TeamRole = models.TeamRoleModelTeam
+	updatedCollaborator, err := UpdatePlanCollaborator(suite.testConfigs.Logger, collaborator.ID, models.TeamRoleEvaluation, "UPDT", suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.EqualValues("UPDT", *updatedCollaborator.ModifiedBy)
+	suite.EqualValues("CLAB", updatedCollaborator.EUAUserID)
+	suite.EqualValues("Clab O' Rater", updatedCollaborator.FullName)
+	suite.EqualValues(models.TeamRoleEvaluation, updatedCollaborator.TeamRole)
+}
 
-// 	result, err := UpdatePlanCollaborator(tc.Logger, &colab, colab.CreatedBy, tc.Store)
+func (suite *ResolverSuite) TestUpdatePlanCollaboratorLastModelLead() {
+	plan := suite.createModelPlan("Plan For Milestones")
 
-// 	assert.NoError(t, err)
-// 	assert.NotNil(t, result.ID)
-// 	assert.EqualValues(t, result.TeamRole, colab.TeamRole)
+	collaborators, err := FetchCollaboratorsByModelPlanID(suite.testConfigs.Logger, &suite.testConfigs.UserInfo.EuaUserID, plan.ID, suite.testConfigs.Store)
+	suite.NoError(err)
 
-// }
+	collaborator := collaborators[0]
+	updatedPlanCollaborator, err := UpdatePlanCollaborator(suite.testConfigs.Logger, collaborator.ID, models.TeamRoleEvaluation, "UPDT", suite.testConfigs.Store)
+	suite.Error(err)
+	suite.EqualValues("pq: There must be at least one MODEL_LEAD assigned to each model plan", err.Error())
+	suite.Nil(updatedPlanCollaborator)
+}
 
-// func TestFetchCollaboratorsByModelPlanID(t *testing.T) {
-// 	tc := GetDefaultTestConfigs()
-// 	modelPlanID := uuid.MustParse("85b3ff03-1be2-4870-b02f-55c764500e48")
+func (suite *ResolverSuite) TestFetchCollaboratorsByModelPlanID() {
+	plan := suite.createModelPlan("Plan For Milestones")
+	_ = suite.createPlanCollaborator(plan, "SCND", "Mr. Second Collaborator", models.TeamRoleLeadership)
 
-// 	result, err := FetchCollaboratorsByModelPlanID(tc.Logger, tc.Principal, modelPlanID, tc.Store)
-// 	assert.NoError(t, err)
+	collaborators, err := FetchCollaboratorsByModelPlanID(suite.testConfigs.Logger, &suite.testConfigs.UserInfo.EuaUserID, plan.ID, suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.Len(collaborators, 2)
+	suite.NotEqual(collaborators[0].ID, collaborators[1].ID) // two different collaborators
+	for _, i := range collaborators {
+		suite.Contains([]string{"TEST", "SCND"}, i.EUAUserID) // contains default collaborator and new one
+	}
+}
 
-// 	assert.NotNil(t, result)
+func (suite *ResolverSuite) TestFetchCollaboratorByID() {
+	plan := suite.createModelPlan("Plan For Milestones")
+	collaborator := suite.createPlanCollaborator(plan, "SCND", "Mr. Second Collaborator", models.TeamRoleLeadership)
 
-// }
+	collaboratorByID, err := FetchCollaboratorByID(suite.testConfigs.Logger, collaborator.ID, suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.EqualValues(collaboratorByID, collaborator)
+}
 
-// func TestDeletePlanCollaborator(t *testing.T) {
-// 	tc := GetDefaultTestConfigs()
-// 	collabDel := makeTestCollaborator()
+func (suite *ResolverSuite) TestDeletePlanCollaborator() {
+	plan := suite.createModelPlan("Plan For Milestones")
+	collaborator := suite.createPlanCollaborator(plan, "SCND", "Mr. Second Collaborator", models.TeamRoleLeadership)
 
-// 	dRes, err := DeletePlanCollaborator(tc.Logger, &collabDel, tc.Principal, tc.Store)
-// 	assert.NoError(t, err)
+	// Delete the 2nd collaborator
+	deletedCollaborator, err := DeletePlanCollaborator(suite.testConfigs.Logger, collaborator.ID, suite.testConfigs.UserInfo.EuaUserID, suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.EqualValues(deletedCollaborator, collaborator)
 
-// 	assert.NotNil(t, dRes)
+	// Ensure we get nil when we fetch it
+	// TODO: FetchByID methods should probably error if they don't find what they're looking for,
+	// but FetchByModelPlanID shouldn't (just return an empty slice)
+	collaboratorByID, err := FetchCollaboratorByID(suite.testConfigs.Logger, collaborator.ID, suite.testConfigs.Store)
+	suite.NoError(err)
+	suite.Nil(collaboratorByID)
+}
 
-// 	modelPlanID := uuid.MustParse("85b3ff03-1be2-4870-b02f-55c764500e48")
+func (suite *ResolverSuite) TestDeletePlanCollaboratorLastModelLead() {
+	plan := suite.createModelPlan("Plan For Milestones")
 
-// 	result, err := FetchCollaboratorsByModelPlanID(tc.Logger, tc.Principal, modelPlanID, tc.Store)
-// 	assert.NoError(t, err)
+	collaborators, err := FetchCollaboratorsByModelPlanID(suite.testConfigs.Logger, &suite.testConfigs.UserInfo.EuaUserID, plan.ID, suite.testConfigs.Store)
+	suite.NoError(err)
 
-// 	assert.NotNil(t, result)
-
-// 	modelLead := result[0]
-
-// 	_, err2 := DeletePlanCollaborator(tc.Logger, modelLead, tc.Principal, tc.Store) //this is the last model lead, deleting will cause error
-// 	assert.Error(t, err2)
-
-// }
+	collaborator := collaborators[0]
+	deletedPlanCollaborator, err := DeletePlanCollaborator(suite.testConfigs.Logger, collaborator.ID, "UPDT", suite.testConfigs.Store)
+	suite.Error(err)
+	suite.EqualValues("pq: There must be at least one MODEL_LEAD assigned to each model plan", err.Error())
+	suite.Nil(deletedPlanCollaborator)
+}

--- a/pkg/graph/resolvers/plan_discussion_test.go
+++ b/pkg/graph/resolvers/plan_discussion_test.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	_ "github.com/lib/pq" // required for postgres driver in sql
-	"github.com/stretchr/testify/assert"
 
 	"github.com/cmsgov/mint-app/pkg/graph/model"
 	"github.com/cmsgov/mint-app/pkg/models"
@@ -17,11 +16,11 @@ func (suite *ResolverSuite) TestCreatePlanDiscussion() {
 	}
 
 	result, err := CreatePlanDiscussion(suite.testConfigs.Logger, input, suite.testConfigs.UserInfo.EuaUserID, suite.testConfigs.Store)
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), result.ID)
-	assert.EqualValues(suite.T(), plan.ID, result.ModelPlanID)
-	assert.EqualValues(suite.T(), input.Content, result.Content)
-	assert.EqualValues(suite.T(), models.DiscussionUnAnswered, result.Status)
+	suite.NoError(err)
+	suite.NotNil(result.ID)
+	suite.EqualValues(plan.ID, result.ModelPlanID)
+	suite.EqualValues(input.Content, result.Content)
+	suite.EqualValues(models.DiscussionUnAnswered, result.Status)
 }
 
 func (suite *ResolverSuite) TestUpdatePlanDiscussion() {
@@ -36,12 +35,12 @@ func (suite *ResolverSuite) TestUpdatePlanDiscussion() {
 	updater := "UPDT"
 	result, err := UpdatePlanDiscussion(suite.testConfigs.Logger, discussion.ID, changes, updater, suite.testConfigs.Store)
 
-	assert.NoError(suite.T(), err)
-	assert.EqualValues(suite.T(), discussion.ID, result.ID)
-	assert.EqualValues(suite.T(), changes["content"], result.Content)
-	assert.EqualValues(suite.T(), changes["status"], result.Status)
-	assert.EqualValues(suite.T(), suite.testConfigs.UserInfo.EuaUserID, result.CreatedBy)
-	assert.EqualValues(suite.T(), updater, result.ModifiedBy)
+	suite.NoError(err)
+	suite.EqualValues(discussion.ID, result.ID)
+	suite.EqualValues(changes["content"], result.Content)
+	suite.EqualValues(changes["status"], result.Status)
+	suite.EqualValues(suite.testConfigs.UserInfo.EuaUserID, result.CreatedBy)
+	suite.EqualValues(updater, result.ModifiedBy)
 }
 
 func (suite *ResolverSuite) TestDeletePlanDiscussion() {
@@ -49,13 +48,13 @@ func (suite *ResolverSuite) TestDeletePlanDiscussion() {
 	discussion := suite.createPlanDiscussion(plan, "This is a test comment")
 
 	result, err := DeletePlanDiscussion(suite.testConfigs.Logger, discussion.ID, suite.testConfigs.UserInfo.EuaUserID, suite.testConfigs.Store)
-	assert.NoError(suite.T(), err)
-	assert.EqualValues(suite.T(), discussion, result)
+	suite.NoError(err)
+	suite.EqualValues(discussion, result)
 
 	// Check that there's no plans for this user
 	discussions, err := PlanDiscussionCollectionByModelPlanID(suite.testConfigs.Logger, discussion.ID, suite.testConfigs.Store)
-	assert.NoError(suite.T(), err)
-	assert.Len(suite.T(), discussions, 0)
+	suite.NoError(err)
+	suite.Len(discussions, 0)
 }
 
 func (suite *ResolverSuite) TestDeletePlanDiscussionWithReply() {
@@ -64,8 +63,8 @@ func (suite *ResolverSuite) TestDeletePlanDiscussionWithReply() {
 	_ = suite.createDiscussionReply(discussion, "This is a test reply", false)
 
 	_, err := DeletePlanDiscussion(suite.testConfigs.Logger, discussion.ID, suite.testConfigs.UserInfo.EuaUserID, suite.testConfigs.Store)
-	assert.Error(suite.T(), err)
-	assert.Contains(suite.T(), err.Error(), "violates foreign key constraint") // maybe a weak check, and should be a custom error type, but works for now
+	suite.Error(err)
+	suite.Contains(err.Error(), "violates foreign key constraint") // maybe a weak check, and should be a custom error type, but works for now
 }
 
 func (suite *ResolverSuite) TestCreateDiscussionReply() {
@@ -79,11 +78,11 @@ func (suite *ResolverSuite) TestCreateDiscussionReply() {
 	}
 
 	result, err := CreateDiscussionReply(suite.testConfigs.Logger, input, suite.testConfigs.UserInfo.EuaUserID, suite.testConfigs.Store)
-	assert.NoError(suite.T(), err)
-	assert.NotNil(suite.T(), result.ID)
-	assert.EqualValues(suite.T(), discussion.ID, result.DiscussionID)
-	assert.EqualValues(suite.T(), input.Content, result.Content)
-	assert.EqualValues(suite.T(), input.Resolution, result.Resolution)
+	suite.NoError(err)
+	suite.NotNil(result.ID)
+	suite.EqualValues(discussion.ID, result.DiscussionID)
+	suite.EqualValues(input.Content, result.Content)
+	suite.EqualValues(input.Resolution, result.Resolution)
 }
 
 func (suite *ResolverSuite) TestUpdateDiscussionReply() {
@@ -98,11 +97,11 @@ func (suite *ResolverSuite) TestUpdateDiscussionReply() {
 	updater := "UPDT"
 
 	result, err := UpdateDiscussionReply(suite.testConfigs.Logger, reply.ID, changes, updater, suite.testConfigs.Store)
-	assert.NoError(suite.T(), err)
-	assert.EqualValues(suite.T(), changes["content"], result.Content)
-	assert.EqualValues(suite.T(), changes["resolution"], result.Resolution)
-	assert.EqualValues(suite.T(), suite.testConfigs.UserInfo.EuaUserID, result.CreatedBy)
-	assert.EqualValues(suite.T(), updater, result.ModifiedBy)
+	suite.NoError(err)
+	suite.EqualValues(changes["content"], result.Content)
+	suite.EqualValues(changes["resolution"], result.Resolution)
+	suite.EqualValues(suite.testConfigs.UserInfo.EuaUserID, result.CreatedBy)
+	suite.EqualValues(updater, result.ModifiedBy)
 }
 
 func (suite *ResolverSuite) TestDiscussionReplyCollectionByDiscusionID() {
@@ -112,8 +111,8 @@ func (suite *ResolverSuite) TestDiscussionReplyCollectionByDiscusionID() {
 	_ = suite.createDiscussionReply(discussion, "This is another test reply", true)
 
 	result, err := DiscussionReplyCollectionByDiscusionID(suite.testConfigs.Logger, discussion.ID, suite.testConfigs.Store)
-	assert.NoError(suite.T(), err)
-	assert.Len(suite.T(), result, 2)
+	suite.NoError(err)
+	suite.Len(result, 2)
 
 	// Check that adding another dicussion doesn't affect the first one
 	discussionTwo := suite.createPlanDiscussion(plan, "This is another test comment")
@@ -123,8 +122,8 @@ func (suite *ResolverSuite) TestDiscussionReplyCollectionByDiscusionID() {
 
 	// Assert the count on the _first_ discussion is still 2
 	result, err = DiscussionReplyCollectionByDiscusionID(suite.testConfigs.Logger, discussion.ID, suite.testConfigs.Store)
-	assert.NoError(suite.T(), err)
-	assert.Len(suite.T(), result, 2)
+	suite.NoError(err)
+	suite.Len(result, 2)
 }
 
 func (suite *ResolverSuite) TestPlanDiscussionCollectionByModelPlanID() {
@@ -134,8 +133,8 @@ func (suite *ResolverSuite) TestPlanDiscussionCollectionByModelPlanID() {
 	_ = suite.createDiscussionReply(discussion, "This is another test reply", true)
 
 	result, err := PlanDiscussionCollectionByModelPlanID(suite.testConfigs.Logger, plan.ID, suite.testConfigs.Store)
-	assert.NoError(suite.T(), err)
-	assert.Len(suite.T(), result, 1)
+	suite.NoError(err)
+	suite.Len(result, 1)
 
 	// Check that adding another dicussion doesn't affect the first one
 	discussionTwo := suite.createPlanDiscussion(plan, "This is another test comment")
@@ -145,8 +144,8 @@ func (suite *ResolverSuite) TestPlanDiscussionCollectionByModelPlanID() {
 
 	// Assert the count on the is now 2 after adding another discussion
 	result, err = PlanDiscussionCollectionByModelPlanID(suite.testConfigs.Logger, plan.ID, suite.testConfigs.Store)
-	assert.NoError(suite.T(), err)
-	assert.Len(suite.T(), result, 2)
+	suite.NoError(err)
+	suite.Len(result, 2)
 }
 
 func (suite *ResolverSuite) TestDeleteDiscussionReply() {
@@ -156,10 +155,10 @@ func (suite *ResolverSuite) TestDeleteDiscussionReply() {
 	_ = suite.createDiscussionReply(discussion, "This is another test reply", false)
 
 	_, err := DeleteDiscussionReply(suite.testConfigs.Logger, reply.ID, suite.testConfigs.UserInfo.EuaUserID, suite.testConfigs.Store)
-	assert.NoError(suite.T(), err)
+	suite.NoError(err)
 
 	// Should only have 1 left now
 	result, err := DiscussionReplyCollectionByDiscusionID(suite.testConfigs.Logger, discussion.ID, suite.testConfigs.Store)
-	assert.NoError(suite.T(), err)
-	assert.Len(suite.T(), result, 1)
+	suite.NoError(err)
+	suite.Len(result, 1)
 }

--- a/pkg/graph/resolvers/plan_milestones_test.go
+++ b/pkg/graph/resolvers/plan_milestones_test.go
@@ -12,10 +12,10 @@ func (suite *ResolverSuite) TestFetchPlanMilestonesByModelPlanID() {
 	milestones, err := FetchPlanMilestonesByModelPlanID(suite.testConfigs.Logger, &suite.testConfigs.UserInfo.EuaUserID, plan.ID, suite.testConfigs.Store)
 
 	suite.NoError(err)
-	suite.EqualValues(milestones.ModelPlanID, plan.ID)
-	suite.EqualValues(milestones.Status, models.TaskReady)
-	suite.EqualValues(*milestones.CreatedBy, suite.testConfigs.UserInfo.EuaUserID)
-	suite.EqualValues(*milestones.ModifiedBy, suite.testConfigs.UserInfo.EuaUserID)
+	suite.EqualValues(plan.ID, milestones.ModelPlanID)
+	suite.EqualValues(models.TaskReady, milestones.Status)
+	suite.EqualValues(suite.testConfigs.UserInfo.EuaUserID, *milestones.CreatedBy)
+	suite.EqualValues(suite.testConfigs.UserInfo.EuaUserID, *milestones.ModifiedBy)
 
 	// Many of the fields are nil upon creation
 	suite.Nil(milestones.CompleteICIP)

--- a/pkg/graph/resolvers/resolver_test.go
+++ b/pkg/graph/resolvers/resolver_test.go
@@ -49,6 +49,18 @@ func (suite *ResolverSuite) createDiscussionReply(pd *models.PlanDiscussion, con
 	return dr
 }
 
+func (suite *ResolverSuite) createPlanCollaborator(mp *models.ModelPlan, EUAUserID string, fullName string, teamRole models.TeamRole) *models.PlanCollaborator {
+	collaboratorInput := &model.PlanCollaboratorCreateInput{
+		ModelPlanID: mp.ID,
+		EuaUserID:   EUAUserID,
+		FullName:    fullName,
+		TeamRole:    teamRole,
+	}
+	collaborator, err := CreatePlanCollaborator(suite.testConfigs.Logger, collaboratorInput, suite.testConfigs.UserInfo.EuaUserID, suite.testConfigs.Store)
+	suite.NoError(err)
+	return collaborator
+}
+
 // TestResolverSuite runs the resolver test suite
 func TestResolverSuite(t *testing.T) {
 	rs := new(ResolverSuite)


### PR DESCRIPTION
# No Ticket

## Changes and Description

- Added Plan Collaborator tests
  - Basic CRUD operations, as well as expecting an error when updating/deleting the last model lead on a plan
- Updated `EqualValues` asserts to be `expected, actual` instead of `actual, expected` in some instances. This doesn't affect the tests as is, but if something breaks one of these tests, the error messages would be a bit confusing.

<!-- Put a description here! -->

## How to test this change

```bash
scripts/dev up:backend
scripts/dev test:go
# Or, to only run these tests, try this!
# scripts/dev test:go:only github.com/cmsgov/mint-app/pkg/graph/resolvers
```

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
