### PR TITLE
Easi 2134/task list last updated

### DIFF
--- a/src/i18n/en-US/modelPlanTaskList.ts
+++ b/src/i18n/en-US/modelPlanTaskList.ts
@@ -34,37 +34,44 @@ const modelPlanTaskList = {
     basics: {
       heading: 'Model basics',
       copy:
-        'Start filling out as much of the basic model information as you know and reach out to the Model Assessment Team if you need help.'
+        'Start filling out as much of the basic model information as you know and reach out to the Model Assessment Team if you need help.',
+      path: 'basics'
     },
-    characteristics: {
+    generalCharacteristics: {
       heading: 'General characteristics',
       copy:
-        'Start filling out as much of the general model characteristics as you know and reach out to the Model Assessment Team if you need help.'
+        'Start filling out as much of the general model characteristics as you know and reach out to the Model Assessment Team if you need help.',
+      path: 'characteristics'
     },
-    'participants-and-providers': {
+    participantsAndProviders: {
       heading: 'Participants and providers',
       copy:
-        'Start filling out as much of the model participant information as you know and reach out to the Model Assessment Team if you need help.'
+        'Start filling out as much of the model participant information as you know and reach out to the Model Assessment Team if you need help.',
+      path: 'participants-and-providers'
     },
     beneficiaries: {
       heading: 'Beneficiaries',
       copy:
-        'Start filling out as much of the beneficiary information as you know and reach out to the Model Assessment Team if you need help.'
+        'Start filling out as much of the beneficiary information as you know and reach out to the Model Assessment Team if you need help.',
+      path: 'beneficiaries'
     },
-    'ops-eval-and-learning': {
+    opsEvalAndLearning: {
       heading: 'Operations, evaluation, and learning',
       copy:
-        'Start filling out as much of the model operation information as you know and reach out to the Model Assessment Team if you need help.'
+        'Start filling out as much of the model operation information as you know and reach out to the Model Assessment Team if you need help.',
+      path: 'ops-eval-and-learning'
     },
-    payment: {
+    payments: {
       heading: 'Payment',
       copy:
-        'Start filling out as much of the payment information as you know and reach out to the Model Assessment Team if you need help.'
+        'Start filling out as much of the payment information as you know and reach out to the Model Assessment Team if you need help.',
+      path: 'payments'
     },
-    finalizeModelPlan: {
-      heading: 'Finalize Model Plan',
+    itTools: {
+      heading: 'IT tools',
       copy:
-        'Review all sections of the Model Plan and confirm with the Model Assessment Team that your model is ready for internal clearance processes.'
+        'Choose the IT solutions your model will utilize. Many questions in this section are populated based on responses to questions answered in previous sections.',
+      path: 'it-tools'
     }
   },
   taskListButton: {

--- a/src/queries/GetModelPlan.ts
+++ b/src/queries/GetModelPlan.ts
@@ -38,6 +38,7 @@ export default gql`
         wrapUpEnds
         phasedIn
         phasedInNote
+        modifiedDts
         status
       }
       documents {

--- a/src/queries/GetModelPlan.ts
+++ b/src/queries/GetModelPlan.ts
@@ -20,6 +20,7 @@ export default gql`
         goal
         testInterventions
         note
+        modifiedDts
         status
       }
       milestones {

--- a/src/queries/types/GetModelPlan.ts
+++ b/src/queries/types/GetModelPlan.ts
@@ -18,6 +18,7 @@ export interface GetModelPlan_modelPlan_basics {
   goal: string | null;
   testInterventions: string | null;
   note: string | null;
+  modifiedDts: Time | null;
   status: TaskStatus;
 }
 

--- a/src/queries/types/GetModelPlan.ts
+++ b/src/queries/types/GetModelPlan.ts
@@ -38,6 +38,7 @@ export interface GetModelPlan_modelPlan_milestones {
   wrapUpEnds: Time | null;
   phasedIn: boolean | null;
   phasedInNote: string | null;
+  modifiedDts: Time | null;
   status: TaskStatus;
 }
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -8,15 +8,16 @@ export const parseAsLocalTime = (date: string) => DateTime.fromISO(date);
 export const formatDateAndIgnoreTimezone = (date: string) =>
   parseAsDate(date).toFormat('MMMM d yyyy');
 
-export const formatDate = (date: string | DateTime) => {
+export const formatDate = (date: string | DateTime, format?: string) => {
+  const dateFormat = format || 'MMMM d yyyy';
   // ISO String
   if (typeof date === 'string') {
-    return parseAsLocalTime(date).toFormat('MMMM d yyyy');
+    return parseAsLocalTime(date).toFormat(dateFormat);
   }
 
   // luxon DateTime
   if (date instanceof DateTime) {
-    return date.toFormat('MMMM d yyyy');
+    return date.toFormat(dateFormat);
   }
 
   return '';

--- a/src/views/ModelPlan/TaskList/index.test.tsx
+++ b/src/views/ModelPlan/TaskList/index.test.tsx
@@ -37,6 +37,7 @@ describe('The Model Plan Task List', () => {
       goal: null,
       testInterventions: null,
       note: null,
+      modifiedDts: null,
       status: 'READY'
     },
     milestones: {

--- a/src/views/ModelPlan/TaskList/index.test.tsx
+++ b/src/views/ModelPlan/TaskList/index.test.tsx
@@ -55,6 +55,7 @@ describe('The Model Plan Task List', () => {
       highLevelNote: null,
       phasedIn: null,
       phasedInNote: null,
+      modifiedDts: null,
       status: 'READY'
     },
     opsEvalAndLearning: [] as any,

--- a/src/views/ModelPlan/TaskList/index.tsx
+++ b/src/views/ModelPlan/TaskList/index.tsx
@@ -326,8 +326,7 @@ const TaskList = () => {
 
                               {/* Basics needs to render the last updated data based on multiple modifiedDts values */}
                               {key === 'basics' &&
-                                renderBasicsStatus() ===
-                                  TaskStatus.IN_PROGRESS && (
+                                renderBasicsStatus() !== TaskStatus.READY && (
                                   <TaskListLastUpdated>
                                     <p className="margin-y-0">
                                       {t('taskListItem.lastUpdated')}
@@ -350,8 +349,8 @@ const TaskList = () => {
                                 )}
 
                               {key !== 'basics' &&
-                                taskListSections[key].status ===
-                                  TaskStatus.IN_PROGRESS && (
+                                taskListSections[key].status !==
+                                  TaskStatus.READY && (
                                   <TaskListLastUpdated>
                                     <p className="margin-y-0">
                                       {t('taskListItem.lastUpdated')}

--- a/src/views/ModelPlan/TaskList/index.tsx
+++ b/src/views/ModelPlan/TaskList/index.tsx
@@ -75,6 +75,7 @@ const TaskList = () => {
 
   const {
     modelName,
+    modifiedDts,
     basics,
     milestones,
     modelCategory,
@@ -110,8 +111,8 @@ const TaskList = () => {
    * */
   const renderBasicsStatus = (): TaskStatus => {
     if (
-      basics?.status === TaskStatus.COMPLETE &&
-      milestones?.status === TaskStatus.COMPLETE
+      basics.status === TaskStatus.COMPLETE &&
+      milestones.status === TaskStatus.COMPLETE
     ) {
       return TaskStatus.COMPLETE;
     }
@@ -119,6 +120,22 @@ const TaskList = () => {
       return TaskStatus.READY;
     }
     return TaskStatus.IN_PROGRESS;
+  };
+
+  /**
+   * Used to calculate last modified date on Basics as milstones is encapsulated in Basics, but has it's modifiedDts
+   * May be changed/merged in the future to match other task list sections
+   * */
+  const renderBasicsLastUpdated = () => {
+    const basicDates = [
+      modifiedDts,
+      basics?.modifiedDts,
+      milestones.modifiedDts
+    ];
+    basicDates.sort((a, b) => {
+      return a?.localeCompare(b!) || 0;
+    });
+    return basicDates[0];
   };
 
   const dicussionBanner = () => {
@@ -306,21 +323,48 @@ const TaskList = () => {
                                   {t(`numberedList.${key}.copy`)}
                                 </p>
                               </TaskListDescription>
-                              {taskListSections[key].status ===
-                                'IN_PROGRESS' && (
-                                <TaskListLastUpdated>
-                                  <p className="margin-y-0">
-                                    {t('taskListItem.lastUpdated')}
-                                  </p>
-                                  <p className="margin-y-0">
-                                    {taskListSections[key].modifiedDts &&
-                                      formatDate(
-                                        taskListSections[key].modifiedDts!,
-                                        'MM/d/yyyy'
-                                      )}
-                                  </p>
-                                </TaskListLastUpdated>
-                              )}
+
+                              {/* Basics needs to render the last updated data based on multiple modifiedDts values */}
+                              {key === 'basics' &&
+                                renderBasicsStatus() ===
+                                  TaskStatus.IN_PROGRESS && (
+                                  <TaskListLastUpdated>
+                                    <p className="margin-y-0">
+                                      {t('taskListItem.lastUpdated')}
+                                    </p>
+                                    <p className="margin-y-0">
+                                      {key === 'basics' &&
+                                        renderBasicsLastUpdated() &&
+                                        formatDate(
+                                          renderBasicsLastUpdated() || '',
+                                          'MM/d/yyyy'
+                                        )}
+                                      {key !== 'basics' &&
+                                        taskListSections[key].modifiedDts &&
+                                        formatDate(
+                                          taskListSections[key].modifiedDts!,
+                                          'MM/d/yyyy'
+                                        )}
+                                    </p>
+                                  </TaskListLastUpdated>
+                                )}
+
+                              {key !== 'bascis' &&
+                                taskListSections[key].status ===
+                                  TaskStatus.IN_PROGRESS && (
+                                  <TaskListLastUpdated>
+                                    <p className="margin-y-0">
+                                      {t('taskListItem.lastUpdated')}
+                                    </p>
+                                    <p className="margin-y-0">
+                                      {taskListSections[key].modifiedDts &&
+                                        formatDate(
+                                          taskListSections[key].modifiedDts!,
+                                          'MM/d/yyyy'
+                                        )}
+                                    </p>
+                                  </TaskListLastUpdated>
+                                )}
                             </div>
                             <TaskListButton
                               path={t(`numberedList.${key}.path`)}

--- a/src/views/ModelPlan/TaskList/index.tsx
+++ b/src/views/ModelPlan/TaskList/index.tsx
@@ -349,7 +349,7 @@ const TaskList = () => {
                                   </TaskListLastUpdated>
                                 )}
 
-                              {key !== 'bascis' &&
+                              {key !== 'basics' &&
                                 taskListSections[key].status ===
                                   TaskStatus.IN_PROGRESS && (
                                   <TaskListLastUpdated>

--- a/src/views/ModelPlan/TaskList/index.tsx
+++ b/src/views/ModelPlan/TaskList/index.tsx
@@ -30,6 +30,7 @@ import {
   GetModelPlan_modelPlan_participantsAndProviders as ParticipantsAndProvidersType,
   GetModelPlanVariables
 } from 'queries/types/GetModelPlan';
+import { TaskStatus } from 'types/graphql-global-types';
 import { formatDate } from 'utils/date';
 import { getUnansweredQuestions } from 'utils/modelPlan';
 
@@ -75,6 +76,9 @@ const TaskList = () => {
   const {
     modelName,
     basics,
+    milestones,
+    modelCategory,
+    cmsCenters,
     discussions,
     documents,
     status,
@@ -99,6 +103,23 @@ const TaskList = () => {
   const { unansweredQuestions, answeredQuestions } = getUnansweredQuestions(
     discussions
   );
+
+  /**
+   * Used to calculate status on Basics as milstones is encapsulated in Basics, but has it's own status
+   * May be changed/merged in the future to match other task list sections
+   * */
+  const renderBasicsStatus = (): TaskStatus => {
+    if (
+      basics?.status === TaskStatus.COMPLETE &&
+      milestones?.status === TaskStatus.COMPLETE
+    ) {
+      return TaskStatus.COMPLETE;
+    }
+    if (modelCategory === null && cmsCenters.length === 0) {
+      return TaskStatus.READY;
+    }
+    return TaskStatus.IN_PROGRESS;
+  };
 
   const dicussionBanner = () => {
     return (
@@ -273,7 +294,11 @@ const TaskList = () => {
                             key={key}
                             testId={`task-list-intake-form-${key}`}
                             heading={t(`numberedList.${key}.heading`)}
-                            status={taskListSections[key].status}
+                            status={
+                              key === 'basics'
+                                ? renderBasicsStatus()
+                                : taskListSections[key].status
+                            }
                           >
                             <div className="model-plan-task-list__task-row display-flex flex-justify flex-align-start">
                               <TaskListDescription>

--- a/src/views/ModelPlan/TaskList/index.tsx
+++ b/src/views/ModelPlan/TaskList/index.tsx
@@ -23,8 +23,14 @@ import GetModelPlan from 'queries/GetModelPlan';
 import {
   GetModelPlan as GetModelPlanType,
   GetModelPlan_modelPlan as GetModelPlanTypes,
+  GetModelPlan_modelPlan_basics as BasicsType,
+  GetModelPlan_modelPlan_beneficiaries as BeneficiariesType,
+  GetModelPlan_modelPlan_generalCharacteristics as GeneralCharacteristicsType,
+  GetModelPlan_modelPlan_opsEvalAndLearning as OpsEvalAndLearningType,
+  GetModelPlan_modelPlan_participantsAndProviders as ParticipantsAndProvidersType,
   GetModelPlanVariables
 } from 'queries/types/GetModelPlan';
+import { formatDate } from 'utils/date';
 import { getUnansweredQuestions } from 'utils/modelPlan';
 
 import Discussions from '../Discussions';
@@ -39,9 +45,13 @@ import TaskListStatus from './_components/TaskListStatus';
 
 import './index.scss';
 
-type TaskListItemProps = {
-  heading: string;
-  copy: string;
+type TaskListSectionsType = {
+  [key: string]:
+    | BasicsType
+    | BeneficiariesType
+    | GeneralCharacteristicsType
+    | OpsEvalAndLearningType
+    | ParticipantsAndProvidersType;
 };
 
 const TaskList = () => {
@@ -64,10 +74,6 @@ const TaskList = () => {
 
   const {
     modelName,
-    modelCategory,
-    cmsCenters,
-    // modifiedDts,
-    milestones,
     basics,
     discussions,
     documents,
@@ -76,48 +82,23 @@ const TaskList = () => {
     participantsAndProviders,
     opsEvalAndLearning,
     beneficiaries
-    // operations,
-    // payment,
-    // finalizeModelPlan
+    // payments,
+    // itTools
   } = modelPlan;
 
-  const taskListItem: TaskListItemProps[] = t('numberedList', {
-    returnObjects: true
-  });
+  const taskListSections: TaskListSectionsType = {
+    basics,
+    generalCharacteristics,
+    participantsAndProviders,
+    beneficiaries,
+    opsEvalAndLearning
+    // payments,
+    // itTools
+  };
 
   const { unansweredQuestions, answeredQuestions } = getUnansweredQuestions(
     discussions
   );
-
-  const taskListItemStatus = (key: string) => {
-    switch (key) {
-      case 'basics':
-        if (
-          basics?.status === 'COMPLETE' &&
-          milestones?.status === 'COMPLETE'
-        ) {
-          return 'COMPLETE';
-        }
-        if (modelCategory === null && cmsCenters.length === 0) {
-          return 'READY';
-        }
-        return 'IN_PROGRESS';
-      case 'characteristics':
-        return generalCharacteristics?.status;
-      case 'participants-and-providers':
-        return participantsAndProviders.status;
-      case 'beneficiaries':
-        return beneficiaries.status;
-      case 'ops-eval-and-learning':
-        return opsEvalAndLearning.status;
-      // case 'payment':
-      //   return;
-      // case 'finalizeModelPlan':
-      //   return;
-      default:
-        return 'CANNOT_START';
-    }
-  };
 
   const dicussionBanner = () => {
     return (
@@ -285,42 +266,43 @@ const TaskList = () => {
                     data-testid="task-list"
                     className="model-plan-task-list__task-list model-plan-task-list__task-list--primary margin-top-6 margin-bottom-0 padding-left-0"
                   >
-                    {Object.keys(taskListItem).map((key: any) => {
-                      const lastTaskItem = Object.keys(taskListItem).slice(
-                        -1
-                      )[0];
-                      const path =
-                        key === 'finalizeModelPlan' ? 'submit-request' : key;
-
+                    {Object.keys(taskListSections).map((key: string) => {
                       return (
                         <Fragment key={key}>
                           <TaskListItem
                             key={key}
                             testId={`task-list-intake-form-${key}`}
-                            heading={taskListItem[key].heading}
-                            status={taskListItemStatus(key)}
+                            heading={t(`numberedList.${key}.heading`)}
+                            status={taskListSections[key].status}
                           >
                             <div className="model-plan-task-list__task-row display-flex flex-justify flex-align-start">
                               <TaskListDescription>
                                 <p className="margin-top-0">
-                                  {taskListItem[key].copy}
+                                  {t(`numberedList.${key}.copy`)}
                                 </p>
                               </TaskListDescription>
-                              {taskListItemStatus(key) === 'IN_PROGRESS' && (
+                              {taskListSections[key].status ===
+                                'IN_PROGRESS' && (
                                 <TaskListLastUpdated>
                                   <p className="margin-y-0">
                                     {t('taskListItem.lastUpdated')}
                                   </p>
-                                  <p className="margin-y-0">4/1/2022</p>
+                                  <p className="margin-y-0">
+                                    {taskListSections[key].modifiedDts &&
+                                      formatDate(
+                                        taskListSections[key].modifiedDts!,
+                                        'MM/d/yyyy'
+                                      )}
+                                  </p>
                                 </TaskListLastUpdated>
                               )}
                             </div>
                             <TaskListButton
-                              path={path}
-                              status={taskListItemStatus(key)}
+                              path={t(`numberedList.${key}.path`)}
+                              status={taskListSections[key].status}
                             />
                           </TaskListItem>
-                          {key !== lastTaskItem && (
+                          {key !== 'itTools' && (
                             <Divider className="margin-bottom-4" />
                           )}
                         </Fragment>


### PR DESCRIPTION
# EASI-2134

## Changes and Description

- Added `Last Updated` to task list sections
- modifiedDts field should be rendered mm/dd/yyyy for all statuses that are not `READY`
- `Basics` is the only outlier as it has 3 different statuses and 3 different modifiedDts
- Reworked how task list renders statuses to better accommodate displaying relevant task list info

## Notes

- Some seeded data won't accurately display the realistic nature of last modified dates, as there are status if `IN_PROGRESS` with no modifiedDts, which would never occur
- There are some fields in the forms that won't trigger `IN_PROGRESS` status change, which is dependent on the `Last Modified` rendering.  *may need to consult with BE if we want to change or audit this*

## How to test this change

- Create a model plan and fill out fields
- Navigate back to task list and see status and `Last Modified` rendered

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
