### PR TITLE
Easi 2069/note field updates

### DIFF
--- a/src/components/AddNote/index.test.tsx
+++ b/src/components/AddNote/index.test.tsx
@@ -19,9 +19,28 @@ describe('The AddNote component', () => {
       screen.getByRole('button', { name: /Add an additional note/i }).click();
 
       await waitFor(() => {
-        userEvent.type(getByTestId('test-note'), 'Test Note');
+        setTimeout(() => {
+          userEvent.type(getByTestId('test-note'), 'Test Note');
 
-        expect(getByTestId('test-note')).toHaveValue('Test Note');
+          expect(getByTestId('test-note')).toHaveValue('Test Note');
+        }, 0);
+      });
+    });
+  });
+
+  it('checks if init value expands note on load', async () => {
+    await act(async () => {
+      const { getByTestId } = render(
+        <Formik initialValues={{ testNote: 'test expand' }} onSubmit={onSubmit}>
+          <AddNote id="test-note" field="testNote" />
+        </Formik>
+      );
+
+      const button = screen.queryByTestId('add-note-toggle');
+      expect(button).not.toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(getByTestId('test-note')).toHaveValue('test expand');
       });
     });
   });

--- a/src/components/AddNote/index.test.tsx
+++ b/src/components/AddNote/index.test.tsx
@@ -16,8 +16,9 @@ describe('The AddNote component', () => {
         </Formik>
       );
 
+      screen.getByRole('button', { name: /Add an additional note/i }).click();
+
       await waitFor(() => {
-        screen.getByRole('button', { name: /Add an additional note/i }).click();
         userEvent.type(getByTestId('test-note'), 'Test Note');
         expect(getByTestId('test-note')).toHaveValue('Test Note');
       });

--- a/src/components/AddNote/index.test.tsx
+++ b/src/components/AddNote/index.test.tsx
@@ -16,14 +16,10 @@ describe('The AddNote component', () => {
         </Formik>
       );
 
-      screen.getByRole('button', { name: /Add an additional note/i }).click();
-
       await waitFor(() => {
-        setTimeout(() => {
-          userEvent.type(getByTestId('test-note'), 'Test Note');
-
-          expect(getByTestId('test-note')).toHaveValue('Test Note');
-        }, 0);
+        screen.getByRole('button', { name: /Add an additional note/i }).click();
+        userEvent.type(getByTestId('test-note'), 'Test Note');
+        expect(getByTestId('test-note')).toHaveValue('Test Note');
       });
     });
   });
@@ -31,8 +27,11 @@ describe('The AddNote component', () => {
   it('checks if init value expands note on load', async () => {
     await act(async () => {
       const { getByTestId } = render(
-        <Formik initialValues={{ testNote: 'test expand' }} onSubmit={onSubmit}>
-          <AddNote id="test-note" field="testNote" />
+        <Formik
+          initialValues={{ testNote2: 'test expand' }}
+          onSubmit={onSubmit}
+        >
+          <AddNote id="test-note-2" field="testNote2" />
         </Formik>
       );
 
@@ -40,7 +39,7 @@ describe('The AddNote component', () => {
       expect(button).not.toBeInTheDocument();
 
       await waitFor(() => {
-        expect(getByTestId('test-note')).toHaveValue('test expand');
+        expect(getByTestId('test-note-2')).toHaveValue('test expand');
       });
     });
   });

--- a/src/components/AddNote/index.tsx
+++ b/src/components/AddNote/index.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, IconAdd } from '@trussworks/react-uswds';
 import classNames from 'classnames';
-import { Field } from 'formik';
+import { Field, useField } from 'formik';
 
 import FieldGroup from 'components/shared/FieldGroup';
 import TextAreaField from 'components/shared/TextAreaField';
@@ -13,21 +13,28 @@ type AddNoteType = {
   className?: string;
 };
 
-const AddNote = ({ field, id, className }: AddNoteType) => {
+const AddNote = ({ field: fieldName, id, className }: AddNoteType) => {
   const { t } = useTranslation('draftModelPlan');
-  const [note, setNote] = useState(false);
+  const [field] = useField(fieldName);
+  const [note, setNote] = useState<boolean>(!!field.value?.trim());
+
+  useEffect(() => {
+    if (!note) setNote(!!field.value?.trim());
+  }, [field.value, note]);
 
   return (
     <div className={classNames('margin-top-4 margin-bottom-8', className)}>
-      <Button
-        type="button"
-        data-testid="add-note-toggle"
-        className="usa-button usa-button--unstyled"
-        onClick={() => setNote(true)}
-      >
-        <IconAdd className="margin-right-1" aria-hidden />
-        {t('additionalNote')}
-      </Button>
+      {!note && (
+        <Button
+          type="button"
+          data-testid="add-note-toggle"
+          className="usa-button usa-button--unstyled"
+          onClick={() => setNote(true)}
+        >
+          <IconAdd className="margin-right-1" aria-hidden />
+          {t('additionalNote')}
+        </Button>
+      )}
 
       {note && (
         <FieldGroup>
@@ -36,7 +43,7 @@ const AddNote = ({ field, id, className }: AddNoteType) => {
             className="height-15"
             id={id}
             data-testid={id}
-            name={field}
+            name={fieldName}
             label={t('Notes')}
           />
         </FieldGroup>

--- a/src/components/AddNote/index.tsx
+++ b/src/components/AddNote/index.tsx
@@ -4,6 +4,7 @@ import { Button, IconAdd } from '@trussworks/react-uswds';
 import classNames from 'classnames';
 import { Field, useField } from 'formik';
 
+import { ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldGroup from 'components/shared/FieldGroup';
 import TextAreaField from 'components/shared/TextAreaField';
 
@@ -15,28 +16,44 @@ type AddNoteType = {
 
 const AddNote = ({ field: fieldName, id, className }: AddNoteType) => {
   const { t } = useTranslation('draftModelPlan');
-  const [field] = useField(fieldName);
+
+  // Formik hook used to fetch the field value based on the field name
+  // meta isn't technically required for the component to work but ts throws errors if not instantiated alongside 'helpers'
+  const [field, meta, helpers] = useField(fieldName);
+
+  // State used to manage if an existing value is present on load
   const [note, setNote] = useState<boolean>(!!field.value?.trim());
 
+  // State used to manage manual toggle of note
+  const [open, setOpen] = useState<boolean>(false);
+
+  // State used to manage if touched - ex: Toggle note open, types, then erases all text
+  // Should not collapse the textarea if text is erased
+  const [touched, setTouched] = useState<boolean>(false);
+
+  // Sets the note value from GQL once fetched
+  // Empty spaces characters should act as empty string
   useEffect(() => {
-    if (!note) setNote(!!field.value?.trim());
+    setNote(!!field.value?.trim());
   }, [field.value, note]);
+
+  const { setValue } = helpers;
 
   return (
     <div className={classNames('margin-top-4 margin-bottom-8', className)}>
-      {!note && (
+      {!note && !open && !touched && (
         <Button
           type="button"
           data-testid="add-note-toggle"
           className="usa-button usa-button--unstyled"
-          onClick={() => setNote(true)}
+          onClick={() => setOpen(true)}
         >
           <IconAdd className="margin-right-1" aria-hidden />
           {t('additionalNote')}
         </Button>
       )}
 
-      {note && (
+      {(note || open || touched) && (
         <FieldGroup>
           <Field
             as={TextAreaField}
@@ -45,8 +62,15 @@ const AddNote = ({ field: fieldName, id, className }: AddNoteType) => {
             data-testid={id}
             name={fieldName}
             label={t('Notes')}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setValue(e.target.value);
+              setTouched(true);
+            }}
           />
         </FieldGroup>
+      )}
+      {meta.error && (
+        <ErrorAlertMessage errorKey={meta.error} message={meta.error} />
       )}
     </div>
   );

--- a/src/views/ModelPlan/Collaborators/AddCollaborator/index.tsx
+++ b/src/views/ModelPlan/Collaborators/AddCollaborator/index.tsx
@@ -209,12 +209,18 @@ const Collaborators = () => {
                             <ComboboxPopover>
                               {foundUsers.formattedUsers.length > 0 ? (
                                 <ComboboxList>
-                                  {foundUsers.formattedUsers.map(user => {
-                                    const str = `${user.label}, ${user.value}`;
-                                    return (
-                                      <ComboboxOption key={str} value={str} />
-                                    );
-                                  })}
+                                  {foundUsers.formattedUsers.map(
+                                    (user, index) => {
+                                      const str = `${user.label}, ${user.value}`;
+                                      return (
+                                        <ComboboxOption
+                                          key={str}
+                                          index={index}
+                                          value={str}
+                                        />
+                                      );
+                                    }
+                                  )}
                                 </ComboboxList>
                               ) : (
                                 <span className="display-block margin-1">

--- a/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
@@ -9,20 +9,19 @@ import {
   Button,
   DatePicker,
   Fieldset,
-  IconAdd,
   IconArrowBack,
   Label,
   Radio
 } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
 
+import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
-import TextAreaField from 'components/shared/TextAreaField';
 import GetMilestones from 'queries/Basics/GetMilestones';
 import {
   GetMilestones as GetMilestonesType,
@@ -47,8 +46,6 @@ const Milestones = () => {
 
   const history = useHistory();
   const formikRef = useRef<FormikProps<MilestonesFormType>>(null);
-  const [hasHighLevelNote, setHasHighLevelNote] = useState(false);
-  const [hasAdditionalNote, setHasAdditionalNote] = useState(false);
 
   const { data, loading, error } = useQuery<
     GetMilestonesType,
@@ -498,28 +495,7 @@ const Milestones = () => {
                     />
                   </FieldGroup>
 
-                  <div className="grid-col-12">
-                    <Button
-                      type="button"
-                      className="usa-button usa-button--unstyled margin-top-4"
-                      onClick={() => setHasHighLevelNote(!hasHighLevelNote)}
-                    >
-                      <IconAdd className="margin-right-1" aria-hidden />
-                      {h('additionalNote')}
-                    </Button>
-                  </div>
-
-                  {hasHighLevelNote && (
-                    <FieldGroup className="margin-top-4 grid-col-12">
-                      <Field
-                        as={TextAreaField}
-                        className="height-15"
-                        id="ModelType-HighLevelNote"
-                        name="highLevelNote"
-                        label={t('Notes')}
-                      />
-                    </FieldGroup>
-                  )}
+                  <AddNote id="ModelType-HighLevelNote" field="highLevelNote" />
 
                   <FieldGroup
                     scrollElement="phasedIn"
@@ -557,28 +533,7 @@ const Milestones = () => {
                     </Fieldset>
                   </FieldGroup>
 
-                  <div className="grid-col-12">
-                    <Button
-                      type="button"
-                      className="usa-button usa-button--unstyled margin-top-4"
-                      onClick={() => setHasAdditionalNote(!hasAdditionalNote)}
-                    >
-                      <IconAdd className="margin-right-1" aria-hidden />
-                      {h('additionalNote')}
-                    </Button>
-                  </div>
-
-                  {hasAdditionalNote && (
-                    <FieldGroup className="margin-top-4 grid-col-12">
-                      <Field
-                        as={TextAreaField}
-                        className="height-15"
-                        id="ModelType-phasedInNote"
-                        name="phasedInNote"
-                        label={t('notes')}
-                      />
-                    </FieldGroup>
-                  )}
+                  <AddNote id="ModelType-phasedInNote" field="phasedInNote" />
 
                   <div className="margin-top-6 margin-bottom-3">
                     <Button

--- a/src/views/ModelPlan/TaskList/Basics/Overview/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/Basics/Overview/__snapshots__/index.test.tsx.snap
@@ -201,31 +201,35 @@ exports[`Model Plan Documents page matches snapshot 1`] = `
           name="testInterventions"
         />
       </div>
-      <button
-        class="usa-button usa-button usa-button--unstyled margin-top-4"
-        data-testid="button"
-        type="button"
+      <div
+        class="margin-top-4 margin-bottom-8"
       >
-        <svg
-          aria-hidden="true"
-          class="usa-icon margin-right-1"
-          focusable="false"
-          height="1em"
-          role="img"
-          viewBox="0 0 24 24"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
+        <button
+          class="usa-button usa-button usa-button--unstyled"
+          data-testid="add-note-toggle"
+          type="button"
         >
-          <path
-            d="M0 0h24v24H0z"
-            fill="none"
-          />
-          <path
-            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-          />
-        </svg>
-        Add an additional note
-      </button>
+          <svg
+            aria-hidden="true"
+            class="usa-icon margin-right-1"
+            focusable="false"
+            height="1em"
+            role="img"
+            viewBox="0 0 24 24"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+            <path
+              d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+            />
+          </svg>
+          Add an additional note
+        </button>
+      </div>
       <div
         class="margin-top-6 margin-bottom-3"
       >

--- a/src/views/ModelPlan/TaskList/Basics/Overview/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/Overview/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
@@ -8,13 +8,13 @@ import {
   BreadcrumbLink,
   Button,
   Fieldset,
-  IconAdd,
   IconArrowBack,
   Label,
   Radio
 } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
 
+import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
@@ -45,7 +45,6 @@ const Overview = () => {
 
   const formikRef = useRef<FormikProps<BasicsFormType>>(null);
   const history = useHistory();
-  const [hasAdditionalNote, setHasAdditionalNote] = useState(false);
 
   const { data, loading, error } = useQuery<GetBasicsType, GetBasicsVariables>(
     GetBasics,
@@ -258,26 +257,7 @@ const Overview = () => {
                   />
                 </FieldGroup>
 
-                <Button
-                  type="button"
-                  className="usa-button usa-button--unstyled margin-top-4"
-                  onClick={() => setHasAdditionalNote(true)}
-                >
-                  <IconAdd className="margin-right-1" aria-hidden />
-                  {h('additionalNote')}
-                </Button>
-
-                {hasAdditionalNote && (
-                  <FieldGroup className="margin-top-4">
-                    <Field
-                      as={TextAreaField}
-                      className="height-15"
-                      id="ModelType-note"
-                      name="note"
-                      label={t('Notes')}
-                    />
-                  </FieldGroup>
-                )}
+                <AddNote id="ModelType-note" field="note" />
 
                 <div className="margin-top-6 margin-bottom-3">
                   <Button

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/Coordination/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/Coordination/index.tsx
@@ -232,7 +232,7 @@ export const Coordination = () => {
                   </Fieldset>
                   <AddNote
                     id="participants-and-providers-coordniate-work-note"
-                    field="coordinateWorkeNote"
+                    field="coordinateWorkNote"
                   />
                 </FieldGroup>
 


### PR DESCRIPTION
# EASI-2069

## Changes and Description

[EASI-2069](https://jiraent.cms.gov/browse/EASI-2069)

- Updated the <AddNote /> component to auto expand if value exists
- Added unit test

Small side fixes
- Fixed a typo on `coordinateWorkNote`
- Added index to collaborator combobox to allow for accessible navigation

[Slack thread about this](https://oddball.slack.com/archives/C030RBZMTRA/p1653597229971309)

![Screen Shot 2022-07-22 at 9 19 46 AM](https://user-images.githubusercontent.com/95709965/180447534-9109e276-03e4-4d28-bf07-0fb81b2c06af.png)

## Notes

- Utilized a Formik hook to fetch field value from name
- This allowed there to be no changes in implementation, only directly in existing component definition

## How to test this change

- Create a model plan or use a seeded plan
- Note field with no text should be collapsed on page load - `Add an additional note`
- Note field with text should automatically expand on load with `Add an additional note` hidden
- Deleting a note should leave the text area expanded until saved - on next load will be collapsed

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
