### PR TITLE
fix: nullable enum arrays and other minor issues

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -607,6 +607,7 @@ type ComplexityRoot struct {
 		ExpectedCalculationComplexityLevelNote            func(childComplexity int) int
 		FundingSource                                     func(childComplexity int) int
 		FundingSourceNote                                 func(childComplexity int) int
+		FundingSourceOther                                func(childComplexity int) int
 		FundingSourceR                                    func(childComplexity int) int
 		FundingSourceRNote                                func(childComplexity int) int
 		FundingSourceROther                               func(childComplexity int) int
@@ -4452,6 +4453,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PlanPayments.FundingSourceNote(childComplexity), true
 
+	case "PlanPayments.fundingSourceOther":
+		if e.complexity.PlanPayments.FundingSourceOther == nil {
+			break
+		}
+
+		return e.complexity.PlanPayments.FundingSourceOther(childComplexity), true
+
 	case "PlanPayments.fundingSourceR":
 		if e.complexity.PlanPayments.FundingSourceR == nil {
 			break
@@ -5656,6 +5664,7 @@ type PlanPayments {
   # Page 1
   fundingSource:                      [FundingSource!]!
   fundingSourceTrustFund:             String
+  fundingSourceOther:                 String
   fundingSourceNote:                  String
   fundingSourceR:                     [FundingSource!]!
   fundingSourceRTrustFund:            String
@@ -5736,6 +5745,7 @@ input PlanPaymentsChanges @goModel(model: "map[string]interface{}") {
   # Page 1
   fundingSource:                      [FundingSource!]
   fundingSourceTrustFund:             String
+  fundingSourceOther:                 String
   fundingSourceNote:                  String
   fundingSourceR:                     [FundingSource!]
   fundingSourceRTrustFund:            String
@@ -10399,6 +10409,8 @@ func (ec *executionContext) fieldContext_ModelPlan_payments(ctx context.Context,
 				return ec.fieldContext_PlanPayments_fundingSource(ctx, field)
 			case "fundingSourceTrustFund":
 				return ec.fieldContext_PlanPayments_fundingSourceTrustFund(ctx, field)
+			case "fundingSourceOther":
+				return ec.fieldContext_PlanPayments_fundingSourceOther(ctx, field)
 			case "fundingSourceNote":
 				return ec.fieldContext_PlanPayments_fundingSourceNote(ctx, field)
 			case "fundingSourceR":
@@ -13617,6 +13629,8 @@ func (ec *executionContext) fieldContext_Mutation_updatePlanPayments(ctx context
 				return ec.fieldContext_PlanPayments_fundingSource(ctx, field)
 			case "fundingSourceTrustFund":
 				return ec.fieldContext_PlanPayments_fundingSourceTrustFund(ctx, field)
+			case "fundingSourceOther":
+				return ec.fieldContext_PlanPayments_fundingSourceOther(ctx, field)
 			case "fundingSourceNote":
 				return ec.fieldContext_PlanPayments_fundingSourceNote(ctx, field)
 			case "fundingSourceR":
@@ -30519,6 +30533,47 @@ func (ec *executionContext) fieldContext_PlanPayments_fundingSourceTrustFund(ctx
 	return fc, nil
 }
 
+func (ec *executionContext) _PlanPayments_fundingSourceOther(ctx context.Context, field graphql.CollectedField, obj *models.PlanPayments) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PlanPayments_fundingSourceOther(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FundingSourceOther, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PlanPayments_fundingSourceOther(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PlanPayments",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _PlanPayments_fundingSourceNote(ctx context.Context, field graphql.CollectedField, obj *models.PlanPayments) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_PlanPayments_fundingSourceNote(ctx, field)
 	if err != nil {
@@ -33761,6 +33816,8 @@ func (ec *executionContext) fieldContext_Query_planPayments(ctx context.Context,
 				return ec.fieldContext_PlanPayments_fundingSource(ctx, field)
 			case "fundingSourceTrustFund":
 				return ec.fieldContext_PlanPayments_fundingSourceTrustFund(ctx, field)
+			case "fundingSourceOther":
+				return ec.fieldContext_PlanPayments_fundingSourceOther(ctx, field)
 			case "fundingSourceNote":
 				return ec.fieldContext_PlanPayments_fundingSourceNote(ctx, field)
 			case "fundingSourceR":
@@ -40004,6 +40061,10 @@ func (ec *executionContext) _PlanPayments(ctx context.Context, sel ast.Selection
 		case "fundingSourceTrustFund":
 
 			out.Values[i] = ec._PlanPayments_fundingSourceTrustFund(ctx, field, obj)
+
+		case "fundingSourceOther":
+
+			out.Values[i] = ec._PlanPayments_fundingSourceOther(ctx, field, obj)
 
 		case "fundingSourceNote":
 

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -5654,28 +5654,28 @@ type PlanPayments {
   modelPlanID: UUID!
 
   # Page 1
-  fundingSource:                      [FundingSource!]
+  fundingSource:                      [FundingSource!]!
   fundingSourceTrustFund:             String
   fundingSourceNote:                  String
-  fundingSourceR:                     [FundingSource!]
+  fundingSourceR:                     [FundingSource!]!
   fundingSourceRTrustFund:            String
   fundingSourceROther:                String
   fundingSourceRNote:                 String
-  payRecipients:                      [PayRecipient!]
+  payRecipients:                      [PayRecipient!]!
   payRecipientsOtherSpecification:    String
   payRecipientsNote:                  String
-  payType:                            [PayType!]
+  payType:                            [PayType!]!
   payTypeNote:                        String
 
   # Page 2
-  payClaims:                                      [ClaimsBasedPayType!]
+  payClaims:                                      [ClaimsBasedPayType!]!
   payClaimsOther:                                 String
   shouldAnyProvidersExcludedFFSSystems:           Boolean
   shouldAnyProviderExcludedFFSSystemsNote:        String
   changesMedicarePhysicianFeeSchedule:            Boolean
   changesMedicarePhysicianFeeScheduleNote:        String
   affectsMedicareSecondaryPayerClaims:            Boolean
-  affectsMedicareSecondaryPayerClaimsHow: String
+  affectsMedicareSecondaryPayerClaimsHow:         String
   affectsMedicareSecondaryPayerClaimsNote:        String
   payModelDifferentiation:                        String
 
@@ -5695,11 +5695,11 @@ type PlanPayments {
   waiveBeneficiaryCostSharingNote:                 String
 
   # Page 5
-  nonClaimsPayments:                               [NonClaimsBasedPayType!]
+  nonClaimsPayments:                               [NonClaimsBasedPayType!]!
   nonClaimsPaymentOther:                           String
   paymentCalculationOwner:                         String
   numberPaymentsPerPayCycle:                       String
-  numberPaymentsPerPayCycleNote:                  String
+  numberPaymentsPerPayCycleNote:                   String
   sharedSystemsInvolvedAdditionalClaimPayment:     Boolean
   sharedSystemsInvolvedAdditionalClaimPaymentNote: String
   planningToUseInnovationPaymentContractor:        Boolean
@@ -5712,24 +5712,24 @@ type PlanPayments {
   canParticipantsSelectBetweenPaymentMechanisms:     Boolean
   canParticipantsSelectBetweenPaymentMechanismsHow:  String
   canParticipantsSelectBetweenPaymentMechanismsNote: String
-  anticipatedPaymentFrequency:                       [AnticipatedPaymentFrequencyType!]
+  anticipatedPaymentFrequency:                       [AnticipatedPaymentFrequencyType!]!
   anticipatedPaymentFrequencyOther:                  String
-  anticipatedPaymentFrequencyNote:                  String
+  anticipatedPaymentFrequencyNote:                   String
 
   # Page 7
   willRecoverPayments:                               Boolean
-  willRecoverPaymentsNote:                          String
+  willRecoverPaymentsNote:                           String
   anticipateReconcilingPaymentsRetrospectively:      Boolean
-  anticipateReconcilingPaymentsRetrospectivelyNote: String
+  anticipateReconcilingPaymentsRetrospectivelyNote:  String
   paymentStartDate:                                  Time
-  paymentStartDateNote:                             String
+  paymentStartDateNote:                              String
 
   # Meta
-  createdBy: String!
-  createdDts: Time!
-  modifiedBy: String
+  createdBy:   String!
+  createdDts:  Time!
+  modifiedBy:  String
   modifiedDts: Time
-  status: TaskStatus!
+  status:      TaskStatus!
 }
 
 input PlanPaymentsChanges @goModel(model: "map[string]interface{}") {
@@ -30455,11 +30455,14 @@ func (ec *executionContext) _PlanPayments_fundingSource(ctx context.Context, fie
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]models.FundingSource)
 	fc.Result = res
-	return ec.marshalOFundingSource2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐFundingSourceᚄ(ctx, field.Selections, res)
+	return ec.marshalNFundingSource2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐFundingSourceᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PlanPayments_fundingSource(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -30578,11 +30581,14 @@ func (ec *executionContext) _PlanPayments_fundingSourceR(ctx context.Context, fi
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]models.FundingSource)
 	fc.Result = res
-	return ec.marshalOFundingSource2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐFundingSourceᚄ(ctx, field.Selections, res)
+	return ec.marshalNFundingSource2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐFundingSourceᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PlanPayments_fundingSourceR(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -30742,11 +30748,14 @@ func (ec *executionContext) _PlanPayments_payRecipients(ctx context.Context, fie
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]models.PayRecipient)
 	fc.Result = res
-	return ec.marshalOPayRecipient2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPayRecipientᚄ(ctx, field.Selections, res)
+	return ec.marshalNPayRecipient2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPayRecipientᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PlanPayments_payRecipients(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -30865,11 +30874,14 @@ func (ec *executionContext) _PlanPayments_payType(ctx context.Context, field gra
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]models.PayType)
 	fc.Result = res
-	return ec.marshalOPayType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPayTypeᚄ(ctx, field.Selections, res)
+	return ec.marshalNPayType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPayTypeᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PlanPayments_payType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -30947,11 +30959,14 @@ func (ec *executionContext) _PlanPayments_payClaims(ctx context.Context, field g
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]models.ClaimsBasedPayType)
 	fc.Result = res
-	return ec.marshalOClaimsBasedPayType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐClaimsBasedPayTypeᚄ(ctx, field.Selections, res)
+	return ec.marshalNClaimsBasedPayType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐClaimsBasedPayTypeᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PlanPayments_payClaims(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -31808,11 +31823,14 @@ func (ec *executionContext) _PlanPayments_nonClaimsPayments(ctx context.Context,
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]model.NonClaimsBasedPayType)
 	fc.Result = res
-	return ec.marshalONonClaimsBasedPayType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐNonClaimsBasedPayTypeᚄ(ctx, field.Selections, res)
+	return ec.marshalNNonClaimsBasedPayType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐNonClaimsBasedPayTypeᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PlanPayments_nonClaimsPayments(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -32423,11 +32441,14 @@ func (ec *executionContext) _PlanPayments_anticipatedPaymentFrequency(ctx contex
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]models.AnticipatedPaymentFrequencyType)
 	fc.Result = res
-	return ec.marshalOAnticipatedPaymentFrequencyType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐAnticipatedPaymentFrequencyTypeᚄ(ctx, field.Selections, res)
+	return ec.marshalNAnticipatedPaymentFrequencyType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐAnticipatedPaymentFrequencyTypeᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PlanPayments_anticipatedPaymentFrequency(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -39970,6 +39991,9 @@ func (ec *executionContext) _PlanPayments(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._PlanPayments_fundingSource(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			}
 
@@ -39995,6 +40019,9 @@ func (ec *executionContext) _PlanPayments(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._PlanPayments_fundingSourceR(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			}
 
@@ -40024,6 +40051,9 @@ func (ec *executionContext) _PlanPayments(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._PlanPayments_payRecipients(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			}
 
@@ -40049,6 +40079,9 @@ func (ec *executionContext) _PlanPayments(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._PlanPayments_payType(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			}
 
@@ -40070,6 +40103,9 @@ func (ec *executionContext) _PlanPayments(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._PlanPayments_payClaims(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			}
 
@@ -40167,6 +40203,9 @@ func (ec *executionContext) _PlanPayments(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._PlanPayments_nonClaimsPayments(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			}
 
@@ -40253,6 +40292,9 @@ func (ec *executionContext) _PlanPayments(ctx context.Context, sel ast.Selection
 					}
 				}()
 				res = ec._PlanPayments_anticipatedPaymentFrequency(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			}
 
@@ -41206,6 +41248,67 @@ func (ec *executionContext) marshalNAnticipatedPaymentFrequencyType2githubᚗcom
 	return res
 }
 
+func (ec *executionContext) unmarshalNAnticipatedPaymentFrequencyType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐAnticipatedPaymentFrequencyTypeᚄ(ctx context.Context, v interface{}) ([]models.AnticipatedPaymentFrequencyType, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]models.AnticipatedPaymentFrequencyType, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNAnticipatedPaymentFrequencyType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐAnticipatedPaymentFrequencyType(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNAnticipatedPaymentFrequencyType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐAnticipatedPaymentFrequencyTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []models.AnticipatedPaymentFrequencyType) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNAnticipatedPaymentFrequencyType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐAnticipatedPaymentFrequencyType(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalNAuthorityAllowance2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐAuthorityAllowance(ctx context.Context, v interface{}) (model.AuthorityAllowance, error) {
 	var res model.AuthorityAllowance
 	err := res.UnmarshalGQL(v)
@@ -41667,6 +41770,67 @@ func (ec *executionContext) marshalNClaimsBasedPayType2githubᚗcomᚋcmsgovᚋm
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNClaimsBasedPayType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐClaimsBasedPayTypeᚄ(ctx context.Context, v interface{}) ([]models.ClaimsBasedPayType, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]models.ClaimsBasedPayType, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNClaimsBasedPayType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐClaimsBasedPayType(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNClaimsBasedPayType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐClaimsBasedPayTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []models.ClaimsBasedPayType) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNClaimsBasedPayType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐClaimsBasedPayType(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalNContractorSupportType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐContractorSupportType(ctx context.Context, v interface{}) (model.ContractorSupportType, error) {
@@ -42205,6 +42369,67 @@ func (ec *executionContext) marshalNFundingSource2githubᚗcomᚋcmsgovᚋmint�
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNFundingSource2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐFundingSourceᚄ(ctx context.Context, v interface{}) ([]models.FundingSource, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]models.FundingSource, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNFundingSource2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐFundingSource(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNFundingSource2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐFundingSourceᚄ(ctx context.Context, sel ast.SelectionSet, v []models.FundingSource) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNFundingSource2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐFundingSource(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalNGcCollectBidsType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐGcCollectBidsType(ctx context.Context, v interface{}) (model.GcCollectBidsType, error) {
@@ -42905,6 +43130,67 @@ func (ec *executionContext) unmarshalNNonClaimsBasedPayType2githubᚗcomᚋcmsgo
 
 func (ec *executionContext) marshalNNonClaimsBasedPayType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐNonClaimsBasedPayType(ctx context.Context, sel ast.SelectionSet, v model.NonClaimsBasedPayType) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) unmarshalNNonClaimsBasedPayType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐNonClaimsBasedPayTypeᚄ(ctx context.Context, v interface{}) ([]model.NonClaimsBasedPayType, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]model.NonClaimsBasedPayType, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNNonClaimsBasedPayType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐNonClaimsBasedPayType(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNNonClaimsBasedPayType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐNonClaimsBasedPayTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []model.NonClaimsBasedPayType) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNNonClaimsBasedPayType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐNonClaimsBasedPayType(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalNOelClaimsBasedMeasuresType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐOelClaimsBasedMeasuresType(ctx context.Context, v interface{}) (model.OelClaimsBasedMeasuresType, error) {
@@ -44485,6 +44771,67 @@ func (ec *executionContext) marshalNPayRecipient2githubᚗcomᚋcmsgovᚋmintᚑ
 	return res
 }
 
+func (ec *executionContext) unmarshalNPayRecipient2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPayRecipientᚄ(ctx context.Context, v interface{}) ([]models.PayRecipient, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]models.PayRecipient, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNPayRecipient2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPayRecipient(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNPayRecipient2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPayRecipientᚄ(ctx context.Context, sel ast.SelectionSet, v []models.PayRecipient) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNPayRecipient2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPayRecipient(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalNPayType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPayType(ctx context.Context, v interface{}) (models.PayType, error) {
 	tmp, err := graphql.UnmarshalString(v)
 	res := models.PayType(tmp)
@@ -44499,6 +44846,67 @@ func (ec *executionContext) marshalNPayType2githubᚗcomᚋcmsgovᚋmintᚑapp�
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNPayType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPayTypeᚄ(ctx context.Context, v interface{}) ([]models.PayType, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]models.PayType, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNPayType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPayType(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNPayType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPayTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []models.PayType) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNPayType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPayType(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalNPlanBasics2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐPlanBasics(ctx context.Context, sel ast.SelectionSet, v models.PlanBasics) graphql.Marshaler {

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -706,28 +706,28 @@ type PlanPayments {
   modelPlanID: UUID!
 
   # Page 1
-  fundingSource:                      [FundingSource!]
+  fundingSource:                      [FundingSource!]!
   fundingSourceTrustFund:             String
   fundingSourceNote:                  String
-  fundingSourceR:                     [FundingSource!]
+  fundingSourceR:                     [FundingSource!]!
   fundingSourceRTrustFund:            String
   fundingSourceROther:                String
   fundingSourceRNote:                 String
-  payRecipients:                      [PayRecipient!]
+  payRecipients:                      [PayRecipient!]!
   payRecipientsOtherSpecification:    String
   payRecipientsNote:                  String
-  payType:                            [PayType!]
+  payType:                            [PayType!]!
   payTypeNote:                        String
 
   # Page 2
-  payClaims:                                      [ClaimsBasedPayType!]
+  payClaims:                                      [ClaimsBasedPayType!]!
   payClaimsOther:                                 String
   shouldAnyProvidersExcludedFFSSystems:           Boolean
   shouldAnyProviderExcludedFFSSystemsNote:        String
   changesMedicarePhysicianFeeSchedule:            Boolean
   changesMedicarePhysicianFeeScheduleNote:        String
   affectsMedicareSecondaryPayerClaims:            Boolean
-  affectsMedicareSecondaryPayerClaimsHow: String
+  affectsMedicareSecondaryPayerClaimsHow:         String
   affectsMedicareSecondaryPayerClaimsNote:        String
   payModelDifferentiation:                        String
 
@@ -747,11 +747,11 @@ type PlanPayments {
   waiveBeneficiaryCostSharingNote:                 String
 
   # Page 5
-  nonClaimsPayments:                               [NonClaimsBasedPayType!]
+  nonClaimsPayments:                               [NonClaimsBasedPayType!]!
   nonClaimsPaymentOther:                           String
   paymentCalculationOwner:                         String
   numberPaymentsPerPayCycle:                       String
-  numberPaymentsPerPayCycleNote:                  String
+  numberPaymentsPerPayCycleNote:                   String
   sharedSystemsInvolvedAdditionalClaimPayment:     Boolean
   sharedSystemsInvolvedAdditionalClaimPaymentNote: String
   planningToUseInnovationPaymentContractor:        Boolean
@@ -764,24 +764,24 @@ type PlanPayments {
   canParticipantsSelectBetweenPaymentMechanisms:     Boolean
   canParticipantsSelectBetweenPaymentMechanismsHow:  String
   canParticipantsSelectBetweenPaymentMechanismsNote: String
-  anticipatedPaymentFrequency:                       [AnticipatedPaymentFrequencyType!]
+  anticipatedPaymentFrequency:                       [AnticipatedPaymentFrequencyType!]!
   anticipatedPaymentFrequencyOther:                  String
-  anticipatedPaymentFrequencyNote:                  String
+  anticipatedPaymentFrequencyNote:                   String
 
   # Page 7
   willRecoverPayments:                               Boolean
-  willRecoverPaymentsNote:                          String
+  willRecoverPaymentsNote:                           String
   anticipateReconcilingPaymentsRetrospectively:      Boolean
-  anticipateReconcilingPaymentsRetrospectivelyNote: String
+  anticipateReconcilingPaymentsRetrospectivelyNote:  String
   paymentStartDate:                                  Time
-  paymentStartDateNote:                             String
+  paymentStartDateNote:                              String
 
   # Meta
-  createdBy: String!
-  createdDts: Time!
-  modifiedBy: String
+  createdBy:   String!
+  createdDts:  Time!
+  modifiedBy:  String
   modifiedDts: Time
-  status: TaskStatus!
+  status:      TaskStatus!
 }
 
 input PlanPaymentsChanges @goModel(model: "map[string]interface{}") {

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -708,6 +708,7 @@ type PlanPayments {
   # Page 1
   fundingSource:                      [FundingSource!]!
   fundingSourceTrustFund:             String
+  fundingSourceOther:                 String
   fundingSourceNote:                  String
   fundingSourceR:                     [FundingSource!]!
   fundingSourceRTrustFund:            String
@@ -788,6 +789,7 @@ input PlanPaymentsChanges @goModel(model: "map[string]interface{}") {
   # Page 1
   fundingSource:                      [FundingSource!]
   fundingSourceTrustFund:             String
+  fundingSourceOther:                 String
   fundingSourceNote:                  String
   fundingSourceR:                     [FundingSource!]
   fundingSourceRTrustFund:            String

--- a/pkg/storage/SQL/plan_payments_create.sql
+++ b/pkg/storage/SQL/plan_payments_create.sql
@@ -61,9 +61,7 @@ INSERT INTO plan_payments (
     payment_start_date,
     payment_start_date_note,
     created_by,
-    created_dts,
     modified_by,
-    modified_dts,
     status
 )
 VALUES (
@@ -129,9 +127,7 @@ VALUES (
     :payment_start_date,
     :payment_start_date_note,
     :created_by,
-    :created_dts,
     :modified_by,
-    :modified_dts,
     :status
 )
 RETURNING


### PR DESCRIPTION
# EASI-000

## Changes and Description

- Fixes to make the enum arrays nullable per FE request

<!-- Put a description here! -->

## How to test this change

### Verify you can create a new model with plan payments
```
mutation createModelPlan ($modelName: String!) {
    createModelPlan (modelName: $modelName) {
        id
        modelName
        modelCategory
        cmsCenters
        cmsOther
        cmmiGroups
        archived
        createdBy
        createdDts
        modifiedBy
        modifiedDts
        basics {
            id
            modelPlanID
            modelType
            problem
            goal
            testInterventions
            note
            createdBy
            createdDts
            modifiedBy
            modifiedDts
            status
        }
        milestones {
            id
            modelPlanID
            completeICIP
            clearanceStarts
            clearanceEnds
            announced
            applicationsStart
            applicationsEnd
            performancePeriodStarts
            performancePeriodEnds
            wrapUpEnds
            highLevelNote
            phasedIn
            phasedInNote
            createdBy
            createdDts
            modifiedBy
            modifiedDts
            status
        }
        generalCharacteristics {
            id
            modelPlanID
            isNewModel
            existingModel
            resemblesExistingModel
            resemblesExistingModelWhich
            resemblesExistingModelHow
            resemblesExistingModelNote
            hasComponentsOrTracks
            hasComponentsOrTracksDiffer
            hasComponentsOrTracksNote
            alternativePaymentModel
            alternativePaymentModelTypes
            alternativePaymentModelNote
            keyCharacteristics
            keyCharacteristicsOther
            keyCharacteristicsNote
            collectPlanBids
            collectPlanBidsNote
            managePartCDEnrollment
            managePartCDEnrollmentNote
            planContactUpdated
            planContactUpdatedNote
            careCoordinationInvolved
            careCoordinationInvolvedDescription
            careCoordinationInvolvedNote
            additionalServicesInvolved
            additionalServicesInvolvedDescription
            additionalServicesInvolvedNote
            communityPartnersInvolved
            communityPartnersInvolvedDescription
            communityPartnersInvolvedNote
            geographiesTargeted
            geographiesTargetedTypes
            geographiesTargetedTypesOther
            geographiesTargetedAppliedTo
            geographiesTargetedAppliedToOther
            geographiesTargetedNote
            participationOptions
            participationOptionsNote
            agreementTypes
            agreementTypesOther
            multiplePatricipationAgreementsNeeded
            multiplePatricipationAgreementsNeededNote
            rulemakingRequired
            rulemakingRequiredDescription
            rulemakingRequiredNote
            authorityAllowances
            authorityAllowancesOther
            authorityAllowancesNote
            waiversRequired
            waiversRequiredTypes
            waiversRequiredNote
            createdBy
            createdDts
            modifiedBy
            modifiedDts
            status
        }
        participantsAndProviders {
            id
            modelPlanID
            participants
            medicareProviderType
            statesEngagement
            participantsOther
            participantsNote
            participantsCurrentlyInModels
            participantsCurrentlyInModelsNote
            modelApplicationLevel
            expectedNumberOfParticipants
            estimateConfidence
            confidenceNote
            recruitmentMethod
            recruitmentOther
            recruitmentNote
            selectionMethod
            selectionOther
            selectionNote
            communicationMethod
            communicationMethodOther
            communicationNote
            participantAssumeRisk
            riskType
            riskOther
            riskNote
            willRiskChange
            willRiskChangeNote
            coordinateWork
            coordinateWorkNote
            gainsharePayments
            gainsharePaymentsTrack
            gainsharePaymentsNote
            participantsIds
            participantsIdsOther
            participantsIDSNote
            providerAdditionFrequency
            providerAdditionFrequencyOther
            providerAdditionFrequencyNote
            providerAddMethod
            providerAddMethodOther
            providerAddMethodNote
            providerLeaveMethod
            providerLeaveMethodOther
            providerLeaveMethodNote
            providerOverlap
            providerOverlapHierarchy
            providerOverlapNote
            createdBy
            createdDts
            modifiedBy
            modifiedDts
            status
        }
        beneficiaries {
            id
            modelPlanID
            beneficiaries
            beneficiariesOther
            beneficiariesNote
            treatDualElligibleDifferent
            treatDualElligibleDifferentHow
            treatDualElligibleDifferentNote
            excludeCertainCharacteristics
            excludeCertainCharacteristicsCriteria
            excludeCertainCharacteristicsNote
            numberPeopleImpacted
            estimateConfidence
            confidenceNote
            beneficiarySelectionMethod
            beneficiarySelectionOther
            beneficiarySelectionNote
            beneficiarySelectionFrequency
            beneficiarySelectionFrequencyOther
            beneficiarySelectionFrequencyNote
            beneficiaryOverlap
            beneficiaryOverlapNote
            precedenceRules
            createdBy
            createdDts
            modifiedBy
            modifiedDts
            status
        }
        opsEvalAndLearning {
            id
            modelPlanID
            agencyOrStateHelp
            agencyOrStateHelpOther
            agencyOrStateHelpNote
            stakeholders
            stakeholdersOther
            stakeholdersNote
            helpdeskUse
            helpdeskUseNote
            contractorSupport
            contractorSupportOther
            contractorSupportHow
            contractorSupportNote
            iddocSupport
            iddocSupportNote
            technicalContactsIdentified
            technicalContactsIdentifiedDetail
            technicalContactsIdentifiedNote
            captureParticipantInfo
            captureParticipantInfoNote
            icdOwner
            draftIcdDueDate
            icdNote
            uatNeeds
            stcNeeds
            testingTimelines
            testingNote
            dataMonitoringFileTypes
            dataMonitoringFileOther
            dataResponseType
            dataResponseFileFrequency
            dataFullTimeOrIncremental
            eftSetUp
            unsolicitedAdjustmentsIncluded
            dataFlowDiagramsNeeded
            produceBenefitEnhancementFiles
            fileNamingConventions
            dataMonitoringNote
            benchmarkForPerformance
            benchmarkForPerformanceNote
            computePerformanceScores
            computePerformanceScoresNote
            riskAdjustPerformance
            riskAdjustFeedback
            riskAdjustPayments
            riskAdjustOther
            riskAdjustNote
            appealPerformance
            appealFeedback
            appealPayments
            appealOther
            appealNote
            evaluationApproaches
            evaluationApproachOther
            evalutaionApproachNote
            ccmInvolvment
            ccmInvolvmentOther
            ccmInvolvmentNote
            dataNeededForMonitoring
            dataNeededForMonitoringOther
            dataNeededForMonitoringNote
            dataToSendParticicipants
            dataToSendParticicipantsOther
            dataToSendParticicipantsNote
            shareCclfData
            shareCclfDataNote
            sendFilesBetweenCcw
            sendFilesBetweenCcwNote
            appToSendFilesToKnown
            appToSendFilesToWhich
            appToSendFilesToNote
            useCcwForFileDistribiutionToParticipants
            useCcwForFileDistribiutionToParticipantsNote
            developNewQualityMeasures
            developNewQualityMeasuresNote
            qualityPerformanceImpactsPayment
            qualityPerformanceImpactsPaymentNote
            dataSharingStarts
            dataSharingStartsOther
            dataSharingFrequency
            dataSharingFrequencyOther
            dataSharingStartsNote
            dataCollectionStarts
            dataCollectionStartsOther
            dataCollectionFrequency
            dataCollectionFrequencyOther
            dataCollectionFrequencyNote
            qualityReportingStarts
            qualityReportingStartsOther
            qualityReportingStartsNote
            modelLearningSystems
            modelLearningSystemsOther
            modelLearningSystemsNote
            anticipatedChallenges
            createdBy
            createdDts
            modifiedBy
            modifiedDts
            status
        }
        collaborators {
            id
            modelPlanID
            euaUserID
            fullName
            teamRole
            createdBy
            createdDts
            modifiedBy
            modifiedDts
        }
        documents {
            id
            modelPlanID
            fileType
            bucket
            fileKey
            virusScanned
            virusClean
            fileName
            fileSize
            documentType
            otherType
            optionalNotes
            deletedAt
            createdBy
            createdDts
            modifiedBy
            modifiedDts
        }
        discussions {
            id
            modelPlanID
            content
            status
            replies {
                id
                discussionID
                content
                resolution
                createdBy
                createdDts
                modifiedBy
                modifiedDts
            }
            createdBy
            createdDts
            modifiedBy
            modifiedDts
        }
        payments {
            id
            modelPlanID
            fundingSource
            fundingSourceTrustFund
            fundingSourceNote
            fundingSourceR
            fundingSourceRTrustFund
            fundingSourceROther
            fundingSourceRNote
            payRecipients
            payRecipientsOtherSpecification
            payRecipientsNote
            payType
            payTypeNote
            payClaims
            payClaimsOther
            shouldAnyProvidersExcludedFFSSystems
            shouldAnyProviderExcludedFFSSystemsNote
            changesMedicarePhysicianFeeSchedule
            changesMedicarePhysicianFeeScheduleNote
            affectsMedicareSecondaryPayerClaims
            affectsMedicareSecondaryPayerClaimsHow
            affectsMedicareSecondaryPayerClaimsNote
            payModelDifferentiation
            creatingDependenciesBetweenServices
            creatingDependenciesBetweenServicesNote
            needsClaimsDataCollection
            needsClaimsDataCollectionNote
            providingThirdPartyFile
            isContractorAwareTestDataRequirements
            beneficiaryCostSharingLevelAndHandling
            waiveBeneficiaryCostSharingForAnyServices
            waiveBeneficiaryCostSharingServiceSpecification
            waiverOnlyAppliesPartOfPayment
            waiveBeneficiaryCostSharingNote
            nonClaimsPayments
            nonClaimsPaymentOther
            paymentCalculationOwner
            numberPaymentsPerPayCycle
            numberPaymentsPerPayCycleNote
            sharedSystemsInvolvedAdditionalClaimPayment
            sharedSystemsInvolvedAdditionalClaimPaymentNote
            planningToUseInnovationPaymentContractor
            planningToUseInnovationPaymentContractorNote
            fundingStructure
            expectedCalculationComplexityLevel
            expectedCalculationComplexityLevelNote
            canParticipantsSelectBetweenPaymentMechanisms
            canParticipantsSelectBetweenPaymentMechanismsHow
            canParticipantsSelectBetweenPaymentMechanismsNote
            anticipatedPaymentFrequency
            anticipatedPaymentFrequencyOther
            anticipatedPaymentFrequencyNote
            willRecoverPayments
            willRecoverPaymentsNote
            anticipateReconcilingPaymentsRetrospectively
            anticipateReconcilingPaymentsRetrospectivelyNote
            paymentStartDate
            paymentStartDateNote
            createdBy
            createdDts
            modifiedBy
            modifiedDts
            status
        }
        itTools {
            id
            modelPlanID
            gcPartCD
            gcPartCDOther
            gcPartCDNote
            gcCollectBids
            gcCollectBidsOther
            gcCollectBidsNote
            gcUpdateContract
            gcUpdateContractOther
            gcUpdateContractNote
            ppToAdvertise
            ppToAdvertiseOther
            ppToAdvertiseNote
            ppCollectScoreReview
            ppCollectScoreReviewOther
            ppCollectScoreReviewNote
            ppAppSupportContractor
            ppAppSupportContractorOther
            ppAppSupportContractorNote
            ppCommunicateWithParticipant
            ppCommunicateWithParticipantOther
            ppCommunicateWithParticipantNote
            ppManageProviderOverlap
            ppManageProviderOverlapOther
            ppManageProviderOverlapNote
            bManageBeneficiaryOverlap
            bManageBeneficiaryOverlapOther
            bManageBeneficiaryOverlapNote
            oelHelpdeskSupport
            oelHelpdeskSupportOther
            oelHelpdeskSupportNote
            oelManageAco
            oelManageAcoOther
            oelManageAcoNote
            oelPerformanceBenchmark
            oelPerformanceBenchmarkOther
            oelPerformanceBenchmarkNote
            oelProcessAppeals
            oelProcessAppealsOther
            oelProcessAppealsNote
            oelEvaluationContractor
            oelEvaluationContractorOther
            oelEvaluationContractorNote
            oelCollectData
            oelCollectDataOther
            oelCollectDataNote
            oelObtainData
            oelObtainDataOther
            oelObtainDataNote
            oelClaimsBasedMeasures
            oelClaimsBasedMeasuresOther
            oelClaimsBasedMeasuresNote
            oelQualityScores
            oelQualityScoresOther
            oelQualityScoresNote
            oelSendReports
            oelSendReportsOther
            oelSendReportsNote
            oelLearningContractor
            oelLearningContractorOther
            oelLearningContractorNote
            oelParticipantCollaboration
            oelParticipantCollaborationOther
            oelParticipantCollaborationNote
            oelEducateBeneficiaries
            oelEducateBeneficiariesOther
            oelEducateBeneficiariesNote
            pMakeClaimsPayments
            pMakeClaimsPaymentsOther
            pMakeClaimsPaymentsNote
            pInformFfs
            pInformFfsOther
            pInformFfsNote
            pNonClaimsBasedPayments
            pNonClaimsBasedPaymentsOther
            pNonClaimsBasedPaymentsNote
            pSharedSavingsPlan
            pSharedSavingsPlanOther
            pSharedSavingsPlanNote
            pRecoverPayments
            pRecoverPaymentsOther
            pRecoverPaymentsNote
            createdBy
            createdDts
            modifiedBy
            modifiedDts
            status
        }
        status
    }
}
```
```
{
  "modelName": "demo"
}
```

Verify that the fundingSourceOther field exists
![image](https://user-images.githubusercontent.com/100007843/178825768-bc6df463-f7c3-4ff6-bc2d-5cf8a7644312.png)

Verify that the createdDts field exists and is a valid DateTime
![image](https://user-images.githubusercontent.com/100007843/178826019-cc0d016b-8d12-42a6-90ee-ee0068429f18.png)


## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
