### PR TITLE
[EASI-2051] SQL error handling

### DIFF
--- a/pkg/graph/resolvers/plan_collaborator_test.go
+++ b/pkg/graph/resolvers/plan_collaborator_test.go
@@ -85,11 +85,9 @@ func (suite *ResolverSuite) TestDeletePlanCollaborator() {
 	suite.NoError(err)
 	suite.EqualValues(deletedCollaborator, collaborator)
 
-	// Ensure we get nil when we fetch it
-	// TODO: FetchByID methods should probably error if they don't find what they're looking for,
-	// but FetchByModelPlanID shouldn't (just return an empty slice)
+	// Ensure we get an error when we try fetch it
 	collaboratorByID, err := FetchCollaboratorByID(suite.testConfigs.Logger, collaborator.ID, suite.testConfigs.Store)
-	suite.NoError(err)
+	suite.Error(err)
 	suite.Nil(collaboratorByID)
 }
 

--- a/pkg/storage/genericmodel/errorhandling.go
+++ b/pkg/storage/genericmodel/errorhandling.go
@@ -1,8 +1,6 @@
 package genericmodel
 
 import (
-	"database/sql"
-	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -48,15 +46,6 @@ func createQueryError(err error, model models.BaseModel) error {
 		Model:     model,
 		Operation: apperrors.QueryUpdate,
 	}
-}
-
-// HandleModelFetchByIDError handles errors from a model being fetched by ID
-func HandleModelFetchByIDError(logger *zap.Logger, err error, id uuid.UUID) error {
-	if errors.Is(err, sql.ErrNoRows) {
-		return HandleModelFetchByIDNoRowsError(logger, err, id)
-	}
-
-	return HandleModelFetchGenericError(logger, err, id)
 }
 
 // HandleModelFetchByIDNoRowsError handles an errors when there's no results from a query by ID

--- a/pkg/storage/model_planStore.go
+++ b/pkg/storage/model_planStore.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 
 	"github.com/cmsgov/mint-app/pkg/shared/utilitySQL"
@@ -108,14 +107,6 @@ func (s *Store) ModelPlanGetByID(logger *zap.Logger, id uuid.UUID) (*models.Mode
 	err = stmt.Get(&plan, arg)
 
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			logger.Info(
-				"No model plan found",
-				zap.Error(err),
-				zap.String("id", id.String()),
-			)
-			return nil, &apperrors.ResourceNotFoundError{Err: err, Resource: models.ModelPlan{}}
-		}
 		logger.Error(
 			"Failed to fetch model plan",
 			zap.Error(err),
@@ -123,7 +114,7 @@ func (s *Store) ModelPlanGetByID(logger *zap.Logger, id uuid.UUID) (*models.Mode
 		)
 		return nil, &apperrors.QueryError{
 			Err:       err,
-			Model:     id,
+			Model:     plan,
 			Operation: apperrors.QueryFetch,
 		}
 	}
@@ -147,14 +138,6 @@ func (s *Store) ModelPlanCollectionByUser(logger *zap.Logger, EUAID string, arch
 	err = stmt.Select(&modelPlans, arg) //this returns more than one
 
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			logger.Info(
-				"No model plans for user found",
-				zap.Error(err),
-				zap.String("euaID", EUAID),
-			)
-			return nil, &apperrors.ResourceNotFoundError{Err: err, Resource: models.ModelPlan{}}
-		}
 		logger.Error(
 			"Failed to fetch model plans",
 			zap.Error(err),

--- a/pkg/storage/plan_basicsStore.go
+++ b/pkg/storage/plan_basicsStore.go
@@ -71,7 +71,7 @@ func (s *Store) PlanBasicsGetByID(logger *zap.Logger, id uuid.UUID) (*models.Pla
 	err = statement.Get(&plan, utilitySQL.CreateIDQueryMap(id))
 
 	if err != nil {
-		return nil, genericmodel.HandleModelFetchByIDError(logger, err, id)
+		return nil, err
 	}
 
 	return &plan, nil
@@ -95,7 +95,7 @@ func (s *Store) PlanBasicsGetByModelPlanID(logger *zap.Logger, principal *string
 	err = statement.Get(&plan, arg)
 
 	if err != nil {
-		return nil, genericmodel.HandleModelFetchByIDError(logger, err, modelPlanID)
+		return nil, err
 	}
 
 	return &plan, nil

--- a/pkg/storage/plan_collaboratorStore.go
+++ b/pkg/storage/plan_collaboratorStore.go
@@ -1,9 +1,7 @@
 package storage
 
 import (
-	"database/sql"
 	_ "embed"
-	"errors"
 
 	"github.com/cmsgov/mint-app/pkg/shared/utilitySQL"
 
@@ -96,10 +94,6 @@ func (s *Store) PlanCollaboratorsByModelPlanID(_ *zap.Logger, modelPlanID uuid.U
 
 	err = statement.Select(&collaborators, arg)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return collaborators, nil
-		}
-
 		return nil, err
 	}
 
@@ -116,10 +110,6 @@ func (s *Store) PlanCollaboratorFetchByID(id uuid.UUID) (*models.PlanCollaborato
 	var collaborator models.PlanCollaborator
 	err = statement.Get(&collaborator, utilitySQL.CreateIDQueryMap(id))
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil
-		}
-
 		return nil, err
 	}
 

--- a/pkg/storage/plan_discussionStore.go
+++ b/pkg/storage/plan_discussionStore.go
@@ -1,9 +1,7 @@
 package storage
 
 import (
-	"database/sql"
 	_ "embed"
-	"errors"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -95,14 +93,6 @@ func (s *Store) DiscussionReplyCollectionByDiscusionID(logger *zap.Logger, discu
 	err = stmt.Select(&replies, arg) //this returns more than one
 
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			logger.Info(
-				"No replies for this discussion",
-				zap.Error(err),
-				zap.String("discussion_id", discussionID.String()),
-			)
-			return nil, &apperrors.ResourceNotFoundError{Err: err, Resource: models.ModelPlan{}}
-		}
 		logger.Error(
 			"Failed to fetch discusion replies",
 			zap.Error(err),
@@ -135,7 +125,7 @@ func (s *Store) PlanDiscussionCollectionByModelPlanID(logger *zap.Logger, modelP
 	err = stmt.Select(&discusions, arg) //this returns more than one
 
 	if err != nil {
-		return nil, genericmodel.HandleModelFetchByIDError(logger, err, modelPlanID)
+		return nil, err
 	}
 	return discusions, nil
 

--- a/pkg/storage/plan_general_characteristicsStore.go
+++ b/pkg/storage/plan_general_characteristicsStore.go
@@ -70,7 +70,7 @@ func (s *Store) PlanGeneralCharacteristicsGetByID(logger *zap.Logger, id uuid.UU
 	err = statement.Get(&gc, utilitySQL.CreateIDQueryMap(id))
 
 	if err != nil {
-		return nil, genericmodel.HandleModelFetchByIDError(logger, err, id)
+		return nil, err
 	}
 
 	return &gc, nil
@@ -94,7 +94,7 @@ func (s *Store) PlanGeneralCharacteristicsGetByModelPlanID(logger *zap.Logger, p
 	err = statement.Get(&gc, arg)
 
 	if err != nil {
-		return nil, genericmodel.HandleModelFetchByIDError(logger, err, modelPlanID)
+		return nil, err
 	}
 
 	return &gc, nil

--- a/pkg/storage/plan_milestonesStore.go
+++ b/pkg/storage/plan_milestonesStore.go
@@ -67,7 +67,7 @@ func (s *Store) PlanMilestonesUpdate(logger *zap.Logger, plan *models.PlanMilest
 func (s *Store) FetchPlanMilestonesByModelPlanID(logger *zap.Logger, principal *string, modelPlanID uuid.UUID) (*models.PlanMilestones, error) {
 	statement, err := s.db.PrepareNamed(planMilestonesGetByModelPlanIDSQL)
 	if err != nil {
-		return nil, genericmodel.HandleModelFetchByIDError(logger, err, modelPlanID)
+		return nil, err
 	}
 
 	args := map[string]interface{}{
@@ -77,7 +77,7 @@ func (s *Store) FetchPlanMilestonesByModelPlanID(logger *zap.Logger, principal *
 	var plan models.PlanMilestones
 	err = statement.Get(&plan, args)
 	if err != nil {
-		return nil, genericmodel.HandleModelFetchByIDError(logger, err, modelPlanID)
+		return nil, err
 	}
 
 	return &plan, nil
@@ -93,7 +93,7 @@ func (s *Store) FetchPlanMilestonesByID(logger *zap.Logger, id uuid.UUID) (*mode
 	var plan models.PlanMilestones
 	err = statement.Get(&plan, utilitySQL.CreateIDQueryMap(id))
 	if err != nil {
-		return nil, genericmodel.HandleModelFetchByIDError(logger, err, id)
+		return nil, err
 	}
 
 	return &plan, nil


### PR DESCRIPTION
# EASI-2051

## Changes and Description

- Removed unneeded error type checking when using SQLX's `Select` (which doesn't actually return an error when no results are found)
- Removed checking of `sql.ErrNoRows` when using SQLX's `Get` (so that we now get an error when querying a single entity and don't find it)

## Open Items
- We should still take some time to figure out how we want to do contextually appropriate error logging, if that's a route we want to take (over just forwarding the errors up the call stack)

## How to test this change

1. `scripts/dev up:backend`
2. Try and get an entity by ID that doesn't exist:
```gql
query getModelPlan {
  modelPlan(id: "eeeeeeee-d693-4daf-87ef-02c97701fc46") {
    id
    basics {
      id
    }
  }
}
```
3. Expect an error

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [x] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [x] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
