### PR TITLE
Easi 1982/generic type array serialization

### DIFF
--- a/cmd/gqlgen/main.go
+++ b/cmd/gqlgen/main.go
@@ -1,0 +1,29 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/99designs/gqlgen/api"
+	"github.com/99designs/gqlgen/codegen/config"
+	enumArray "github.com/cmsgov/mint-app/cmd/gqlgen/plugin"
+)
+
+func main() {
+	cfg, err := config.LoadConfigFromDefaultLocations()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to load config", err.Error())
+		os.Exit(2)
+	}
+
+	err = api.Generate(cfg,
+		api.AddPlugin(enumArray.New()),
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(3)
+	}
+}

--- a/cmd/gqlgen/plugin/enum_array_plugin.go
+++ b/cmd/gqlgen/plugin/enum_array_plugin.go
@@ -1,0 +1,130 @@
+package enumArray
+
+import (
+	// "fmt"
+	"fmt"
+	"go/types"
+
+	// "sort"
+	"strings"
+
+	// "github.com/99designs/gqlgen/codegen/config"
+	// "github.com/99designs/gqlgen/codegen/templates"
+	"github.com/99designs/gqlgen/plugin"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+type BuildMutateHook = func(b *ModelBuild) *ModelBuild
+
+type FieldMutateHook = func(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error)
+
+// defaultFieldMutateHook is the default hook for the Plugin which applies the GoTagFieldHook.
+func defaultFieldMutateHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error) {
+	return GoTagFieldHook(td, fd, f)
+}
+
+func defaultBuildMutateHook(b *ModelBuild) *ModelBuild {
+	return b
+}
+
+type ModelBuild struct {
+	PackageName string
+	Interfaces  []*Interface
+	Models      []*Object
+	Enums       []*Enum
+	Scalars     []string
+}
+
+type Interface struct {
+	Description string
+	Name        string
+	Implements  []string
+}
+
+type Object struct {
+	Description string
+	Name        string
+	Fields      []*Field
+	Implements  []string
+}
+
+type Field struct {
+	Description string
+	// Name is the field's name as it appears in the schema
+	Name string
+	// GoName is the field's name as it appears in the generated Go code
+	GoName string
+	Type   types.Type
+	Tag    string
+}
+
+type Enum struct {
+	Description string
+	Name        string
+	Values      []*EnumValue
+}
+
+type EnumValue struct {
+	Description string
+	Name        string
+}
+
+func New() plugin.Plugin {
+	return &Plugin{
+		MutateHook: defaultBuildMutateHook,
+		FieldHook:  defaultFieldMutateHook,
+	}
+}
+
+type Plugin struct {
+	MutateHook BuildMutateHook
+	FieldHook  FieldMutateHook
+}
+
+func (m *Plugin) Name() string {
+	return "enumArray"
+}
+
+// GoTagFieldHook applies the goTag directive to the generated Field f. When applying the Tag to the field, the field
+// name is used when no value argument is present.
+func GoTagFieldHook(td *ast.Definition, fd *ast.FieldDefinition, f *Field) (*Field, error) {
+	args := make([]string, 0)
+	for _, goTag := range fd.Directives.ForNames("goTag") {
+		key := ""
+		value := fd.Name
+
+		if arg := goTag.Arguments.ForName("key"); arg != nil {
+			if k, err := arg.Value.Value(nil); err == nil {
+				key = k.(string)
+			}
+		}
+
+		if arg := goTag.Arguments.ForName("value"); arg != nil {
+			if v, err := arg.Value.Value(nil); err == nil {
+				value = v.(string)
+			}
+		}
+
+		args = append(args, key+":\""+value+"\"")
+		fmt.Print("Found goTag Array Directive")
+		fmt.Print(key, value)
+
+	}
+
+	for _, enumArray := range fd.Directives.ForNames("enumArray") {
+
+		fmt.Print("Found enum Array Directive")
+		if arg := enumArray.Arguments.ForName("enumType"); arg != nil {
+			if enum, err := arg.Value.Value(nil); err == nil {
+				enum = enum.(string)
+			}
+
+		}
+	}
+
+	if len(args) > 0 {
+		f.Tag = f.Tag + " " + strings.Join(args, " ")
+	}
+
+	return f, nil
+}

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -57,3 +57,6 @@ models:
   UUID:
     model:
       - github.com/cmsgov/mint-app/pkg/models.UUID
+  EnumArray:
+    model:
+    - github.com/cmsgov/mint-app/pkg/models.EnumArray

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -60,3 +60,8 @@ models:
   EnumArray:
     model:
     - github.com/cmsgov/mint-app/pkg/models.EnumArray
+    - github.com/cmsgov/mint-app/pkg/models.CMSCenterG
+    - github.com/cmsgov/mint-app/pkg/models.CMMIGroupG
+directives:
+  enumArray:
+    skip_runtime: true #this should only be used for code generation

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -402,7 +402,7 @@ type ComplexityRoot struct {
 type ModelPlanResolver interface {
 	CmsCenters(ctx context.Context, obj *models.ModelPlan) ([]models.CMSCenter, error)
 
-	CmmiGroups(ctx context.Context, obj *models.ModelPlan) ([]model.CMMIGroup, error)
+	CmmiGroups(ctx context.Context, obj *models.ModelPlan) ([]models.CMMIGroup, error)
 
 	Basics(ctx context.Context, obj *models.ModelPlan) (*models.PlanBasics, error)
 	Milestones(ctx context.Context, obj *models.ModelPlan) (*models.PlanMilestones, error)
@@ -2758,6 +2758,13 @@ Time values are represented as strings using RFC3339 format, for example 2019-10
 """
 scalar Time
 
+
+# scalar EnumArray
+
+# type CMSArray {
+#   items: [CMSCenter!]!
+
+# }
 """
 ModelPlan represent the data point for plans about a model. It is the central data type in the application
 """
@@ -2765,7 +2772,8 @@ type ModelPlan {
   id: UUID!
   modelName: String!
   modelCategory: ModelCategory
-  cmsCenters: [CMSCenter!]!
+  # cmsCenters:CMSArray
+  cmsCenters:[CMSCenter!]!
   cmsOther: String
   cmmiGroups: [CMMIGroup!]!
   archived: Boolean!
@@ -5870,9 +5878,9 @@ func (ec *executionContext) _ModelPlan_cmmiGroups(ctx context.Context, field gra
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]model.CMMIGroup)
+	res := resTmp.([]models.CMMIGroup)
 	fc.Result = res
-	return ec.marshalNCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐCMMIGroupᚄ(ctx, field.Selections, res)
+	return ec.marshalNCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐCMMIGroupᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ModelPlan_cmmiGroups(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -23835,26 +23843,32 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
-func (ec *executionContext) unmarshalNCMMIGroup2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐCMMIGroup(ctx context.Context, v interface{}) (model.CMMIGroup, error) {
-	var res model.CMMIGroup
-	err := res.UnmarshalGQL(v)
+func (ec *executionContext) unmarshalNCMMIGroup2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐCMMIGroup(ctx context.Context, v interface{}) (models.CMMIGroup, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := models.CMMIGroup(tmp)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNCMMIGroup2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐCMMIGroup(ctx context.Context, sel ast.SelectionSet, v model.CMMIGroup) graphql.Marshaler {
-	return v
+func (ec *executionContext) marshalNCMMIGroup2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐCMMIGroup(ctx context.Context, sel ast.SelectionSet, v models.CMMIGroup) graphql.Marshaler {
+	res := graphql.MarshalString(string(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
 }
 
-func (ec *executionContext) unmarshalNCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐCMMIGroupᚄ(ctx context.Context, v interface{}) ([]model.CMMIGroup, error) {
+func (ec *executionContext) unmarshalNCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐCMMIGroupᚄ(ctx context.Context, v interface{}) ([]models.CMMIGroup, error) {
 	var vSlice []interface{}
 	if v != nil {
 		vSlice = graphql.CoerceList(v)
 	}
 	var err error
-	res := make([]model.CMMIGroup, len(vSlice))
+	res := make([]models.CMMIGroup, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNCMMIGroup2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐCMMIGroup(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNCMMIGroup2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐCMMIGroup(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}
@@ -23862,7 +23876,7 @@ func (ec *executionContext) unmarshalNCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmint�
 	return res, nil
 }
 
-func (ec *executionContext) marshalNCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐCMMIGroupᚄ(ctx context.Context, sel ast.SelectionSet, v []model.CMMIGroup) graphql.Marshaler {
+func (ec *executionContext) marshalNCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐCMMIGroupᚄ(ctx context.Context, sel ast.SelectionSet, v []models.CMMIGroup) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -23886,7 +23900,7 @@ func (ec *executionContext) marshalNCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmintᚑ
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNCMMIGroup2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐCMMIGroup(ctx, sel, v[i])
+			ret[i] = ec.marshalNCMMIGroup2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐCMMIGroup(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -25648,7 +25662,7 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	return res
 }
 
-func (ec *executionContext) unmarshalOCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐCMMIGroupᚄ(ctx context.Context, v interface{}) ([]model.CMMIGroup, error) {
+func (ec *executionContext) unmarshalOCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐCMMIGroupᚄ(ctx context.Context, v interface{}) ([]models.CMMIGroup, error) {
 	if v == nil {
 		return nil, nil
 	}
@@ -25657,10 +25671,10 @@ func (ec *executionContext) unmarshalOCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmint�
 		vSlice = graphql.CoerceList(v)
 	}
 	var err error
-	res := make([]model.CMMIGroup, len(vSlice))
+	res := make([]models.CMMIGroup, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNCMMIGroup2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐCMMIGroup(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNCMMIGroup2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐCMMIGroup(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}
@@ -25668,7 +25682,7 @@ func (ec *executionContext) unmarshalOCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmint�
 	return res, nil
 }
 
-func (ec *executionContext) marshalOCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐCMMIGroupᚄ(ctx context.Context, sel ast.SelectionSet, v []model.CMMIGroup) graphql.Marshaler {
+func (ec *executionContext) marshalOCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐCMMIGroupᚄ(ctx context.Context, sel ast.SelectionSet, v []models.CMMIGroup) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -25695,7 +25709,7 @@ func (ec *executionContext) marshalOCMMIGroup2ᚕgithubᚗcomᚋcmsgovᚋmintᚑ
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNCMMIGroup2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐCMMIGroup(ctx, sel, v[i])
+			ret[i] = ec.marshalNCMMIGroup2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐCMMIGroup(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -2773,7 +2773,7 @@ type ModelPlan {
   modelName: String!
   modelCategory: ModelCategory
   # cmsCenters:CMSArray
-  cmsCenters:[CMSCenter!]!
+  cmsCenters:[CMSCenter!]!  @enumArray(enumType: "CMSGroupG" ) 
   cmsOther: String
   cmmiGroups: [CMMIGroup!]!
   archived: Boolean!
@@ -3562,7 +3562,7 @@ enum ModelStatus {
 	ANNOUNCED
 }
 
-enum CMSCenter {
+enum CMSCenter @enumArray(enumType: "CMSGroupG" ) {
   CMMI
   CENTER_FOR_MEDICARE
   FEDERAL_COORDINATED_HEALTH_CARE_OFFICE
@@ -3763,6 +3763,9 @@ NOT_APPLICABLE
 }
 
 directive @hasRole(role: Role!) on FIELD_DEFINITION
+
+directive @enumArray(enumType: String!) on ENUM | FIELD_DEFINITION
+#/SCALAR
 
 # https://gqlgen.com/config/#inline-config-with-directives
 directive @goModel(

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -138,7 +138,7 @@ type ComplexityRoot struct {
 		UpdateDiscussionReply              func(childComplexity int, id uuid.UUID, changes map[string]interface{}) int
 		UpdateModelPlan                    func(childComplexity int, id uuid.UUID, changes map[string]interface{}) int
 		UpdatePlanBasics                   func(childComplexity int, id uuid.UUID, changes map[string]interface{}) int
-		UpdatePlanBeneficiares             func(childComplexity int, id uuid.UUID, changes map[string]interface{}) int
+		UpdatePlanBeneficiaries            func(childComplexity int, id uuid.UUID, changes map[string]interface{}) int
 		UpdatePlanCollaborator             func(childComplexity int, id uuid.UUID, newRole models.TeamRole) int
 		UpdatePlanDiscussion               func(childComplexity int, id uuid.UUID, changes map[string]interface{}) int
 		UpdatePlanDocument                 func(childComplexity int, input model.PlanDocumentInput) int
@@ -422,7 +422,7 @@ type MutationResolver interface {
 	UpdatePlanBasics(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanBasics, error)
 	UpdatePlanMilestones(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanMilestones, error)
 	UpdatePlanGeneralCharacteristics(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanGeneralCharacteristics, error)
-	UpdatePlanBeneficiares(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanBeneficiaries, error)
+	UpdatePlanBeneficiaries(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanBeneficiaries, error)
 	UpdatePlanParticipantsAndProviders(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanParticipantsAndProviders, error)
 	GeneratePresignedUploadURL(ctx context.Context, input model.GeneratePresignedUploadURLInput) (*model.GeneratePresignedUploadURLPayload, error)
 	CreatePlanDocument(ctx context.Context, input model.PlanDocumentInput) (*model.PlanDocumentPayload, error)
@@ -1019,17 +1019,17 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.UpdatePlanBasics(childComplexity, args["id"].(uuid.UUID), args["changes"].(map[string]interface{})), true
 
-	case "Mutation.updatePlanBeneficiares":
-		if e.complexity.Mutation.UpdatePlanBeneficiares == nil {
+	case "Mutation.updatePlanBeneficiaries":
+		if e.complexity.Mutation.UpdatePlanBeneficiaries == nil {
 			break
 		}
 
-		args, err := ec.field_Mutation_updatePlanBeneficiares_args(context.TODO(), rawArgs)
+		args, err := ec.field_Mutation_updatePlanBeneficiaries_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdatePlanBeneficiares(childComplexity, args["id"].(uuid.UUID), args["changes"].(map[string]interface{})), true
+		return e.complexity.Mutation.UpdatePlanBeneficiaries(childComplexity, args["id"].(uuid.UUID), args["changes"].(map[string]interface{})), true
 
 	case "Mutation.updatePlanCollaborator":
 		if e.complexity.Mutation.UpdatePlanCollaborator == nil {
@@ -3471,7 +3471,7 @@ updatePlanMilestones(id: UUID!, changes: PlanMilestoneChanges!): PlanMilestones!
 updatePlanGeneralCharacteristics(id: UUID!, changes: PlanGeneralCharacteristicsChanges!): PlanGeneralCharacteristics!
 @hasRole(role: MINT_BASE_USER)
 
-updatePlanBeneficiares(id: UUID!, changes: PlanBeneficiariesChanges!): PlanBeneficiaries!
+updatePlanBeneficiaries(id: UUID!, changes: PlanBeneficiariesChanges!): PlanBeneficiaries!
 @hasRole(role: MINT_BASE_USER)
 
 updatePlanParticipantsAndProviders(id: UUID!, changes: PlanParticipantsAndProvidersChanges!): PlanParticipantsAndProviders!
@@ -4021,7 +4021,7 @@ func (ec *executionContext) field_Mutation_updatePlanBasics_args(ctx context.Con
 	return args, nil
 }
 
-func (ec *executionContext) field_Mutation_updatePlanBeneficiares_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Mutation_updatePlanBeneficiaries_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 uuid.UUID
@@ -7882,8 +7882,8 @@ func (ec *executionContext) fieldContext_Mutation_updatePlanGeneralCharacteristi
 	return fc, nil
 }
 
-func (ec *executionContext) _Mutation_updatePlanBeneficiares(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_updatePlanBeneficiares(ctx, field)
+func (ec *executionContext) _Mutation_updatePlanBeneficiaries(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_updatePlanBeneficiaries(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -7897,7 +7897,7 @@ func (ec *executionContext) _Mutation_updatePlanBeneficiares(ctx context.Context
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().UpdatePlanBeneficiares(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
+			return ec.resolvers.Mutation().UpdatePlanBeneficiaries(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
@@ -7937,7 +7937,7 @@ func (ec *executionContext) _Mutation_updatePlanBeneficiares(ctx context.Context
 	return ec.marshalNPlanBeneficiaries2ᚖgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPlanBeneficiaries(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Mutation_updatePlanBeneficiares(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Mutation_updatePlanBeneficiaries(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -8012,7 +8012,7 @@ func (ec *executionContext) fieldContext_Mutation_updatePlanBeneficiares(ctx con
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_updatePlanBeneficiares_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Mutation_updatePlanBeneficiaries_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -21435,10 +21435,10 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "updatePlanBeneficiares":
+		case "updatePlanBeneficiaries":
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_updatePlanBeneficiares(ctx, field)
+				return ec._Mutation_updatePlanBeneficiaries(ctx, field)
 			})
 
 			if out.Values[i] == graphql.Null {

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -2774,7 +2774,7 @@ type ModelPlan {
   modelCategory: ModelCategory
   # cmsCenters:CMSArray
   cmsCenters:[CMSCenter!]!  @enumArray(enumType: "CMSGroupG" ) 
-  cmsOther: String
+  cmsOther: String @goTag(key: "Exclamation" value: "hooray")
   cmmiGroups: [CMMIGroup!]!
   archived: Boolean!
   createdBy: String!
@@ -3766,6 +3766,10 @@ directive @hasRole(role: Role!) on FIELD_DEFINITION
 
 directive @enumArray(enumType: String!) on ENUM | FIELD_DEFINITION
 #/SCALAR
+directive @goTag(
+	key: String!
+	value: String
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 # https://gqlgen.com/config/#inline-config-with-directives
 directive @goModel(

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -263,53 +263,6 @@ func (e BeneficiariesType) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
-type CMMIGroup string
-
-const (
-	CMMIGroupPatientCareModelsGroup                       CMMIGroup = "PATIENT_CARE_MODELS_GROUP"
-	CMMIGroupPolicyAndProgramsGroup                       CMMIGroup = "POLICY_AND_PROGRAMS_GROUP"
-	CMMIGroupPreventiveAndPopulationHealthCareModelsGroup CMMIGroup = "PREVENTIVE_AND_POPULATION_HEALTH_CARE_MODELS_GROUP"
-	CMMIGroupSeamlessCareModelsGroup                      CMMIGroup = "SEAMLESS_CARE_MODELS_GROUP"
-	CMMIGroupStateInnovationsGroup                        CMMIGroup = "STATE_INNOVATIONS_GROUP"
-)
-
-var AllCMMIGroup = []CMMIGroup{
-	CMMIGroupPatientCareModelsGroup,
-	CMMIGroupPolicyAndProgramsGroup,
-	CMMIGroupPreventiveAndPopulationHealthCareModelsGroup,
-	CMMIGroupSeamlessCareModelsGroup,
-	CMMIGroupStateInnovationsGroup,
-}
-
-func (e CMMIGroup) IsValid() bool {
-	switch e {
-	case CMMIGroupPatientCareModelsGroup, CMMIGroupPolicyAndProgramsGroup, CMMIGroupPreventiveAndPopulationHealthCareModelsGroup, CMMIGroupSeamlessCareModelsGroup, CMMIGroupStateInnovationsGroup:
-		return true
-	}
-	return false
-}
-
-func (e CMMIGroup) String() string {
-	return string(e)
-}
-
-func (e *CMMIGroup) UnmarshalGQL(v interface{}) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("enums must be strings")
-	}
-
-	*e = CMMIGroup(str)
-	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid CMMIGroup", str)
-	}
-	return nil
-}
-
-func (e CMMIGroup) MarshalGQL(w io.Writer) {
-	fmt.Fprint(w, strconv.Quote(e.String()))
-}
-
 type GeographyApplication string
 
 const (

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -39,7 +39,7 @@ type ModelPlan {
   modelCategory: ModelCategory
   # cmsCenters:CMSArray
   cmsCenters:[CMSCenter!]!  @enumArray(enumType: "CMSGroupG" ) 
-  cmsOther: String
+  cmsOther: String @goTag(key: "Exclamation" value: "hooray")
   cmmiGroups: [CMMIGroup!]!
   archived: Boolean!
   createdBy: String!
@@ -1031,6 +1031,10 @@ directive @hasRole(role: Role!) on FIELD_DEFINITION
 
 directive @enumArray(enumType: String!) on ENUM | FIELD_DEFINITION
 #/SCALAR
+directive @goTag(
+	key: String!
+	value: String
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
 # https://gqlgen.com/config/#inline-config-with-directives
 directive @goModel(

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -23,6 +23,13 @@ Time values are represented as strings using RFC3339 format, for example 2019-10
 """
 scalar Time
 
+
+# scalar EnumArray
+
+# type CMSArray {
+#   items: [CMSCenter!]!
+
+# }
 """
 ModelPlan represent the data point for plans about a model. It is the central data type in the application
 """
@@ -30,7 +37,8 @@ type ModelPlan {
   id: UUID!
   modelName: String!
   modelCategory: ModelCategory
-  cmsCenters: [CMSCenter!]!
+  # cmsCenters:CMSArray
+  cmsCenters:[CMSCenter!]!
   cmsOther: String
   cmmiGroups: [CMMIGroup!]!
   archived: Boolean!

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -38,7 +38,7 @@ type ModelPlan {
   modelName: String!
   modelCategory: ModelCategory
   # cmsCenters:CMSArray
-  cmsCenters:[CMSCenter!]!
+  cmsCenters:[CMSCenter!]!  @enumArray(enumType: "CMSGroupG" ) 
   cmsOther: String
   cmmiGroups: [CMMIGroup!]!
   archived: Boolean!
@@ -827,7 +827,7 @@ enum ModelStatus {
 	ANNOUNCED
 }
 
-enum CMSCenter {
+enum CMSCenter @enumArray(enumType: "CMSGroupG" ) {
   CMMI
   CENTER_FOR_MEDICARE
   FEDERAL_COORDINATED_HEALTH_CARE_OFFICE
@@ -1028,6 +1028,9 @@ NOT_APPLICABLE
 }
 
 directive @hasRole(role: Role!) on FIELD_DEFINITION
+
+directive @enumArray(enumType: String!) on ENUM | FIELD_DEFINITION
+#/SCALAR
 
 # https://gqlgen.com/config/#inline-config-with-directives
 directive @goModel(

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -736,7 +736,7 @@ updatePlanMilestones(id: UUID!, changes: PlanMilestoneChanges!): PlanMilestones!
 updatePlanGeneralCharacteristics(id: UUID!, changes: PlanGeneralCharacteristicsChanges!): PlanGeneralCharacteristics!
 @hasRole(role: MINT_BASE_USER)
 
-updatePlanBeneficiares(id: UUID!, changes: PlanBeneficiariesChanges!): PlanBeneficiaries!
+updatePlanBeneficiaries(id: UUID!, changes: PlanBeneficiariesChanges!): PlanBeneficiaries!
 @hasRole(role: MINT_BASE_USER)
 
 updatePlanParticipantsAndProviders(id: UUID!, changes: PlanParticipantsAndProvidersChanges!): PlanParticipantsAndProviders!

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -17,24 +17,12 @@ import (
 )
 
 func (r *modelPlanResolver) CmsCenters(ctx context.Context, obj *models.ModelPlan) ([]models.CMSCenter, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var cmsCenters []models.CMSCenter
-
-	for _, item := range obj.CMSCenters {
-		cmsCenters = append(cmsCenters, models.CMSCenter(item))
-	}
-
+	cmsCenters := models.ConvertEnums[models.CMSCenter](obj.CMSCenters)
 	return cmsCenters, nil
 }
 
 func (r *modelPlanResolver) CmmiGroups(ctx context.Context, obj *models.ModelPlan) ([]model.CMMIGroup, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var cmmiGroups []model.CMMIGroup
-
-	for _, item := range obj.CMMIGroups {
-		cmmiGroups = append(cmmiGroups, model.CMMIGroup(item))
-	}
-
+	cmmiGroups := models.ConvertEnums[model.CMMIGroup](obj.CMMIGroups)
 	return cmmiGroups, nil
 }
 
@@ -159,7 +147,7 @@ func (r *mutationResolver) UpdatePlanGeneralCharacteristics(ctx context.Context,
 	return resolvers.UpdatePlanGeneralCharacteristics(logger, id, changes, principal, r.store)
 }
 
-func (r *mutationResolver) UpdatePlanBeneficiares(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanBeneficiaries, error) {
+func (r *mutationResolver) UpdatePlanBeneficiaries(ctx context.Context, id uuid.UUID, changes map[string]interface{}) (*models.PlanBeneficiaries, error) {
 	principal := appcontext.Principal(ctx).ID()
 	logger := appcontext.ZLogger(ctx)
 	return resolvers.PlanBeneficiariesUpdate(logger, id, changes, principal, r.store)
@@ -251,24 +239,12 @@ func (r *mutationResolver) DeleteDiscussionReply(ctx context.Context, id uuid.UU
 }
 
 func (r *planBeneficiariesResolver) Beneficiaries(ctx context.Context, obj *models.PlanBeneficiaries) ([]model.BeneficiariesType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var bTypes []model.BeneficiariesType
-
-	for _, item := range obj.Beneficiaries {
-		bTypes = append(bTypes, model.BeneficiariesType(item))
-	}
-
+	bTypes := models.ConvertEnums[model.BeneficiariesType](obj.Beneficiaries)
 	return bTypes, nil
 }
 
 func (r *planBeneficiariesResolver) BeneficiarySelectionMethod(ctx context.Context, obj *models.PlanBeneficiaries) ([]model.SelectionMethodType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var sTypes []model.SelectionMethodType
-
-	for _, item := range obj.BeneficiarySelectionMethod {
-		sTypes = append(sTypes, model.SelectionMethodType(item))
-	}
-
+	sTypes := models.ConvertEnums[model.SelectionMethodType](obj.BeneficiarySelectionMethod)
 	return sTypes, nil
 }
 
@@ -287,128 +263,67 @@ func (r *planGeneralCharacteristicsResolver) ResemblesExistingModelWhich(ctx con
 }
 
 func (r *planGeneralCharacteristicsResolver) AlternativePaymentModelTypes(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.AlternativePaymentModelType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var apmTypes []model.AlternativePaymentModelType
-
-	for _, item := range obj.AlternativePaymentModelTypes {
-		apmTypes = append(apmTypes, model.AlternativePaymentModelType(item))
-	}
-
+	apmTypes := models.ConvertEnums[model.AlternativePaymentModelType](obj.AlternativePaymentModelTypes)
 	return apmTypes, nil
 }
 
 func (r *planGeneralCharacteristicsResolver) KeyCharacteristics(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.KeyCharacteristic, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var keyCharacteristics []model.KeyCharacteristic
-
-	for _, item := range obj.KeyCharacteristics {
-		keyCharacteristics = append(keyCharacteristics, model.KeyCharacteristic(item))
-	}
-
+	keyCharacteristics := models.ConvertEnums[model.KeyCharacteristic](obj.KeyCharacteristics)
 	return keyCharacteristics, nil
 }
 
 func (r *planGeneralCharacteristicsResolver) GeographiesTargetedTypes(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.GeographyType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var geographyTypes []model.GeographyType
-
-	for _, item := range obj.GeographiesTargetedTypes {
-		geographyTypes = append(geographyTypes, model.GeographyType(item))
-	}
-
+	geographyTypes := models.ConvertEnums[model.GeographyType](obj.GeographiesTargetedTypes)
 	return geographyTypes, nil
 }
 
 func (r *planGeneralCharacteristicsResolver) GeographiesTargetedAppliedTo(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.GeographyApplication, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var geographyApplications []model.GeographyApplication
-
-	for _, item := range obj.GeographiesTargetedAppliedTo {
-		geographyApplications = append(geographyApplications, model.GeographyApplication(item))
-	}
-
+	geographyApplications := models.ConvertEnums[model.GeographyApplication](obj.GeographiesTargetedAppliedTo)
 	return geographyApplications, nil
 }
 
 func (r *planGeneralCharacteristicsResolver) AgreementTypes(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.AgreementType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var agreementTypes []model.AgreementType
-
-	for _, item := range obj.AgreementTypes {
-		agreementTypes = append(agreementTypes, model.AgreementType(item))
-	}
-
+	agreementTypes := models.ConvertEnums[model.AgreementType](obj.AgreementTypes)
 	return agreementTypes, nil
 }
 
 func (r *planGeneralCharacteristicsResolver) AuthorityAllowances(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.AuthorityAllowance, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var authorityAllowances []model.AuthorityAllowance
-
-	for _, item := range obj.AuthorityAllowances {
-		authorityAllowances = append(authorityAllowances, model.AuthorityAllowance(item))
-	}
-
+	authorityAllowances := models.ConvertEnums[model.AuthorityAllowance](obj.AuthorityAllowances)
 	return authorityAllowances, nil
 }
 
 func (r *planGeneralCharacteristicsResolver) WaiversRequiredTypes(ctx context.Context, obj *models.PlanGeneralCharacteristics) ([]model.WaiverType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var waiverTypes []model.WaiverType
-
-	for _, item := range obj.WaiversRequiredTypes {
-		waiverTypes = append(waiverTypes, model.WaiverType(item))
-	}
-
+	waiverTypes := models.ConvertEnums[model.WaiverType](obj.WaiversRequiredTypes)
 	return waiverTypes, nil
 }
 
 func (r *planParticipantsAndProvidersResolver) Participants(ctx context.Context, obj *models.PlanParticipantsAndProviders) ([]model.ParticipantsType, error) {
-	// TODO: We should probably have a better way to handle enum arrays
-	var participants []model.ParticipantsType
-	for _, item := range obj.Participants {
-		participants = append(participants, model.ParticipantsType(item))
-	}
+	participants := models.ConvertEnums[model.ParticipantsType](obj.Participants)
 	return participants, nil
 }
 
 func (r *planParticipantsAndProvidersResolver) SelectionMethod(ctx context.Context, obj *models.PlanParticipantsAndProviders) ([]model.ParticipantSelectionType, error) {
-	var selectionTypes []model.ParticipantSelectionType
-	for _, item := range obj.SelectionMethod {
-		selectionTypes = append(selectionTypes, model.ParticipantSelectionType(item))
-	}
+	selectionTypes := models.ConvertEnums[model.ParticipantSelectionType](obj.SelectionMethod)
 	return selectionTypes, nil
 }
 
 func (r *planParticipantsAndProvidersResolver) CommunicationMethod(ctx context.Context, obj *models.PlanParticipantsAndProviders) ([]model.ParticipantCommunicationType, error) {
-	var communicationTypes []model.ParticipantCommunicationType
-	for _, item := range obj.CommunicationMethod {
-		communicationTypes = append(communicationTypes, model.ParticipantCommunicationType(item))
-	}
+	communicationTypes := models.ConvertEnums[model.ParticipantCommunicationType](obj.CommunicationMethod)
 	return communicationTypes, nil
 }
 
 func (r *planParticipantsAndProvidersResolver) ParticipantsIds(ctx context.Context, obj *models.PlanParticipantsAndProviders) ([]model.ParticipantsIDType, error) {
-	var participantsIDTypes []model.ParticipantsIDType
-	for _, item := range obj.ParticipantsIds {
-		participantsIDTypes = append(participantsIDTypes, model.ParticipantsIDType(item))
-	}
+	participantsIDTypes := models.ConvertEnums[model.ParticipantsIDType](obj.ParticipantsIds)
 	return participantsIDTypes, nil
 }
 
 func (r *planParticipantsAndProvidersResolver) ProviderAddMethod(ctx context.Context, obj *models.PlanParticipantsAndProviders) ([]model.ProviderAddType, error) {
-	var providerAddTypes []model.ProviderAddType
-	for _, item := range obj.ProviderAddMethod {
-		providerAddTypes = append(providerAddTypes, model.ProviderAddType(item))
-	}
+	providerAddTypes := models.ConvertEnums[model.ProviderAddType](obj.ProviderAddMethod)
 	return providerAddTypes, nil
 }
 
 func (r *planParticipantsAndProvidersResolver) ProviderLeaveMethod(ctx context.Context, obj *models.PlanParticipantsAndProviders) ([]model.ProviderLeaveType, error) {
-	var providerLeaveTypes []model.ProviderLeaveType
-	for _, item := range obj.ProviderLeaveMethod {
-		providerLeaveTypes = append(providerLeaveTypes, model.ProviderLeaveType(item))
-	}
+	providerLeaveTypes := models.ConvertEnums[model.ProviderLeaveType](obj.ProviderLeaveMethod)
 	return providerLeaveTypes, nil
 }
 

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -17,12 +17,15 @@ import (
 )
 
 func (r *modelPlanResolver) CmsCenters(ctx context.Context, obj *models.ModelPlan) ([]models.CMSCenter, error) {
+	// return obj.CMSCenters, nil
 	return obj.CMSCenters, nil
+	// return models.EnumArray{}, nil
 }
 
-func (r *modelPlanResolver) CmmiGroups(ctx context.Context, obj *models.ModelPlan) ([]model.CMMIGroup, error) {
-	cmmiGroups := models.ConvertEnums[model.CMMIGroup](obj.CMMIGroups)
-	return cmmiGroups, nil
+func (r *modelPlanResolver) CmmiGroups(ctx context.Context, obj *models.ModelPlan) ([]models.CMMIGroup, error) {
+	return obj.CMMIGroups, nil
+	// cmmiGroups := models.ConvertEnums[model.CMMIGroup](obj.CMMIGroups)
+	// return cmmiGroups, nil
 }
 
 func (r *modelPlanResolver) Basics(ctx context.Context, obj *models.ModelPlan) (*models.PlanBasics, error) {

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -17,8 +17,7 @@ import (
 )
 
 func (r *modelPlanResolver) CmsCenters(ctx context.Context, obj *models.ModelPlan) ([]models.CMSCenter, error) {
-	cmsCenters := models.ConvertEnums[models.CMSCenter](obj.CMSCenters)
-	return cmsCenters, nil
+	return obj.CMSCenters, nil
 }
 
 func (r *modelPlanResolver) CmmiGroups(ctx context.Context, obj *models.ModelPlan) ([]model.CMMIGroup, error) {

--- a/pkg/models/enum_array.go
+++ b/pkg/models/enum_array.go
@@ -1,0 +1,221 @@
+package models
+
+import (
+	"bytes"
+	"database/sql/driver"
+
+	// "errors"
+	"fmt"
+	// "github.com/99designs/gqlgen/graphql"
+)
+
+// type ArrayEnum[T []string] []string
+
+// []string
+
+// MarshalEnumArray allows an EnumArray to be marshalled by graphql
+// func MarshalEnumArray(id uuid.UUID) graphql.Marshaler {
+// 	return graphql.MarshalString(id.String())
+// }
+
+// UnmarshalEnumArray allows an EnumArray to be unmarshalled by graphql
+// func UnmarshalEnumArray(v interface{}) (uuid.UUID, error) {
+// 	idAsString, ok := v.(string)
+// 	if !ok {
+// 		return uuid.Nil, errors.New("id should be a valid UUID")
+// 	}
+// 	return uuid.Parse(idAsString)
+// }
+
+//GenericScan provides functionality
+func GenericScan[ArrayType ~[]memberType, memberType ~string](src interface{}, array *ArrayType) error {
+	switch src := src.(type) {
+	case []byte:
+		// return array.scanBytes(src)
+		// return scanBytes[ArrayType, memberType](src, array)
+		return scanBytes(src, array)
+	case string:
+		// return array.scanBytes([]byte(src))
+		// return scanBytes[ArrayType, memberType]([]byte(src), array)
+		return scanBytes([]byte(src), array)
+	case nil:
+		*array = nil
+		return nil
+	}
+
+	return fmt.Errorf("pq: cannot convert %T to StringArray", src)
+	//todo call the scan functions here
+
+}
+
+// GenericValue implements the driver.Valuer interface.
+func GenericValue[ArrayType ~[]memberType, memberType ~string](a ArrayType) (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+
+	if n := len(a); n > 0 {
+		// There will be at least two curly brackets, 2*N bytes of quotes,
+		// and N-1 bytes of delimiters.
+		b := make([]byte, 1, 1+3*n)
+		b[0] = '{'
+
+		b = appendArrayQuotedBytes(b, []byte(a[0]))
+		for i := 1; i < n; i++ {
+			b = append(b, ',')
+			b = appendArrayQuotedBytes(b, []byte(a[i]))
+		}
+
+		return string(append(b, '}')), nil
+	}
+
+	return "{}", nil
+
+}
+
+func scanBytes[ArrayType ~[]memberType, memberType ~string](src []byte, a *ArrayType) error { //Should this be a bpoint
+	elems, err := scanLinearArray(src, []byte{','}, "StringArray")
+	if err != nil {
+		return err
+	}
+	if a != nil && len(elems) == 0 {
+		*a = (*a)[:0]
+	} else {
+		b := make(ArrayType, len(elems))
+		for i, v := range elems {
+			if b[i] = memberType(v); v == nil { //TODO, we can't use memberType here.... will this work?
+				return fmt.Errorf("pq: parsing array element index %d: cannot convert nil to string", i)
+			}
+		}
+		*a = b
+	}
+	return nil
+}
+func appendArrayQuotedBytes(b, v []byte) []byte {
+	b = append(b, '"')
+	for {
+		i := bytes.IndexAny(v, `"\`)
+		if i < 0 {
+			b = append(b, v...)
+			break
+		}
+		if i > 0 {
+			b = append(b, v[:i]...)
+		}
+		b = append(b, '\\', v[i])
+		v = v[i+1:]
+	}
+	return append(b, '"')
+}
+
+//Taken from pq.string Array
+// parseArray extracts the dimensions and elements of an array represented in
+// text format. Only representations emitted by the backend are supported.
+// Notably, whitespace around brackets and delimiters is significant, and NULL
+// is case-sensitive.
+//
+// See http://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
+func parseArray(src, del []byte) (dims []int, elems [][]byte, err error) {
+	var depth, i int
+
+	if len(src) < 1 || src[0] != '{' {
+		return nil, nil, fmt.Errorf("pq: unable to parse array; expected %q at offset %d", '{', 0)
+	}
+
+Open:
+	for i < len(src) {
+		switch src[i] {
+		case '{':
+			depth++
+			i++
+		case '}':
+			elems = make([][]byte, 0)
+			goto Close
+		default:
+			break Open
+		}
+	}
+	dims = make([]int, i)
+
+Element:
+	for i < len(src) {
+		switch src[i] {
+		case '{':
+			if depth == len(dims) {
+				break Element
+			}
+			depth++
+			dims[depth-1] = 0
+			i++
+		case '"':
+			var elem = []byte{}
+			var escape bool
+			for i++; i < len(src); i++ {
+				if escape {
+					elem = append(elem, src[i])
+					escape = false
+				} else {
+					switch src[i] {
+					default:
+						elem = append(elem, src[i])
+					case '\\':
+						escape = true
+					case '"':
+						elems = append(elems, elem)
+						i++
+						break Element
+					}
+				}
+			}
+		default:
+			for start := i; i < len(src); i++ {
+				if bytes.HasPrefix(src[i:], del) || src[i] == '}' {
+					elem := src[start:i]
+					if len(elem) == 0 {
+						return nil, nil, fmt.Errorf("pq: unable to parse array; unexpected %q at offset %d", src[i], i)
+					}
+					if bytes.Equal(elem, []byte("NULL")) {
+						elem = nil
+					}
+					elems = append(elems, elem)
+					break Element
+				}
+			}
+		}
+	}
+
+	for i < len(src) {
+		if bytes.HasPrefix(src[i:], del) && depth > 0 {
+			dims[depth-1]++
+			i += len(del)
+			goto Element
+		} else if src[i] == '}' && depth > 0 {
+			dims[depth-1]++
+			depth--
+			i++
+		} else {
+			return nil, nil, fmt.Errorf("pq: unable to parse array; unexpected %q at offset %d", src[i], i)
+		}
+	}
+
+Close:
+	for i < len(src) {
+		if src[i] == '}' && depth > 0 {
+			depth--
+			i++
+		} else {
+			return nil, nil, fmt.Errorf("pq: unable to parse array; unexpected %q at offset %d", src[i], i)
+		}
+	}
+	if depth > 0 {
+		err = fmt.Errorf("pq: unable to parse array; expected %q at offset %d", '}', i)
+	}
+	if err == nil {
+		for _, d := range dims {
+			if (len(elems) % d) != 0 {
+				err = fmt.Errorf("pq: multidimensional arrays must have elements with matching dimensions")
+			}
+		}
+	}
+	return
+}

--- a/pkg/models/enum_array.go
+++ b/pkg/models/enum_array.go
@@ -3,29 +3,38 @@ package models
 import (
 	"bytes"
 	"database/sql/driver"
+	"strings"
 
-	// "errors"
+	"errors"
 	"fmt"
-	// "github.com/99designs/gqlgen/graphql"
+
+	"github.com/99designs/gqlgen/graphql"
 )
+
+// EnumString is a string that can be converted to an Enum
+type EnumString string
+
+// EnumArray is an array of EnumString
+type EnumArray []EnumString
 
 // type ArrayEnum[T []string] []string
 
 // []string
 
 // MarshalEnumArray allows an EnumArray to be marshalled by graphql
-// func MarshalEnumArray(id uuid.UUID) graphql.Marshaler {
-// 	return graphql.MarshalString(id.String())
-// }
+func MarshalEnumArray(array EnumArray) graphql.Marshaler {
+	// return graphql.MarshalString(array)
+	return graphql.MarshalAny(array)
+}
 
 // UnmarshalEnumArray allows an EnumArray to be unmarshalled by graphql
-// func UnmarshalEnumArray(v interface{}) (uuid.UUID, error) {
-// 	idAsString, ok := v.(string)
-// 	if !ok {
-// 		return uuid.Nil, errors.New("id should be a valid UUID")
-// 	}
-// 	return uuid.Parse(idAsString)
-// }
+func UnmarshalEnumArray(v interface{}) (EnumArray, error) {
+	idAsString, ok := v.(EnumArray)
+	if !ok {
+		return EnumArray{}, errors.New("not a valid EnumArray")
+	}
+	return idAsString, nil
+}
 
 //GenericScan provides functionality
 func GenericScan[ArrayType ~[]memberType, memberType ~string](src interface{}, array *ArrayType) error {
@@ -43,7 +52,7 @@ func GenericScan[ArrayType ~[]memberType, memberType ~string](src interface{}, a
 		return nil
 	}
 
-	return fmt.Errorf("pq: cannot convert %T to StringArray", src)
+	return fmt.Errorf("generic scan: cannot convert %T to an EnumArray", src)
 	//todo call the scan functions here
 
 }
@@ -84,7 +93,7 @@ func scanBytes[ArrayType ~[]memberType, memberType ~string](src []byte, a *Array
 		b := make(ArrayType, len(elems))
 		for i, v := range elems {
 			if b[i] = memberType(v); v == nil { //TODO, we can't use memberType here.... will this work?
-				return fmt.Errorf("pq: parsing array element index %d: cannot convert nil to string", i)
+				return fmt.Errorf(" parsing array element index %d: cannot convert nil to string", i)
 			}
 		}
 		*a = b
@@ -119,7 +128,7 @@ func parseArray(src, del []byte) (dims []int, elems [][]byte, err error) {
 	var depth, i int
 
 	if len(src) < 1 || src[0] != '{' {
-		return nil, nil, fmt.Errorf("pq: unable to parse array; expected %q at offset %d", '{', 0)
+		return nil, nil, fmt.Errorf(" unable to parse array; expected %q at offset %d", '{', 0)
 	}
 
 Open:
@@ -172,7 +181,7 @@ Element:
 				if bytes.HasPrefix(src[i:], del) || src[i] == '}' {
 					elem := src[start:i]
 					if len(elem) == 0 {
-						return nil, nil, fmt.Errorf("pq: unable to parse array; unexpected %q at offset %d", src[i], i)
+						return nil, nil, fmt.Errorf(" unable to parse array; unexpected %q at offset %d", src[i], i)
 					}
 					if bytes.Equal(elem, []byte("NULL")) {
 						elem = nil
@@ -194,7 +203,7 @@ Element:
 			depth--
 			i++
 		} else {
-			return nil, nil, fmt.Errorf("pq: unable to parse array; unexpected %q at offset %d", src[i], i)
+			return nil, nil, fmt.Errorf(" unable to parse array; unexpected %q at offset %d", src[i], i)
 		}
 	}
 
@@ -204,18 +213,29 @@ Close:
 			depth--
 			i++
 		} else {
-			return nil, nil, fmt.Errorf("pq: unable to parse array; unexpected %q at offset %d", src[i], i)
+			return nil, nil, fmt.Errorf(" unable to parse array; unexpected %q at offset %d", src[i], i)
 		}
 	}
 	if depth > 0 {
-		err = fmt.Errorf("pq: unable to parse array; expected %q at offset %d", '}', i)
+		err = fmt.Errorf(" unable to parse array; expected %q at offset %d", '}', i)
 	}
 	if err == nil {
 		for _, d := range dims {
 			if (len(elems) % d) != 0 {
-				err = fmt.Errorf("pq: multidimensional arrays must have elements with matching dimensions")
+				err = fmt.Errorf(" multidimensional arrays must have elements with matching dimensions")
 			}
 		}
 	}
 	return
+}
+
+func scanLinearArray(src, del []byte, typ string) (elems [][]byte, err error) {
+	dims, elems, err := parseArray(src, del)
+	if err != nil {
+		return nil, err
+	}
+	if len(dims) > 1 {
+		return nil, fmt.Errorf(" cannot convert ARRAY%s to %s", strings.Replace(fmt.Sprint(dims), " ", "][", -1), typ)
+	}
+	return elems, err
 }

--- a/pkg/models/model_helpers.go
+++ b/pkg/models/model_helpers.go
@@ -1,5 +1,7 @@
 package models
 
+import "github.com/lib/pq"
+
 // StringPointer returns a pointer to a string input
 func StringPointer(st string) *string {
 	return &st
@@ -21,4 +23,13 @@ func ValueOrEmpty(st *string) string {
 		return *st
 	}
 	return ""
+}
+
+//ConvertEnums converts a pq.StringArray to specific, castable type
+func ConvertEnums[EnumType ~string](pqGroups pq.StringArray) []EnumType {
+	enumValues := []EnumType{}
+	for _, item := range pqGroups {
+		enumValues = append(enumValues, EnumType(item))
+	}
+	return enumValues
 }

--- a/pkg/models/model_plan.go
+++ b/pkg/models/model_plan.go
@@ -1,6 +1,10 @@
 package models
 
 import (
+	"bytes"
+	"database/sql/driver"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -12,7 +16,7 @@ type ModelPlan struct {
 	ID            uuid.UUID      `json:"id" db:"id"`
 	ModelName     string         `json:"modelName" db:"model_name"`
 	ModelCategory *ModelCategory `json:"modelCategory" db:"model_category"`
-	CMSCenters    pq.StringArray `json:"cmsCenters" db:"cms_centers"`
+	CMSCenters    CMSArray       `json:"cmsCenters" db:"cms_centers"`
 	CMSOther      *string        `json:"cmsOther" db:"cms_other"`
 	CMMIGroups    pq.StringArray `json:"cmmiGroups" db:"cmmi_groups"`
 	Archived      bool           `json:"archived" db:"archived"`
@@ -22,6 +26,9 @@ type ModelPlan struct {
 	ModifiedBy    *string        `json:"modifiedBy" db:"modified_by"`
 	ModifiedDts   *time.Time     `json:"modifiedDts" db:"modified_dts"`
 }
+
+//CMSArray is an array of CMSCenter
+type CMSArray []CMSCenter
 
 // GetModelTypeName returns a string name that represents the ModelPlan struct
 func (m ModelPlan) GetModelTypeName() string {
@@ -42,3 +49,227 @@ func (m ModelPlan) GetModifiedBy() *string {
 func (m ModelPlan) GetCreatedBy() string {
 	return m.CreatedBy
 }
+
+//Scan is used by sql.scan to read the values from the DB
+func (a *CMSArray) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		return a.scanBytes(src)
+	case string:
+		return a.scanBytes([]byte(src))
+	case nil:
+		*a = nil
+		return nil
+	}
+
+	return fmt.Errorf("pq: cannot convert %T to StringArray", src)
+}
+
+func (a *CMSArray) scanBytes(src []byte) error {
+	elems, err := scanLinearArray(src, []byte{','}, "StringArray")
+	if err != nil {
+		return err
+	}
+	if *a != nil && len(elems) == 0 {
+		*a = (*a)[:0]
+	} else {
+		b := make(CMSArray, len(elems))
+		for i, v := range elems {
+			if b[i] = CMSCenter(v); v == nil {
+				return fmt.Errorf("pq: parsing array element index %d: cannot convert nil to string", i)
+			}
+		}
+		*a = b
+	}
+	return nil
+}
+func scanLinearArray(src, del []byte, typ string) (elems [][]byte, err error) {
+	dims, elems, err := parseArray(src, del)
+	if err != nil {
+		return nil, err
+	}
+	if len(dims) > 1 {
+		return nil, fmt.Errorf("pq: cannot convert ARRAY%s to %s", strings.Replace(fmt.Sprint(dims), " ", "][", -1), typ)
+	}
+	return elems, err
+}
+
+//Taken from pq.string Array
+// parseArray extracts the dimensions and elements of an array represented in
+// text format. Only representations emitted by the backend are supported.
+// Notably, whitespace around brackets and delimiters is significant, and NULL
+// is case-sensitive.
+//
+// See http://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
+func parseArray(src, del []byte) (dims []int, elems [][]byte, err error) {
+	var depth, i int
+
+	if len(src) < 1 || src[0] != '{' {
+		return nil, nil, fmt.Errorf("pq: unable to parse array; expected %q at offset %d", '{', 0)
+	}
+
+Open:
+	for i < len(src) {
+		switch src[i] {
+		case '{':
+			depth++
+			i++
+		case '}':
+			elems = make([][]byte, 0)
+			goto Close
+		default:
+			break Open
+		}
+	}
+	dims = make([]int, i)
+
+Element:
+	for i < len(src) {
+		switch src[i] {
+		case '{':
+			if depth == len(dims) {
+				break Element
+			}
+			depth++
+			dims[depth-1] = 0
+			i++
+		case '"':
+			var elem = []byte{}
+			var escape bool
+			for i++; i < len(src); i++ {
+				if escape {
+					elem = append(elem, src[i])
+					escape = false
+				} else {
+					switch src[i] {
+					default:
+						elem = append(elem, src[i])
+					case '\\':
+						escape = true
+					case '"':
+						elems = append(elems, elem)
+						i++
+						break Element
+					}
+				}
+			}
+		default:
+			for start := i; i < len(src); i++ {
+				if bytes.HasPrefix(src[i:], del) || src[i] == '}' {
+					elem := src[start:i]
+					if len(elem) == 0 {
+						return nil, nil, fmt.Errorf("pq: unable to parse array; unexpected %q at offset %d", src[i], i)
+					}
+					if bytes.Equal(elem, []byte("NULL")) {
+						elem = nil
+					}
+					elems = append(elems, elem)
+					break Element
+				}
+			}
+		}
+	}
+
+	for i < len(src) {
+		if bytes.HasPrefix(src[i:], del) && depth > 0 {
+			dims[depth-1]++
+			i += len(del)
+			goto Element
+		} else if src[i] == '}' && depth > 0 {
+			dims[depth-1]++
+			depth--
+			i++
+		} else {
+			return nil, nil, fmt.Errorf("pq: unable to parse array; unexpected %q at offset %d", src[i], i)
+		}
+	}
+
+Close:
+	for i < len(src) {
+		if src[i] == '}' && depth > 0 {
+			depth--
+			i++
+		} else {
+			return nil, nil, fmt.Errorf("pq: unable to parse array; unexpected %q at offset %d", src[i], i)
+		}
+	}
+	if depth > 0 {
+		err = fmt.Errorf("pq: unable to parse array; expected %q at offset %d", '}', i)
+	}
+	if err == nil {
+		for _, d := range dims {
+			if (len(elems) % d) != 0 {
+				err = fmt.Errorf("pq: multidimensional arrays must have elements with matching dimensions")
+			}
+		}
+	}
+	return
+}
+
+// Value implements the driver.Valuer interface.
+func (a CMSArray) Value() (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+
+	if n := len(a); n > 0 {
+		// There will be at least two curly brackets, 2*N bytes of quotes,
+		// and N-1 bytes of delimiters.
+		b := make([]byte, 1, 1+3*n)
+		b[0] = '{'
+
+		b = appendArrayQuotedBytes(b, []byte(a[0]))
+		for i := 1; i < n; i++ {
+			b = append(b, ',')
+			b = appendArrayQuotedBytes(b, []byte(a[i]))
+		}
+
+		return string(append(b, '}')), nil
+	}
+
+	return "{}", nil
+}
+
+func appendArrayQuotedBytes(b, v []byte) []byte {
+	b = append(b, '"')
+	for {
+		i := bytes.IndexAny(v, `"\`)
+		if i < 0 {
+			b = append(b, v...)
+			break
+		}
+		if i > 0 {
+			b = append(b, v[:i]...)
+		}
+		b = append(b, '\\', v[i])
+		v = v[i+1:]
+	}
+	return append(b, '"')
+}
+
+// 	source, ok := src.([]byte)
+// 	if !ok {
+// 		return errors.New("type assertion .([]byte) failed")
+// 	}
+// 	pqArr := pq.StringArray{}
+// 	err := json.Unmarshal(source, &pqArr)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	new := ConvertEnums[CMSCenter](pqArr)
+// 	*array = new
+
+// 	return err
+// 	// var i interface{}
+// 	// err := json.Unmarshal(source, &i)
+// 	// if err != nil {
+// 	// 	return err
+// 	// }
+// 	// *array, ok = i.([]CMSCenter)
+// 	// if !ok {
+// 	// 	return errors.New("type assertion .(map[string]interface{}) failed")
+// 	// }
+// 	// return ok
+
+// }

--- a/pkg/models/model_plan.go
+++ b/pkg/models/model_plan.go
@@ -2,12 +2,9 @@ package models
 
 import (
 	"database/sql/driver"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/lib/pq"
 )
 
 // ModelPlan is the top-level object for an entire draft model plan
@@ -15,9 +12,9 @@ type ModelPlan struct {
 	ID            uuid.UUID      `json:"id" db:"id"`
 	ModelName     string         `json:"modelName" db:"model_name"`
 	ModelCategory *ModelCategory `json:"modelCategory" db:"model_category"`
-	CMSCenters    CMSArray       `json:"cmsCenters" db:"cms_centers"`
+	CMSCenters    CMSCenterG     `json:"cmsCenters" db:"cms_centers"`
 	CMSOther      *string        `json:"cmsOther" db:"cms_other"`
-	CMMIGroups    pq.StringArray `json:"cmmiGroups" db:"cmmi_groups"`
+	CMMIGroups    CMMIGroupG     `json:"cmmiGroups" db:"cmmi_groups"`
 	Archived      bool           `json:"archived" db:"archived"`
 	Status        ModelStatus    `json:"status" db:"status"`
 	CreatedBy     string         `json:"createdBy" db:"created_by"`
@@ -26,8 +23,11 @@ type ModelPlan struct {
 	ModifiedDts   *time.Time     `json:"modifiedDts" db:"modified_dts"`
 }
 
-//CMSArray is an array of CMSCenter
-type CMSArray []CMSCenter
+//CMSCenterG is an array of CMSCenter
+type CMSCenterG []CMSCenter
+
+//CMMIGroupG is an array of CMMIGroup
+type CMMIGroupG []CMMIGroup
 
 // GetModelTypeName returns a string name that represents the ModelPlan struct
 func (m ModelPlan) GetModelTypeName() string {
@@ -50,106 +50,21 @@ func (m ModelPlan) GetCreatedBy() string {
 }
 
 //Scan is used by sql.scan to read the values from the DB
-func (a *CMSArray) Scan(src interface{}) error {
+func (a *CMSCenterG) Scan(src interface{}) error {
 	return GenericScan(src, a)
-	// return GenericScan[CMSArray, CMSCenter](src, a)
-}
-
-// func (a *CMSArray) scanBytes(src []byte) error {
-// 	elems, err := scanLinearArray(src, []byte{','}, "StringArray")
-// 	if err != nil {
-// 		return err
-// 	}
-// 	if *a != nil && len(elems) == 0 {
-// 		*a = (*a)[:0]
-// 	} else {
-// 		b := make(CMSArray, len(elems))
-// 		for i, v := range elems {
-// 			if b[i] = CMSCenter(v); v == nil {
-// 				return fmt.Errorf("pq: parsing array element index %d: cannot convert nil to string", i)
-// 			}
-// 		}
-// 		*a = b
-// 	}
-// 	return nil
-// }
-func scanLinearArray(src, del []byte, typ string) (elems [][]byte, err error) {
-	dims, elems, err := parseArray(src, del)
-	if err != nil {
-		return nil, err
-	}
-	if len(dims) > 1 {
-		return nil, fmt.Errorf("pq: cannot convert ARRAY%s to %s", strings.Replace(fmt.Sprint(dims), " ", "][", -1), typ)
-	}
-	return elems, err
 }
 
 // Value implements the driver.Valuer interface.
-func (a CMSArray) Value() (driver.Value, error) {
+func (a CMSCenterG) Value() (driver.Value, error) {
 	return GenericValue(a)
-	// return GenericValue[CMSArray, CMSCenter](a)
-	// if a == nil {
-	// 	return nil, nil
-	// }
-
-	// if n := len(a); n > 0 {
-	// 	// There will be at least two curly brackets, 2*N bytes of quotes,
-	// 	// and N-1 bytes of delimiters.
-	// 	b := make([]byte, 1, 1+3*n)
-	// 	b[0] = '{'
-
-	// 	b = appendArrayQuotedBytes(b, []byte(a[0]))
-	// 	for i := 1; i < n; i++ {
-	// 		b = append(b, ',')
-	// 		b = appendArrayQuotedBytes(b, []byte(a[i]))
-	// 	}
-
-	// 	return string(append(b, '}')), nil
-	// }
-
-	// return "{}", nil
 }
 
-// func appendArrayQuotedBytes(b, v []byte) []byte {
-// 	b = append(b, '"')
-// 	for {
-// 		i := bytes.IndexAny(v, `"\`)
-// 		if i < 0 {
-// 			b = append(b, v...)
-// 			break
-// 		}
-// 		if i > 0 {
-// 			b = append(b, v[:i]...)
-// 		}
-// 		b = append(b, '\\', v[i])
-// 		v = v[i+1:]
-// 	}
-// 	return append(b, '"')
-// }
+//Scan is used by sql.scan to read the values from the DB
+func (a *CMMIGroupG) Scan(src interface{}) error {
+	return GenericScan(src, a)
+}
 
-// 	source, ok := src.([]byte)
-// 	if !ok {
-// 		return errors.New("type assertion .([]byte) failed")
-// 	}
-// 	pqArr := pq.StringArray{}
-// 	err := json.Unmarshal(source, &pqArr)
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	new := ConvertEnums[CMSCenter](pqArr)
-// 	*array = new
-
-// 	return err
-// 	// var i interface{}
-// 	// err := json.Unmarshal(source, &i)
-// 	// if err != nil {
-// 	// 	return err
-// 	// }
-// 	// *array, ok = i.([]CMSCenter)
-// 	// if !ok {
-// 	// 	return errors.New("type assertion .(map[string]interface{}) failed")
-// 	// }
-// 	// return ok
-
-// }
+// Value implements the driver.Valuer interface.
+func (a CMMIGroupG) Value() (driver.Value, error) {
+	return GenericValue(a)
+}

--- a/pkg/models/model_plan.go
+++ b/pkg/models/model_plan.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"bytes"
 	"database/sql/driver"
 	"fmt"
 	"strings"
@@ -52,37 +51,28 @@ func (m ModelPlan) GetCreatedBy() string {
 
 //Scan is used by sql.scan to read the values from the DB
 func (a *CMSArray) Scan(src interface{}) error {
-	switch src := src.(type) {
-	case []byte:
-		return a.scanBytes(src)
-	case string:
-		return a.scanBytes([]byte(src))
-	case nil:
-		*a = nil
-		return nil
-	}
-
-	return fmt.Errorf("pq: cannot convert %T to StringArray", src)
+	return GenericScan(src, a)
+	// return GenericScan[CMSArray, CMSCenter](src, a)
 }
 
-func (a *CMSArray) scanBytes(src []byte) error {
-	elems, err := scanLinearArray(src, []byte{','}, "StringArray")
-	if err != nil {
-		return err
-	}
-	if *a != nil && len(elems) == 0 {
-		*a = (*a)[:0]
-	} else {
-		b := make(CMSArray, len(elems))
-		for i, v := range elems {
-			if b[i] = CMSCenter(v); v == nil {
-				return fmt.Errorf("pq: parsing array element index %d: cannot convert nil to string", i)
-			}
-		}
-		*a = b
-	}
-	return nil
-}
+// func (a *CMSArray) scanBytes(src []byte) error {
+// 	elems, err := scanLinearArray(src, []byte{','}, "StringArray")
+// 	if err != nil {
+// 		return err
+// 	}
+// 	if *a != nil && len(elems) == 0 {
+// 		*a = (*a)[:0]
+// 	} else {
+// 		b := make(CMSArray, len(elems))
+// 		for i, v := range elems {
+// 			if b[i] = CMSCenter(v); v == nil {
+// 				return fmt.Errorf("pq: parsing array element index %d: cannot convert nil to string", i)
+// 			}
+// 		}
+// 		*a = b
+// 	}
+// 	return nil
+// }
 func scanLinearArray(src, del []byte, typ string) (elems [][]byte, err error) {
 	dims, elems, err := parseArray(src, del)
 	if err != nil {
@@ -94,158 +84,48 @@ func scanLinearArray(src, del []byte, typ string) (elems [][]byte, err error) {
 	return elems, err
 }
 
-//Taken from pq.string Array
-// parseArray extracts the dimensions and elements of an array represented in
-// text format. Only representations emitted by the backend are supported.
-// Notably, whitespace around brackets and delimiters is significant, and NULL
-// is case-sensitive.
-//
-// See http://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
-func parseArray(src, del []byte) (dims []int, elems [][]byte, err error) {
-	var depth, i int
-
-	if len(src) < 1 || src[0] != '{' {
-		return nil, nil, fmt.Errorf("pq: unable to parse array; expected %q at offset %d", '{', 0)
-	}
-
-Open:
-	for i < len(src) {
-		switch src[i] {
-		case '{':
-			depth++
-			i++
-		case '}':
-			elems = make([][]byte, 0)
-			goto Close
-		default:
-			break Open
-		}
-	}
-	dims = make([]int, i)
-
-Element:
-	for i < len(src) {
-		switch src[i] {
-		case '{':
-			if depth == len(dims) {
-				break Element
-			}
-			depth++
-			dims[depth-1] = 0
-			i++
-		case '"':
-			var elem = []byte{}
-			var escape bool
-			for i++; i < len(src); i++ {
-				if escape {
-					elem = append(elem, src[i])
-					escape = false
-				} else {
-					switch src[i] {
-					default:
-						elem = append(elem, src[i])
-					case '\\':
-						escape = true
-					case '"':
-						elems = append(elems, elem)
-						i++
-						break Element
-					}
-				}
-			}
-		default:
-			for start := i; i < len(src); i++ {
-				if bytes.HasPrefix(src[i:], del) || src[i] == '}' {
-					elem := src[start:i]
-					if len(elem) == 0 {
-						return nil, nil, fmt.Errorf("pq: unable to parse array; unexpected %q at offset %d", src[i], i)
-					}
-					if bytes.Equal(elem, []byte("NULL")) {
-						elem = nil
-					}
-					elems = append(elems, elem)
-					break Element
-				}
-			}
-		}
-	}
-
-	for i < len(src) {
-		if bytes.HasPrefix(src[i:], del) && depth > 0 {
-			dims[depth-1]++
-			i += len(del)
-			goto Element
-		} else if src[i] == '}' && depth > 0 {
-			dims[depth-1]++
-			depth--
-			i++
-		} else {
-			return nil, nil, fmt.Errorf("pq: unable to parse array; unexpected %q at offset %d", src[i], i)
-		}
-	}
-
-Close:
-	for i < len(src) {
-		if src[i] == '}' && depth > 0 {
-			depth--
-			i++
-		} else {
-			return nil, nil, fmt.Errorf("pq: unable to parse array; unexpected %q at offset %d", src[i], i)
-		}
-	}
-	if depth > 0 {
-		err = fmt.Errorf("pq: unable to parse array; expected %q at offset %d", '}', i)
-	}
-	if err == nil {
-		for _, d := range dims {
-			if (len(elems) % d) != 0 {
-				err = fmt.Errorf("pq: multidimensional arrays must have elements with matching dimensions")
-			}
-		}
-	}
-	return
-}
-
 // Value implements the driver.Valuer interface.
 func (a CMSArray) Value() (driver.Value, error) {
-	if a == nil {
-		return nil, nil
-	}
+	return GenericValue(a)
+	// return GenericValue[CMSArray, CMSCenter](a)
+	// if a == nil {
+	// 	return nil, nil
+	// }
 
-	if n := len(a); n > 0 {
-		// There will be at least two curly brackets, 2*N bytes of quotes,
-		// and N-1 bytes of delimiters.
-		b := make([]byte, 1, 1+3*n)
-		b[0] = '{'
+	// if n := len(a); n > 0 {
+	// 	// There will be at least two curly brackets, 2*N bytes of quotes,
+	// 	// and N-1 bytes of delimiters.
+	// 	b := make([]byte, 1, 1+3*n)
+	// 	b[0] = '{'
 
-		b = appendArrayQuotedBytes(b, []byte(a[0]))
-		for i := 1; i < n; i++ {
-			b = append(b, ',')
-			b = appendArrayQuotedBytes(b, []byte(a[i]))
-		}
+	// 	b = appendArrayQuotedBytes(b, []byte(a[0]))
+	// 	for i := 1; i < n; i++ {
+	// 		b = append(b, ',')
+	// 		b = appendArrayQuotedBytes(b, []byte(a[i]))
+	// 	}
 
-		return string(append(b, '}')), nil
-	}
+	// 	return string(append(b, '}')), nil
+	// }
 
-	return "{}", nil
+	// return "{}", nil
 }
 
-func appendArrayQuotedBytes(b, v []byte) []byte {
-	b = append(b, '"')
-	for {
-		i := bytes.IndexAny(v, `"\`)
-		if i < 0 {
-			b = append(b, v...)
-			break
-		}
-		if i > 0 {
-			b = append(b, v[:i]...)
-		}
-		b = append(b, '\\', v[i])
-		v = v[i+1:]
-	}
-	return append(b, '"')
-}
+// func appendArrayQuotedBytes(b, v []byte) []byte {
+// 	b = append(b, '"')
+// 	for {
+// 		i := bytes.IndexAny(v, `"\`)
+// 		if i < 0 {
+// 			b = append(b, v...)
+// 			break
+// 		}
+// 		if i > 0 {
+// 			b = append(b, v[:i]...)
+// 		}
+// 		b = append(b, '\\', v[i])
+// 		v = v[i+1:]
+// 	}
+// 	return append(b, '"')
+// }
 
 // 	source, ok := src.([]byte)
 // 	if !ok {

--- a/pkg/models/shared_enums.go
+++ b/pkg/models/shared_enums.go
@@ -78,16 +78,17 @@ const (
 )
 
 //  CMMIGroup representes the group at CMMI
-// type CMMIGroup EnumString
+type CMMIGroup string
 
-// const (
-// 	CMMIPatientCareModels                       CMMIGroup = "PATIENT_CARE_MODELS_GROUP"
-// 	CMMIPolicyAndPrograms                       CMMIGroup = "POLICY_AND_PROGRAMS_GROUP"
-// 	CMMIPreventiveAndPopulationHealthCareModels CMMIGroup = "PREVENTIVE_AND_POPULATION_HEALTH_CARE_MODELS_GROUP"
-// 	CMMISeamlessCareModels                      CMMIGroup = "SEAMLESS_CARE_MODELS_GROUP"
-// 	CMMIStateInnovations                        CMMIGroup = "STATE_INNOVATIONS_GROUP"
-// 	CMMITBD                                     CMMIGroup = "TBD"
-// )
+// These constants represent the different values of CMMIGroup
+const (
+	CMMIPatientCareModels                       CMMIGroup = "PATIENT_CARE_MODELS_GROUP"
+	CMMIPolicyAndPrograms                       CMMIGroup = "POLICY_AND_PROGRAMS_GROUP"
+	CMMIPreventiveAndPopulationHealthCareModels CMMIGroup = "PREVENTIVE_AND_POPULATION_HEALTH_CARE_MODELS_GROUP"
+	CMMISeamlessCareModels                      CMMIGroup = "SEAMLESS_CARE_MODELS_GROUP"
+	CMMIStateInnovations                        CMMIGroup = "STATE_INNOVATIONS_GROUP"
+	CMMITBD                                     CMMIGroup = "TBD"
+)
 
 // ModelType is an enum that represents the basic type of a model
 type ModelType string
@@ -143,11 +144,11 @@ const (
 	TsFinal           TaskSection = "FINAL"
 )
 
-// EnumString is a string that can be converted to an Enum
-type EnumString string
+// // EnumString is a string that can be converted to an Enum
+// type EnumString string
 
-// EnumArray is an array of EnumString
-type EnumArray []EnumString
+// // EnumArray is an array of EnumString
+// type EnumArray []EnumString
 
 // type EnumArray []interface{}
 

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -166,7 +166,15 @@ func (s *Server) routes(
 			return nil, errors.New("not authorized")
 		}
 		return next(ctx)
-	}}
+	},
+	// , //TODO, if we need a runtime Directive, we would insert the function here.
+	// EnumArray: func(ctx context.Context, obj interface{}, next graphql.Resolver, enumType string) (res interface{}, err error) {
+	// 	if enumType == "CMSGroupG" {
+	// 		return nil, errors.New("looks like you tried to use a CMSGroupG enum. Cool. The directive worked then")
+	// 	}
+	// 	return next(ctx)
+	// }
+	}
 	gqlConfig := generated.Config{Resolvers: resolver, Directives: gqlDirectives}
 	graphqlServer := handler.NewDefaultServer(generated.NewExecutableSchema(gqlConfig))
 	graphqlServer.Use(extension.FixedComplexityLimit(1000))


### PR DESCRIPTION
# EASI-1982

## Changes and Description

- Proof of concept generic scan and value functions
- Place holder enumArray GQL directive


This branch is a proof of concept for how we can have explicit types on GO models, and also share generic functionality to scan and value.  This functionality was largely adopted from PQ.stringArray scan and value functions,  but adapted to use GO 1.18 generics.
- [GenericScan](https://github.com/CMSgov/mint-app/pull/123/files#diff-5767031ae723e7829be9ca1e85a874abed8b30d61f21d920c15fecb41e119182R40-R58)
- [GenericValue](https://github.com/CMSgov/mint-app/pull/123/files#diff-5767031ae723e7829be9ca1e85a874abed8b30d61f21d920c15fecb41e119182R60-R83)

GO does not allow UnNamed types to have a receiver function defined for it. To use the scan and value functions, you need to make a type alias for the typed array, and then implement the Scan and Value interface.
- [CMSCentersG](https://github.com/CMSgov/mint-app/pull/123/files#diff-4d084287bb8a7e16fba216370cecb9a2089414aa0704977c440d4837b35be904R52-R60)
- [CMMIGroupG](https://github.com/CMSgov/mint-app/pull/123/files#diff-4d084287bb8a7e16fba216370cecb9a2089414aa0704977c440d4837b35be904R62-R70)

Unfortunately, you can not use a type alias in GraphQL, as such you still need to implement the resolver
 - [CMMIGroups](https://github.com/CMSgov/mint-app/pull/123/files#diff-67372475881f223c5f20bf1514c5035f46db7372effcf91c6fc249c55c4f24e1R25-R29)

It looks like the way to get around this would be to define a plugin for GQL to handle these cases explicitly. You can see some introductory work done towards this effort [here](https://github.com/CMSgov/mint-app/pull/123/files#diff-166a0d682d447944991a09dab5e4b52919964900e077025895db9931ec364c99R60-R67), but more would need to be done. These GQL config changes are unnecessary at the current implementation level, but I left them to show possibilities for development in that direction. Note specifically, the skip_runtime decorator specifies that this is used in the code generation phase.

I started a plugin for GQL gen to see if we could bypass the requirement. It seems like a fairly big lift, and we would also have to support the plug in the future. I think it would be reasonable to simply implement the resolvers for the unnamed types, to type aliases. You can run the GQL endpoint with the example plugin injected by running this command `go run cmd/gqlgen/main.go` The example is largely taken from gqlgens documentation [here](https://gqlgen.com/reference/plugins/#using-a-plugin).  The main example file is [here](https://github.com/99designs/gqlgen/tree/master/plugin/modelgen)
If we want to go forward with this, we would need to either A. Remove this plugin, B. fully implement it.

Another thing to note, when you have the type defined in the go object, you need to explicitly define the enum in GO, GQL, and GRAPHQL. You can't use the autogenerated types from the model package, because it is a circular dependency.  



<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
