### PR TITLE
implement common function for deserializing pq.string arrays in resolver

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -138,7 +138,7 @@ type ComplexityRoot struct {
 		UpdateDiscussionReply              func(childComplexity int, id uuid.UUID, changes map[string]interface{}) int
 		UpdateModelPlan                    func(childComplexity int, id uuid.UUID, changes map[string]interface{}) int
 		UpdatePlanBasics                   func(childComplexity int, id uuid.UUID, changes map[string]interface{}) int
-		UpdatePlanBeneficiares             func(childComplexity int, id uuid.UUID, changes map[string]interface{}) int
+		UpdatePlanBeneficiaries            func(childComplexity int, id uuid.UUID, changes map[string]interface{}) int
 		UpdatePlanCollaborator             func(childComplexity int, id uuid.UUID, newRole models.TeamRole) int
 		UpdatePlanDiscussion               func(childComplexity int, id uuid.UUID, changes map[string]interface{}) int
 		UpdatePlanDocument                 func(childComplexity int, input model.PlanDocumentInput) int
@@ -422,7 +422,7 @@ type MutationResolver interface {
 	UpdatePlanBasics(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanBasics, error)
 	UpdatePlanMilestones(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanMilestones, error)
 	UpdatePlanGeneralCharacteristics(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanGeneralCharacteristics, error)
-	UpdatePlanBeneficiares(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanBeneficiaries, error)
+	UpdatePlanBeneficiaries(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanBeneficiaries, error)
 	UpdatePlanParticipantsAndProviders(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanParticipantsAndProviders, error)
 	GeneratePresignedUploadURL(ctx context.Context, input model.GeneratePresignedUploadURLInput) (*model.GeneratePresignedUploadURLPayload, error)
 	CreatePlanDocument(ctx context.Context, input model.PlanDocumentInput) (*model.PlanDocumentPayload, error)
@@ -1019,17 +1019,17 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.UpdatePlanBasics(childComplexity, args["id"].(uuid.UUID), args["changes"].(map[string]interface{})), true
 
-	case "Mutation.updatePlanBeneficiares":
-		if e.complexity.Mutation.UpdatePlanBeneficiares == nil {
+	case "Mutation.updatePlanBeneficiaries":
+		if e.complexity.Mutation.UpdatePlanBeneficiaries == nil {
 			break
 		}
 
-		args, err := ec.field_Mutation_updatePlanBeneficiares_args(context.TODO(), rawArgs)
+		args, err := ec.field_Mutation_updatePlanBeneficiaries_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdatePlanBeneficiares(childComplexity, args["id"].(uuid.UUID), args["changes"].(map[string]interface{})), true
+		return e.complexity.Mutation.UpdatePlanBeneficiaries(childComplexity, args["id"].(uuid.UUID), args["changes"].(map[string]interface{})), true
 
 	case "Mutation.updatePlanCollaborator":
 		if e.complexity.Mutation.UpdatePlanCollaborator == nil {
@@ -3471,7 +3471,7 @@ updatePlanMilestones(id: UUID!, changes: PlanMilestoneChanges!): PlanMilestones!
 updatePlanGeneralCharacteristics(id: UUID!, changes: PlanGeneralCharacteristicsChanges!): PlanGeneralCharacteristics!
 @hasRole(role: MINT_BASE_USER)
 
-updatePlanBeneficiares(id: UUID!, changes: PlanBeneficiariesChanges!): PlanBeneficiaries!
+updatePlanBeneficiaries(id: UUID!, changes: PlanBeneficiariesChanges!): PlanBeneficiaries!
 @hasRole(role: MINT_BASE_USER)
 
 updatePlanParticipantsAndProviders(id: UUID!, changes: PlanParticipantsAndProvidersChanges!): PlanParticipantsAndProviders!
@@ -4021,7 +4021,7 @@ func (ec *executionContext) field_Mutation_updatePlanBasics_args(ctx context.Con
 	return args, nil
 }
 
-func (ec *executionContext) field_Mutation_updatePlanBeneficiares_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Mutation_updatePlanBeneficiaries_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 uuid.UUID
@@ -7882,8 +7882,8 @@ func (ec *executionContext) fieldContext_Mutation_updatePlanGeneralCharacteristi
 	return fc, nil
 }
 
-func (ec *executionContext) _Mutation_updatePlanBeneficiares(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_updatePlanBeneficiares(ctx, field)
+func (ec *executionContext) _Mutation_updatePlanBeneficiaries(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updatePlanBeneficiaries(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -7897,7 +7897,7 @@ func (ec *executionContext) _Mutation_updatePlanBeneficiares(ctx context.Context
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().UpdatePlanBeneficiares(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
+			return ec.resolvers.Mutation().UpdatePlanBeneficiaries(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
@@ -7937,7 +7937,7 @@ func (ec *executionContext) _Mutation_updatePlanBeneficiares(ctx context.Context
 	return ec.marshalNPlanBeneficiaries2ᚖgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPlanBeneficiaries(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Mutation_updatePlanBeneficiares(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Mutation_updatePlanBeneficiaries(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -8012,7 +8012,7 @@ func (ec *executionContext) fieldContext_Mutation_updatePlanBeneficiares(ctx con
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_updatePlanBeneficiares_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Mutation_updatePlanBeneficiaries_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -21435,10 +21435,10 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "updatePlanBeneficiares":
+		case "updatePlanBeneficiaries":
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_updatePlanBeneficiares(ctx, field)
+				return ec._Mutation_updatePlanBeneficiaries(ctx, field)
 			})
 
 			if out.Values[i] == graphql.Null {

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -736,7 +736,7 @@ updatePlanMilestones(id: UUID!, changes: PlanMilestoneChanges!): PlanMilestones!
 updatePlanGeneralCharacteristics(id: UUID!, changes: PlanGeneralCharacteristicsChanges!): PlanGeneralCharacteristics!
 @hasRole(role: MINT_BASE_USER)
 
-updatePlanBeneficiares(id: UUID!, changes: PlanBeneficiariesChanges!): PlanBeneficiaries!
+updatePlanBeneficiaries(id: UUID!, changes: PlanBeneficiariesChanges!): PlanBeneficiaries!
 @hasRole(role: MINT_BASE_USER)
 
 updatePlanParticipantsAndProviders(id: UUID!, changes: PlanParticipantsAndProvidersChanges!): PlanParticipantsAndProviders!

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -5,6 +5,7 @@ package graph
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 
@@ -17,24 +18,12 @@ import (
 )
 
 func (r *modelPlanResolver) CmsCenters(ctx context.Context, obj *models.ModelPlan) ([]models.CMSCenter, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var cmsCenters []models.CMSCenter
-
-	for _, item := range obj.CMSCenters {
-		cmsCenters = append(cmsCenters, models.CMSCenter(item))
-	}
-
+	cmsCenters := models.ConvertEnums[models.CMSCenter](obj.CMSCenters)
 	return cmsCenters, nil
 }
 
 func (r *modelPlanResolver) CmmiGroups(ctx context.Context, obj *models.ModelPlan) ([]model.CMMIGroup, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var cmmiGroups []model.CMMIGroup
-
-	for _, item := range obj.CMMIGroups {
-		cmmiGroups = append(cmmiGroups, model.CMMIGroup(item))
-	}
-
+	cmmiGroups := models.ConvertEnums[model.CMMIGroup](obj.CMMIGroups)
 	return cmmiGroups, nil
 }
 
@@ -159,10 +148,8 @@ func (r *mutationResolver) UpdatePlanGeneralCharacteristics(ctx context.Context,
 	return resolvers.UpdatePlanGeneralCharacteristics(logger, id, changes, principal, r.store)
 }
 
-func (r *mutationResolver) UpdatePlanBeneficiares(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanBeneficiaries, error) {
-	principal := appcontext.Principal(ctx).ID()
-	logger := appcontext.ZLogger(ctx)
-	return resolvers.PlanBeneficiariesUpdate(logger, id, changes, principal, r.store)
+func (r *mutationResolver) UpdatePlanBeneficiaries(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanBeneficiaries, error) {
+	panic(fmt.Errorf("not implemented"))
 }
 
 func (r *mutationResolver) UpdatePlanParticipantsAndProviders(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanParticipantsAndProviders, error) {
@@ -251,24 +238,12 @@ func (r *mutationResolver) DeleteDiscussionReply(ctx context.Context, id uuid.UU
 }
 
 func (r *planBeneficiariesResolver) Beneficiaries(ctx context.Context, obj *models.PlanBeneficiaries) ([]model.BeneficiariesType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var bTypes []model.BeneficiariesType
-
-	for _, item := range obj.Beneficiaries {
-		bTypes = append(bTypes, model.BeneficiariesType(item))
-	}
-
+	bTypes := models.ConvertEnums[model.BeneficiariesType](obj.Beneficiaries)
 	return bTypes, nil
 }
 
 func (r *planBeneficiariesResolver) BeneficiarySelectionMethod(ctx context.Context, obj *models.PlanBeneficiaries) ([]model.SelectionMethodType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var sTypes []model.SelectionMethodType
-
-	for _, item := range obj.BeneficiarySelectionMethod {
-		sTypes = append(sTypes, model.SelectionMethodType(item))
-	}
-
+	sTypes := models.ConvertEnums[model.SelectionMethodType](obj.BeneficiarySelectionMethod)
 	return sTypes, nil
 }
 
@@ -287,128 +262,67 @@ func (r *planGeneralCharacteristicsResolver) ResemblesExistingModelWhich(ctx con
 }
 
 func (r *planGeneralCharacteristicsResolver) AlternativePaymentModelTypes(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.AlternativePaymentModelType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var apmTypes []model.AlternativePaymentModelType
-
-	for _, item := range obj.AlternativePaymentModelTypes {
-		apmTypes = append(apmTypes, model.AlternativePaymentModelType(item))
-	}
-
+	apmTypes := models.ConvertEnums[model.AlternativePaymentModelType](obj.AlternativePaymentModelTypes)
 	return apmTypes, nil
 }
 
 func (r *planGeneralCharacteristicsResolver) KeyCharacteristics(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.KeyCharacteristic, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var keyCharacteristics []model.KeyCharacteristic
-
-	for _, item := range obj.KeyCharacteristics {
-		keyCharacteristics = append(keyCharacteristics, model.KeyCharacteristic(item))
-	}
-
+	keyCharacteristics := models.ConvertEnums[model.KeyCharacteristic](obj.KeyCharacteristics)
 	return keyCharacteristics, nil
 }
 
 func (r *planGeneralCharacteristicsResolver) GeographiesTargetedTypes(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.GeographyType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var geographyTypes []model.GeographyType
-
-	for _, item := range obj.GeographiesTargetedTypes {
-		geographyTypes = append(geographyTypes, model.GeographyType(item))
-	}
-
+	geographyTypes := models.ConvertEnums[model.GeographyType](obj.GeographiesTargetedTypes)
 	return geographyTypes, nil
 }
 
 func (r *planGeneralCharacteristicsResolver) GeographiesTargetedAppliedTo(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.GeographyApplication, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var geographyApplications []model.GeographyApplication
-
-	for _, item := range obj.GeographiesTargetedAppliedTo {
-		geographyApplications = append(geographyApplications, model.GeographyApplication(item))
-	}
-
+	geographyApplications := models.ConvertEnums[model.GeographyApplication](obj.GeographiesTargetedAppliedTo)
 	return geographyApplications, nil
 }
 
 func (r *planGeneralCharacteristicsResolver) AgreementTypes(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.AgreementType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var agreementTypes []model.AgreementType
-
-	for _, item := range obj.AgreementTypes {
-		agreementTypes = append(agreementTypes, model.AgreementType(item))
-	}
-
+	agreementTypes := models.ConvertEnums[model.AgreementType](obj.AgreementTypes)
 	return agreementTypes, nil
 }
 
 func (r *planGeneralCharacteristicsResolver) AuthorityAllowances(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.AuthorityAllowance, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var authorityAllowances []model.AuthorityAllowance
-
-	for _, item := range obj.AuthorityAllowances {
-		authorityAllowances = append(authorityAllowances, model.AuthorityAllowance(item))
-	}
-
+	authorityAllowances := models.ConvertEnums[model.AuthorityAllowance](obj.AuthorityAllowances)
 	return authorityAllowances, nil
 }
 
 func (r *planGeneralCharacteristicsResolver) WaiversRequiredTypes(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.WaiverType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var waiverTypes []model.WaiverType
-
-	for _, item := range obj.WaiversRequiredTypes {
-		waiverTypes = append(waiverTypes, model.WaiverType(item))
-	}
-
+	waiverTypes := models.ConvertEnums[model.WaiverType](obj.WaiversRequiredTypes)
 	return waiverTypes, nil
 }
 
 func (r *planParticipantsAndProvidersResolver) Participants(ctx context.Context, obj *models.PlanParticipantsAndProviders) ([]model.ParticipantsType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var participants []model.ParticipantsType
-	for _, item := range obj.Participants {
-		participants = append(participants, model.ParticipantsType(item))
-	}
+	participants := models.ConvertEnums[model.ParticipantsType](obj.Participants)
 	return participants, nil
 }
 
 func (r *planParticipantsAndProvidersResolver) SelectionMethod(ctx context.Context, obj *models.PlanParticipantsAndProviders) ([]model.ParticipantSelectionType, error) {
-	var selectionTypes []model.ParticipantSelectionType
-	for _, item := range obj.SelectionMethod {
-		selectionTypes = append(selectionTypes, model.ParticipantSelectionType(item))
-	}
+	selectionTypes := models.ConvertEnums[model.ParticipantSelectionType](obj.SelectionMethod)
 	return selectionTypes, nil
 }
 
 func (r *planParticipantsAndProvidersResolver) CommunicationMethod(ctx context.Context, obj *models.PlanParticipantsAndProviders) ([]model.ParticipantCommunicationType, error) {
-	var communicationTypes []model.ParticipantCommunicationType
-	for _, item := range obj.CommunicationMethod {
-		communicationTypes = append(communicationTypes, model.ParticipantCommunicationType(item))
-	}
+	communicationTypes := models.ConvertEnums[model.ParticipantCommunicationType](obj.CommunicationMethod)
 	return communicationTypes, nil
 }
 
 func (r *planParticipantsAndProvidersResolver) ParticipantsIds(ctx context.Context, obj *models.PlanParticipantsAndProviders) ([]model.ParticipantsIDType, error) {
-	var participantsIDTypes []model.ParticipantsIDType
-	for _, item := range obj.ParticipantsIds {
-		participantsIDTypes = append(participantsIDTypes, model.ParticipantsIDType(item))
-	}
+	participantsIDTypes := models.ConvertEnums[model.ParticipantsIDType](obj.ParticipantsIds)
 	return participantsIDTypes, nil
 }
 
 func (r *planParticipantsAndProvidersResolver) ProviderAddMethod(ctx context.Context, obj *models.PlanParticipantsAndProviders) ([]model.ProviderAddType, error) {
-	var providerAddTypes []model.ProviderAddType
-	for _, item := range obj.ProviderAddMethod {
-		providerAddTypes = append(providerAddTypes, model.ProviderAddType(item))
-	}
+	providerAddTypes := models.ConvertEnums[model.ProviderAddType](obj.ProviderAddMethod)
 	return providerAddTypes, nil
 }
 
 func (r *planParticipantsAndProvidersResolver) ProviderLeaveMethod(ctx context.Context, obj *models.PlanParticipantsAndProviders) ([]model.ProviderLeaveType, error) {
-	var providerLeaveTypes []model.ProviderLeaveType
-	for _, item := range obj.ProviderLeaveMethod {
-		providerLeaveTypes = append(providerLeaveTypes, model.ProviderLeaveType(item))
-	}
+	providerLeaveTypes := models.ConvertEnums[model.ProviderLeaveType](obj.ProviderLeaveMethod)
 	return providerLeaveTypes, nil
 }
 
@@ -537,3 +451,15 @@ type planGeneralCharacteristicsResolver struct{ *Resolver }
 type planParticipantsAndProvidersResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type userInfoResolver struct{ *Resolver }
+
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//    it when you're done.
+//  - You have helper methods in this file. Move them out to keep these resolver files clean.
+func (r *mutationResolver) UpdatePlanBeneficiares(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanBeneficiaries, error) {
+	principal := appcontext.Principal(ctx).ID()
+	logger := appcontext.ZLogger(ctx)
+	return resolvers.PlanBeneficiariesUpdate(logger, id, changes, principal, r.store)
+}

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -5,7 +5,6 @@ package graph
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/google/uuid"
 
@@ -149,7 +148,9 @@ func (r *mutationResolver) UpdatePlanGeneralCharacteristics(ctx context.Context,
 }
 
 func (r *mutationResolver) UpdatePlanBeneficiaries(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanBeneficiaries, error) {
-	panic(fmt.Errorf("not implemented"))
+	principal := appcontext.Principal(ctx).ID()
+	logger := appcontext.ZLogger(ctx)
+	return resolvers.PlanBeneficiariesUpdate(logger, id, changes, principal, r.store)
 }
 
 func (r *mutationResolver) UpdatePlanParticipantsAndProviders(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanParticipantsAndProviders, error) {
@@ -451,15 +452,3 @@ type planGeneralCharacteristicsResolver struct{ *Resolver }
 type planParticipantsAndProvidersResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type userInfoResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//  - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//    it when you're done.
-//  - You have helper methods in this file. Move them out to keep these resolver files clean.
-func (r *mutationResolver) UpdatePlanBeneficiares(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanBeneficiaries, error) {
-	principal := appcontext.Principal(ctx).ID()
-	logger := appcontext.ZLogger(ctx)
-	return resolvers.PlanBeneficiariesUpdate(logger, id, changes, principal, r.store)
-}

--- a/pkg/models/model_helpers.go
+++ b/pkg/models/model_helpers.go
@@ -1,5 +1,7 @@
 package models
 
+import "github.com/lib/pq"
+
 // StringPointer returns a pointer to a string input
 func StringPointer(st string) *string {
 	return &st
@@ -21,4 +23,13 @@ func ValueOrEmpty(st *string) string {
 		return *st
 	}
 	return ""
+}
+
+//ConvertEnums converts a pq.StringArray to specific, castable type
+func ConvertEnums[EnumType ~string](pqGroups pq.StringArray) []EnumType {
+	enumValues := []EnumType{}
+	for _, item := range pqGroups {
+		enumValues = append(enumValues, EnumType(item))
+	}
+	return enumValues
 }


### PR DESCRIPTION
This change implements common functionality for casting a PQ string array to a specific enum type. At present, you still have to implement the resolver for each pq.StringArray, but it reduces the lines of code considerably. 

Note, credit goes to @DylanSpOddball for implementation of ConvertEnums  helper function. Thanks Dylan!

I also corrected a type in the updatePlanBeneficiaries mutation. No functional change made there.
## How to test this change

`scripts/dev up:backend:debug && scripts/dev db:seed`

Run this GQL script that should include most / all of the properties that are an array of enums
```gql
query ModelPlan{
  
  modelPlan(id:"6e224030-09d5-46f7-ad04-4bb851b36eab"){
    id
    modelName
    modelCategory
    cmsCenters
    cmmiGroups
    generalCharacteristics {
        resemblesExistingModelWhich
        alternativePaymentModelTypes
        keyCharacteristics
        geographiesTargetedTypes
        geographiesTargetedAppliedTo
        agreementTypes
        authorityAllowances
        waiversRequiredTypes
    }
    providersAndParticipants {
        participants
        selectionMethod
        communicationMethod
        participantsIds
        providerAddMethod
        providerLeaveMethod

    }
    beneficiaries {
        beneficiaries
        beneficiarySelectionMethod

    }
    

  }
  
  
}
```

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
