### PR TITLE
Update milestones subheader to render modelName correctly

### DIFF
--- a/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
@@ -161,7 +161,7 @@ const Milestones = () => {
             data-testid="model-plan-name"
           >
             <Trans i18nKey="modelPlanTaskList:subheading">
-              indexZero {{ modelName }} indexTwo
+              indexZero {modelName} indexTwo
             </Trans>
           </p>
           <p className="margin-bottom-2 font-body-md line-height-sans-4">


### PR DESCRIPTION
# EASI-2068

## Changes and Description

This bug occurred because of an extra set of {}. One set of {} denotes that the text in between them is javascript, so if you put in another set of brackets in between that, it denotes an object literal. React rendered the model name incorrectly because of this. This syntax now passes the string directly 

Thanks @patrickseguraoddball for discovering this!

![image](https://user-images.githubusercontent.com/99294987/176004425-9282824e-64eb-4b83-8000-c6795b97f153.png)

<!-- Put a description here! -->

## How to test this change
`scripts/dev up && scripts/dev db:seed`
1. Navigate to http://localhost:3005/models/6e224030-09d5-46f7-ad04-4bb851b36eab/task-list/basics/milestones
2. Confirm that the subtitle renders the model name correctly

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
