### PR TITLE
[NOREF] Introduce GitHub teams for specific files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,20 +3,20 @@
 * @CMSGov/mint
 
 # Frontend Changes
-# /yarn.lock @CMSGov/mint-frontend
-# /package.json @CMSGov/mint-frontend
-# /src/ @CMSGov/mint-frontend
-# /cypress/ @CMSGov/mint-frontend
-# /public/ @CMSGov/mint-frontend
-# /.storybook/ @CMSGov/mint-frontend
-# *.js @CMSGov/mint-frontend
-# *.ts @CMSGov/mint-frontend
-# *.tsx @CMSGov/mint-frontend
+/yarn.lock @CMSGov/mint-frontend
+/package.json @CMSGov/mint-frontend
+/src/ @CMSGov/mint-frontend
+/cypress/ @CMSGov/mint-frontend
+/public/ @CMSGov/mint-frontend
+/.storybook/ @CMSGov/mint-frontend
+*.js @CMSGov/mint-frontend
+*.ts @CMSGov/mint-frontend
+*.tsx @CMSGov/mint-frontend
 
 # Backend Changes
-# /go.mod @CMSGov/mint-backend
-# /go.sum @CMSGov/mint-backend
-# /pkg/ @CMSGov/mint-backend
-# /cmd/ @CMSGov/mint-backend
-# /migrations/ @CMSGov/mint-backend
-# *.go @CMSGov/mint-backend
+/go.mod @CMSGov/mint-backend
+/go.sum @CMSGov/mint-backend
+/pkg/ @CMSGov/mint-backend
+/cmd/ @CMSGov/mint-backend
+/migrations/ @CMSGov/mint-backend
+*.go @CMSGov/mint-backend


### PR DESCRIPTION
# No ticket

## Changes and Description

- Introduces GitHub CODEOWNERS that use newly created teams for mint frontend and mint backend specifically.

The goal of this was to make it so that the right people are being tagged for reviews by default, rather than randomly assigning from the entire team.

## How to test this change

You can technically test this change by making a PR that targets this branch as the base and seeing if the right people are requested (or you can just trust that GitHub says it's valid and go with it)
<img width="413" alt="image" src="https://user-images.githubusercontent.com/15203744/180300399-d963a074-6343-4101-b3ae-d4504e409ddd.png">


## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
