### PR TITLE
Easi 2175/backend websocket changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,8 @@ require (
 	gopkg.in/launchdarkly/go-server-sdk.v5 v5.6.0
 )
 
+require github.com/gorilla/websocket v1.5.0
+
 require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
@@ -48,7 +50,6 @@ require (
 	github.com/go-openapi/spec v0.20.4 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/goccy/go-json v0.9.4 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/pkg/authorization/require_principal_middleware.go
+++ b/pkg/authorization/require_principal_middleware.go
@@ -3,9 +3,10 @@ package authorization
 import (
 	"net/http"
 
+	"go.uber.org/zap"
+
 	"github.com/cmsgov/mint-app/pkg/appcontext"
 	"github.com/cmsgov/mint-app/pkg/authentication"
-	"go.uber.org/zap"
 )
 
 func requirePrincipalMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
@@ -16,13 +17,13 @@ func requirePrincipalMiddleware(logger *zap.Logger, next http.Handler) http.Hand
 		if principal == authentication.ANON {
 			logger.Info("Authorization failure: principal not found in context")
 
-			// w.Header().Set("Content-Type", "application/json")
-			// w.WriteHeader(http.StatusUnauthorized)
-			// _, writeErr := w.Write([]byte(`{"errors": [{"message": "Unauthorized"}]}`))
-			// if writeErr != nil {
-			// 	logger.Error("failed to write response body")
-			// }
-			// return
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, writeErr := w.Write([]byte(`{"errors": [{"message": "Unauthorized"}]}`))
+			if writeErr != nil {
+				logger.Error("failed to write response body")
+			}
+			return
 		}
 
 		next.ServeHTTP(w, r)

--- a/pkg/authorization/require_principal_middleware.go
+++ b/pkg/authorization/require_principal_middleware.go
@@ -3,10 +3,9 @@ package authorization
 import (
 	"net/http"
 
-	"go.uber.org/zap"
-
 	"github.com/cmsgov/mint-app/pkg/appcontext"
 	"github.com/cmsgov/mint-app/pkg/authentication"
+	"go.uber.org/zap"
 )
 
 func requirePrincipalMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
@@ -17,13 +16,13 @@ func requirePrincipalMiddleware(logger *zap.Logger, next http.Handler) http.Hand
 		if principal == authentication.ANON {
 			logger.Info("Authorization failure: principal not found in context")
 
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusUnauthorized)
-			_, writeErr := w.Write([]byte(`{"errors": [{"message": "Unauthorized"}]}`))
-			if writeErr != nil {
-				logger.Error("failed to write response body")
-			}
-			return
+			// w.Header().Set("Content-Type", "application/json")
+			// w.WriteHeader(http.StatusUnauthorized)
+			// _, writeErr := w.Write([]byte(`{"errors": [{"message": "Unauthorized"}]}`))
+			// if writeErr != nil {
+			// 	logger.Error("failed to write response body")
+			// }
+			// return
 		}
 
 		next.ServeHTTP(w, r)

--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -1,10 +1,14 @@
 package local
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/go-openapi/swag"
 	"go.uber.org/zap"
 
@@ -28,42 +32,75 @@ func authenticateMiddleware(logger *zap.Logger, next http.Handler) http.Handler 
 			return
 		}
 
-		// don't attempt to handle local auth if the Authorization Header doesn't start with "Local"
-		if !strings.HasPrefix(r.Header["Authorization"][0], "Local") {
+		authHeader := r.Header["Authorization"][0]
+		ctx, err := devUserContext(r.Context(), authHeader)
+		if err != nil {
+			logger.Error("Empty dev user config JSON")
+			w.WriteHeader(http.StatusBadRequest)
+			next.ServeHTTP(w, r)
+			return
+		}
+		if ctx == nil {
+			logger.Info("No local auth header present")
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		tokenParts := strings.Split(r.Header["Authorization"][0], "Local ")
-		if len(tokenParts) < 2 {
-			logger.Error("Invalid local auth header")
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-
-		devUserConfigJSON := tokenParts[1]
-		if devUserConfigJSON == "" {
-			logger.Error("Empty dev user config JSON")
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-
-		config := DevUserConfig{}
-
-		if parseErr := json.Unmarshal([]byte(devUserConfigJSON), &config); parseErr != nil {
-			logger.Error("Could not parse local auth JSON")
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-
 		logger.Info("Using local authorization middleware and populating EUA ID and job codes")
-		ctx := appcontext.WithPrincipal(r.Context(), &authentication.EUAPrincipal{
-			EUAID:        config.EUA,
-			JobCodeMINT:  true,
-			JobCodeADMIN: swag.ContainsStrings(config.JobCodes, "MINT_D_ADMIN_USER"),
-		})
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+func devUserContext(ctx context.Context, authHeader string) (context.Context, error) {
+	// don't attempt to handle local auth if the Authorization Header doesn't start with "Local"
+	if !strings.HasPrefix(authHeader, "Local") {
+		return nil, nil
+	}
+
+	tokenParts := strings.Split(authHeader, "Local ")
+	if len(tokenParts) < 2 {
+		return nil, errors.New("invalid local auth header")
+	}
+
+	devUserConfigJSON := tokenParts[1]
+	if devUserConfigJSON == "" {
+		return nil, errors.New("empty dev user config JSON")
+	}
+
+	config := DevUserConfig{}
+
+	if parseErr := json.Unmarshal([]byte(devUserConfigJSON), &config); parseErr != nil {
+		return nil, errors.New("could not parse local auth JSON")
+	}
+
+	return appcontext.WithPrincipal(ctx, &authentication.EUAPrincipal{
+		EUAID:        config.EUA,
+		JobCodeMINT:  true,
+		JobCodeADMIN: swag.ContainsStrings(config.JobCodes, "MINT_D_ADMIN_USER"),
+	}), nil
+}
+
+// NewLocalWebSocketAuthenticationMiddleware returns a transport.WebsocketInitFunc that uses the `authToken` in
+// the websocket connection payload to authenticate a local user.
+func NewLocalWebSocketAuthenticationMiddleware(logger *zap.Logger) transport.WebsocketInitFunc {
+	return func(ctx context.Context, initPayload transport.InitPayload) (context.Context, error) {
+		// Get the token from payload
+		all := initPayload
+		fmt.Println("ALL OF EM BABY", all)
+		any := initPayload["authToken"]
+		token, ok := any.(string)
+		if !ok || token == "" {
+			return nil, errors.New("authToken not found in transport payload")
+		}
+
+		devCtx, err := devUserContext(ctx, token)
+		if err != nil {
+			logger.Error("could not set context for local dev auth", zap.Error(err))
+			return nil, err
+		}
+
+		return devCtx, nil
+	}
 }
 
 // NewLocalAuthenticationMiddleware stubs out context info for local (non-Okta) authentication

--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -54,7 +54,7 @@ func authenticateMiddleware(logger *zap.Logger, next http.Handler) http.Handler 
 func devUserContext(ctx context.Context, authHeader string) (context.Context, error) {
 	// don't attempt to handle local auth if the Authorization Header doesn't start with "Local"
 	if !strings.HasPrefix(authHeader, "Local") {
-		return nil, nil
+		return ctx, nil
 	}
 
 	tokenParts := strings.Split(authHeader, "Local ")

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -8,15 +8,19 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/lru"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
 	_ "github.com/lib/pq" // pq is required to get the postgres driver into sqlx
 	"go.uber.org/zap"
 
@@ -59,10 +63,10 @@ func (s *Server) routes(
 		oktaAuthenticationMiddleware,
 	)
 
-	if s.NewLocalAuthIsEnabled() {
-		localAuthenticationMiddleware := local.NewLocalAuthenticationMiddleware(s.logger)
-		s.router.Use(localAuthenticationMiddleware)
-	}
+	// if s.NewLocalAuthIsEnabled() {
+	// 	localAuthenticationMiddleware := local.NewLocalAuthenticationMiddleware(s.logger)
+	// 	s.router.Use(localAuthenticationMiddleware)
+	// }
 
 	requirePrincipalMiddleware := authorization.NewRequirePrincipalMiddleware(s.logger)
 
@@ -145,7 +149,7 @@ func (s *Server) routes(
 	// set up GraphQL routes
 	gql := s.router.PathPrefix("/api/graph").Subrouter()
 
-	gql.Use(requirePrincipalMiddleware)
+	// gql.Use(requirePrincipalMiddleware)
 
 	resolver := graph.NewResolver(
 		store,
@@ -169,7 +173,45 @@ func (s *Server) routes(
 		return next(ctx)
 	}}
 	gqlConfig := generated.Config{Resolvers: resolver, Directives: gqlDirectives}
-	graphqlServer := handler.NewDefaultServer(generated.NewExecutableSchema(gqlConfig))
+	graphqlServer := handler.New(generated.NewExecutableSchema(gqlConfig))
+	graphqlServer.AddTransport(transport.Websocket{
+		KeepAlivePingInterval: 10 * time.Second,
+		Upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool {
+				return true
+			},
+			Subprotocols: []string{"graphql-transport-ws"},
+		},
+		InitFunc: func(ctx context.Context, initPayload transport.InitPayload) (context.Context, error) {
+			// Get the token from payload
+			all := initPayload
+			fmt.Println("ALL OF EM BABY", all)
+			any := initPayload["authToken"]
+			token, ok := any.(string)
+			if !ok || token == "" {
+				return nil, errors.New("authToken not found in transport payload")
+			}
+
+			// Perform token verification and authentication...
+			userId := "john.doe" // e.g. userId, err := GetUserFromAuthentication(token)
+
+			// put it in context
+			ctxNew := context.WithValue(ctx, "username", userId)
+
+			return ctxNew, nil
+		},
+	})
+	graphqlServer.AddTransport(transport.Options{})
+	graphqlServer.AddTransport(transport.GET{})
+	graphqlServer.AddTransport(transport.POST{})
+	graphqlServer.AddTransport(transport.MultipartForm{})
+
+	graphqlServer.SetQueryCache(lru.New(1000))
+
+	graphqlServer.Use(extension.Introspection{})
+	graphqlServer.Use(extension.AutomaticPersistedQuery{
+		Cache: lru.New(100),
+	})
 	graphqlServer.Use(extension.FixedComplexityLimit(1000))
 	graphqlServer.AroundResponses(NewGQLResponseMiddleware())
 

--- a/pkg/services/auth.go
+++ b/pkg/services/auth.go
@@ -2,15 +2,31 @@ package services
 
 import (
 	"context"
-
-	"go.uber.org/zap"
+	"fmt"
 
 	"github.com/cmsgov/mint-app/pkg/appcontext"
 	"github.com/cmsgov/mint-app/pkg/graph/model"
+	"go.uber.org/zap"
 )
 
 // HasRole authorizes a user as having a given role
 func HasRole(ctx context.Context, role model.Role) (bool, error) {
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
 	logger := appcontext.ZLogger(ctx)
 	principal := appcontext.Principal(ctx)
 	switch role {

--- a/pkg/services/auth.go
+++ b/pkg/services/auth.go
@@ -4,29 +4,22 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
+
 	"github.com/cmsgov/mint-app/pkg/appcontext"
 	"github.com/cmsgov/mint-app/pkg/graph/model"
-	"go.uber.org/zap"
 )
 
 // HasRole authorizes a user as having a given role
 func HasRole(ctx context.Context, role model.Role) (bool, error) {
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
-	fmt.Println("CONTEXT VALUE USERNAME", ctx.Value("username"))
+	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
+	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
+	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
+	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
+	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
+	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
+	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
+	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
 	logger := appcontext.ZLogger(ctx)
 	principal := appcontext.Principal(ctx)
 	switch role {


### PR DESCRIPTION
# EASI-2175 BE updates to support FE websockets

## Changes and Description

- Support for authentication in websocket payload

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
