### PR TITLE
[NOREF] Rename job codes and related auth/principal function/property names

### DIFF
--- a/docs/graphql_playground.md
+++ b/docs/graphql_playground.md
@@ -17,16 +17,16 @@ The GraphQL endpoints require a valid `Authorization` header to use, which can b
 Job codes can be included in an array for querying endpoints such as `systemIntake` that require them:
 
 ```
-{ "Authorization":"Local {\"favorLocalAuth\":true, \"jobCodes\":[\"MINT_P_USER\"]}"}
+{ "Authorization":"Local {\"favorLocalAuth\":true, \"jobCodes\":[\"MINT_USER\"]}"}
 ```
-Additional job codes beyond/instead of `MINT_P_USER` can be included in the `jobCodes` array, just make sure to escape the `"`'s around the job code names.
+Additional job codes beyond/instead of `MINT_USER` can be included in the `jobCodes` array, just make sure to escape the `"`'s around the job code names.
 
 #### EUA ID
 
 An EUA ID is needed for some endpoints such as creating system intakes; this can be added with the `EUAID` field:
 
 ```
-{ "Authorization":"Local {\"EUAID\":\"ABCD\",\"favorLocalAuth\":true, \"jobCodes\":[\"MINT_P_USER\", \"MINT_P_ADMIN\"]}"}
+{ "Authorization":"Local {\"EUAID\":\"ABCD\",\"favorLocalAuth\":true, \"jobCodes\":[\"MINT_USER\", \"MINT_ASSESSMENT\"]}"}
 ```
 
 

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -183,9 +183,6 @@ const OktaClientID = "OKTA_CLIENT_ID"
 // OktaIssuer is the okta issuer
 const OktaIssuer = "OKTA_ISSUER"
 
-// AltJobCodes are alternate job codes
-const AltJobCodes = "ALT_JOB_CODES"
-
 // FlagSourceOption represents an environment
 type FlagSourceOption string
 

--- a/pkg/appcontext/context_test.go
+++ b/pkg/appcontext/context_test.go
@@ -96,9 +96,9 @@ func TestContextPrincipal(t *testing.T) {
 		},
 		"regular user": {
 			ctx: WithPrincipal(context.Background(), &authentication.EUAPrincipal{
-				EUAID:        submitterID,
-				JobCodeMINT:  true,
-				JobCodeADMIN: false,
+				EUAID:             submitterID,
+				JobCodeUSER:       true,
+				JobCodeASSESSMENT: false,
 			}),
 			expectID:    submitterID,
 			expectMINT:  true,
@@ -106,9 +106,9 @@ func TestContextPrincipal(t *testing.T) {
 		},
 		"admin User": {
 			ctx: WithPrincipal(context.Background(), &authentication.EUAPrincipal{
-				EUAID:        reviewerID,
-				JobCodeMINT:  true,
-				JobCodeADMIN: true,
+				EUAID:             reviewerID,
+				JobCodeUSER:       true,
+				JobCodeASSESSMENT: true,
 			}),
 			expectID:    reviewerID,
 			expectMINT:  true,
@@ -123,8 +123,8 @@ func TestContextPrincipal(t *testing.T) {
 
 			// Assert (of AAA)
 			assert.Equal(t, tc.expectID, p.ID(), "ID")
-			assert.Equal(t, tc.expectMINT, p.AllowMINT(), "MINT")
-			assert.Equal(t, tc.expectADMIN, p.AllowADMIN(), "ADMIN")
+			assert.Equal(t, tc.expectMINT, p.AllowUSER(), "MINT_USER")
+			assert.Equal(t, tc.expectADMIN, p.AllowASSESSMENT(), "MINT_ASSESSMENT")
 		})
 	}
 }

--- a/pkg/authentication/principal.go
+++ b/pkg/authentication/principal.go
@@ -17,14 +17,14 @@ type Principal interface {
 	// for the given Principal
 	ID() string
 
-	// AllowMINT says whether this principal
-	// is authorized to operate within MINT
-	AllowMINT() bool
+	// AllowUSER says whether this principal
+	// is authorized to operate within MINT as a regular user
+	AllowUSER() bool
 
-	// AllowADMIN says whether this principal
+	// AllowASSESSMENT says whether this principal
 	// is authorized to operate as part of
 	// the Review Team within MINT
-	AllowADMIN() bool
+	AllowASSESSMENT() bool
 }
 
 type anonymous struct{}
@@ -43,22 +43,22 @@ func (*anonymous) ID() string {
 // AllowMINT says Anonymous users are
 // not explicitly allowed to submit
 // info to EASi
-func (*anonymous) AllowMINT() bool {
+func (*anonymous) AllowUSER() bool {
 	return false
 }
 
 // AllowADMIN says Anonymous users are
 // not explicitly ruled in as ADMIN
-func (*anonymous) AllowADMIN() bool {
+func (*anonymous) AllowASSESSMENT() bool {
 	return false
 }
 
 // EUAPrincipal represents information
 // gleaned from the Okta JWT
 type EUAPrincipal struct {
-	EUAID        string
-	JobCodeMINT  bool
-	JobCodeADMIN bool
+	EUAID             string
+	JobCodeUSER       bool
+	JobCodeASSESSMENT bool
 }
 
 // String satisfies the fmt.Stringer interface
@@ -72,15 +72,15 @@ func (p *EUAPrincipal) ID() string {
 	return p.EUAID
 }
 
-// AllowMINT says whether this principal
+// AllowUSER says whether this principal
 // is authorized to operate within MINT
-func (p *EUAPrincipal) AllowMINT() bool {
-	return p.JobCodeMINT
+func (p *EUAPrincipal) AllowUSER() bool {
+	return p.JobCodeUSER
 }
 
-// AllowADMIN says whether this principal
+// AllowASSESSMENT says whether this principal
 // is authorized to operate as part of
-// the Admin Team within MINT
-func (p *EUAPrincipal) AllowADMIN() bool {
-	return p.JobCodeADMIN
+// the Assessment Team within MINT
+func (p *EUAPrincipal) AllowASSESSMENT() bool {
+	return p.JobCodeASSESSMENT
 }

--- a/pkg/authentication/principal_test.go
+++ b/pkg/authentication/principal_test.go
@@ -10,34 +10,49 @@ import (
 
 func TestPrincipal(t *testing.T) {
 	// Arrange
-
-	// using current time for a bit of fuzzing
-	now := time.Now().Unix()
-	okMINT := bool(now%2 == 0)
-	okADMIN := bool(now%3 == 0)
-	id := fmt.Sprintf("%X", now)
+	id := fmt.Sprintf("%X", time.Now())
 
 	testCases := map[string]struct {
-		p           Principal
-		expectID    string
-		expectMINT  bool
-		expectADMIN bool
+		p                     Principal
+		expectID              string
+		expectAllowUser       bool
+		expectAllowAssessment bool
 	}{
 		"anonymous is unauthorized": {
-			p:           ANON,
-			expectID:    anonID,
-			expectMINT:  false,
-			expectADMIN: false,
+			p:                     ANON,
+			expectID:              anonID,
+			expectAllowUser:       false,
+			expectAllowAssessment: false,
 		},
 		"regular eua user": {
 			p: &EUAPrincipal{
-				EUAID:        id,
-				JobCodeMINT:  okMINT,
-				JobCodeADMIN: okADMIN,
+				EUAID:             id,
+				JobCodeUSER:       true,
+				JobCodeASSESSMENT: false,
 			},
-			expectID:    id,
-			expectMINT:  okMINT,
-			expectADMIN: okADMIN,
+			expectID:              id,
+			expectAllowUser:       true,
+			expectAllowAssessment: false,
+		},
+		"assessment user": {
+			p: &EUAPrincipal{
+				EUAID:             id,
+				JobCodeUSER:       false,
+				JobCodeASSESSMENT: true,
+			},
+			expectID:              id,
+			expectAllowUser:       false,
+			expectAllowAssessment: true,
+		},
+		"both users": {
+			p: &EUAPrincipal{
+				EUAID:             id,
+				JobCodeUSER:       true,
+				JobCodeASSESSMENT: true,
+			},
+			expectID:              id,
+			expectAllowUser:       true,
+			expectAllowAssessment: true,
 		},
 	}
 
@@ -49,8 +64,8 @@ func TestPrincipal(t *testing.T) {
 			assert.NotEmpty(t, tc.p.String(), "fmt.Stringer")
 			assert.NotEmpty(t, tc.p.ID(), "ID()")
 			assert.Equal(t, tc.expectID, tc.p.ID(), "ID()")
-			assert.Equal(t, tc.expectMINT, tc.p.AllowMINT(), "AllowMINT()")
-			assert.Equal(t, tc.expectADMIN, tc.p.AllowADMIN(), "AllowADMIN()")
+			assert.Equal(t, tc.expectAllowUser, tc.p.AllowUSER(), "AllowUSER()")
+			assert.Equal(t, tc.expectAllowAssessment, tc.p.AllowASSESSMENT(), "AllowASSESSMENT()")
 		})
 	}
 }

--- a/pkg/flags/client.go
+++ b/pkg/flags/client.go
@@ -41,7 +41,7 @@ func Principal(ctx context.Context) lduser.User {
 	// is an Anonymous user. Over time, may want to consider adding
 	// a `func Anonymous() bool` accessor to the authorizaion.Principal interface
 	// definition instead of doing this inference
-	authed := (p.AllowMINT() || p.AllowADMIN())
+	authed := (p.AllowUSER() || p.AllowASSESSMENT())
 
 	return lduser.
 		NewUserBuilder(key).

--- a/pkg/flags/client_test.go
+++ b/pkg/flags/client_test.go
@@ -30,14 +30,14 @@ func TestPrincipal(t *testing.T) {
 		"submitter": {
 			appcontext.WithPrincipal(
 				context.Background(),
-				&authentication.EUAPrincipal{EUAID: "MINT", JobCodeMINT: true},
+				&authentication.EUAPrincipal{EUAID: "MINT", JobCodeUSER: true},
 			),
 			false,
 		},
 		"reviewer": {
 			appcontext.WithPrincipal(
 				context.Background(),
-				&authentication.EUAPrincipal{EUAID: "BOSS", JobCodeADMIN: true},
+				&authentication.EUAPrincipal{EUAID: "BOSS", JobCodeASSESSMENT: true},
 			),
 			false,
 		},

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -6469,84 +6469,84 @@ Mutations definition for the schema
 """
 type Mutation {
 createModelPlan(modelName: String!): ModelPlan!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updateModelPlan(id: UUID!, changes: ModelPlanChanges!): ModelPlan!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 createPlanCollaborator(input: PlanCollaboratorCreateInput!): PlanCollaborator!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanCollaborator(id: UUID!, newRole: TeamRole!): PlanCollaborator!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 deletePlanCollaborator(id: UUID!): PlanCollaborator!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanBasics(id: UUID!, changes: PlanBasicsChanges!): PlanBasics!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanGeneralCharacteristics(id: UUID!, changes: PlanGeneralCharacteristicsChanges!): PlanGeneralCharacteristics!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanBeneficiaries(id: UUID!, changes: PlanBeneficiariesChanges!): PlanBeneficiaries!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanParticipantsAndProviders(id: UUID!, changes: PlanParticipantsAndProvidersChanges!): PlanParticipantsAndProviders!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanItTools(id: UUID!, changes:PlanITToolsChanges!): PlanITTools!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanOpsEvalAndLearning(id: UUID!, changes: PlanOpsEvalAndLearningChanges!): PlanOpsEvalAndLearning!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 generatePresignedUploadURL(input: GeneratePresignedUploadURLInput!): GeneratePresignedUploadURLPayload!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 createPlanDocument(input: PlanDocumentInput!): PlanDocumentPayload!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanDocument(input: PlanDocumentInput!): PlanDocumentPayload!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 deletePlanDocument(input: PlanDocumentInput!): Int!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 createPlanDiscussion(input: PlanDiscussionCreateInput!): PlanDiscussion!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanDiscussion(id: UUID!, changes: PlanDiscussionChanges!): PlanDiscussion!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 deletePlanDiscussion(id: UUID!): PlanDiscussion!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 createDiscussionReply(input: DiscussionReplyCreateInput!): DiscussionReply!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updateDiscussionReply(id: UUID!, changes: DiscussionReplyChanges!): DiscussionReply!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 deleteDiscussionReply(id: UUID!): DiscussionReply!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 lockTaskListSection(modelPlanID: UUID!, section: TaskListSection!): Boolean!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 unlockTaskListSection(modelPlanID: UUID!, section: TaskListSection!): Boolean!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 unlockAllTaskListSections(modelPlanID: UUID!): [TaskListSectionLockStatus!]!
-@hasRole(role: MINT_ADMIN_USER)
+@hasRole(role: MINT_ASSESSMENT)
 
 updatePlanPayments(id: UUID!, changes: PlanPaymentsChanges!): PlanPayments!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 }
 
 type Subscription {
   onTaskListSectionLocksChanged(modelPlanID: UUID!): TaskListSectionLockStatusChanged!
-  @hasRole(role: MINT_BASE_USER)
+  @hasRole(role: MINT_USER)
 }
 
 enum ChangeType {
@@ -7153,12 +7153,12 @@ enum Role {
   """
   A basic MINT user
   """
-  MINT_BASE_USER
+  MINT_USER
 
   """
-  A MINT admin user
+  A MINT assessment team user
   """
-  MINT_ADMIN_USER
+  MINT_ASSESSMENT
 }
 `, BuiltIn: false},
 }
@@ -10934,7 +10934,7 @@ func (ec *executionContext) _Mutation_createModelPlan(ctx context.Context, field
 			return ec.resolvers.Mutation().CreateModelPlan(rctx, fc.Args["modelName"].(string))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -11051,7 +11051,7 @@ func (ec *executionContext) _Mutation_updateModelPlan(ctx context.Context, field
 			return ec.resolvers.Mutation().UpdateModelPlan(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -11168,7 +11168,7 @@ func (ec *executionContext) _Mutation_createPlanCollaborator(ctx context.Context
 			return ec.resolvers.Mutation().CreatePlanCollaborator(rctx, fc.Args["input"].(model.PlanCollaboratorCreateInput))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -11267,7 +11267,7 @@ func (ec *executionContext) _Mutation_updatePlanCollaborator(ctx context.Context
 			return ec.resolvers.Mutation().UpdatePlanCollaborator(rctx, fc.Args["id"].(uuid.UUID), fc.Args["newRole"].(models.TeamRole))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -11366,7 +11366,7 @@ func (ec *executionContext) _Mutation_deletePlanCollaborator(ctx context.Context
 			return ec.resolvers.Mutation().DeletePlanCollaborator(rctx, fc.Args["id"].(uuid.UUID))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -11465,7 +11465,7 @@ func (ec *executionContext) _Mutation_updatePlanBasics(ctx context.Context, fiel
 			return ec.resolvers.Mutation().UpdatePlanBasics(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -11606,7 +11606,7 @@ func (ec *executionContext) _Mutation_updatePlanGeneralCharacteristics(ctx conte
 			return ec.resolvers.Mutation().UpdatePlanGeneralCharacteristics(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -11807,7 +11807,7 @@ func (ec *executionContext) _Mutation_updatePlanBeneficiaries(ctx context.Contex
 			return ec.resolvers.Mutation().UpdatePlanBeneficiaries(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -11948,7 +11948,7 @@ func (ec *executionContext) _Mutation_updatePlanParticipantsAndProviders(ctx con
 			return ec.resolvers.Mutation().UpdatePlanParticipantsAndProviders(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -12139,7 +12139,7 @@ func (ec *executionContext) _Mutation_updatePlanItTools(ctx context.Context, fie
 			return ec.resolvers.Mutation().UpdatePlanItTools(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -12400,7 +12400,7 @@ func (ec *executionContext) _Mutation_updatePlanOpsEvalAndLearning(ctx context.C
 			return ec.resolvers.Mutation().UpdatePlanOpsEvalAndLearning(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -12685,7 +12685,7 @@ func (ec *executionContext) _Mutation_generatePresignedUploadURL(ctx context.Con
 			return ec.resolvers.Mutation().GeneratePresignedUploadURL(rctx, fc.Args["input"].(model.GeneratePresignedUploadURLInput))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -12768,7 +12768,7 @@ func (ec *executionContext) _Mutation_createPlanDocument(ctx context.Context, fi
 			return ec.resolvers.Mutation().CreatePlanDocument(rctx, fc.Args["input"].(model.PlanDocumentInput))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -12853,7 +12853,7 @@ func (ec *executionContext) _Mutation_updatePlanDocument(ctx context.Context, fi
 			return ec.resolvers.Mutation().UpdatePlanDocument(rctx, fc.Args["input"].(model.PlanDocumentInput))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -12938,7 +12938,7 @@ func (ec *executionContext) _Mutation_deletePlanDocument(ctx context.Context, fi
 			return ec.resolvers.Mutation().DeletePlanDocument(rctx, fc.Args["input"].(model.PlanDocumentInput))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -13017,7 +13017,7 @@ func (ec *executionContext) _Mutation_createPlanDiscussion(ctx context.Context, 
 			return ec.resolvers.Mutation().CreatePlanDiscussion(rctx, fc.Args["input"].(model.PlanDiscussionCreateInput))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -13116,7 +13116,7 @@ func (ec *executionContext) _Mutation_updatePlanDiscussion(ctx context.Context, 
 			return ec.resolvers.Mutation().UpdatePlanDiscussion(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -13215,7 +13215,7 @@ func (ec *executionContext) _Mutation_deletePlanDiscussion(ctx context.Context, 
 			return ec.resolvers.Mutation().DeletePlanDiscussion(rctx, fc.Args["id"].(uuid.UUID))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -13314,7 +13314,7 @@ func (ec *executionContext) _Mutation_createDiscussionReply(ctx context.Context,
 			return ec.resolvers.Mutation().CreateDiscussionReply(rctx, fc.Args["input"].(model.DiscussionReplyCreateInput))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -13411,7 +13411,7 @@ func (ec *executionContext) _Mutation_updateDiscussionReply(ctx context.Context,
 			return ec.resolvers.Mutation().UpdateDiscussionReply(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -13508,7 +13508,7 @@ func (ec *executionContext) _Mutation_deleteDiscussionReply(ctx context.Context,
 			return ec.resolvers.Mutation().DeleteDiscussionReply(rctx, fc.Args["id"].(uuid.UUID))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -13605,7 +13605,7 @@ func (ec *executionContext) _Mutation_lockTaskListSection(ctx context.Context, f
 			return ec.resolvers.Mutation().LockTaskListSection(rctx, fc.Args["modelPlanID"].(uuid.UUID), fc.Args["section"].(model.TaskListSection))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -13684,7 +13684,7 @@ func (ec *executionContext) _Mutation_unlockTaskListSection(ctx context.Context,
 			return ec.resolvers.Mutation().UnlockTaskListSection(rctx, fc.Args["modelPlanID"].(uuid.UUID), fc.Args["section"].(model.TaskListSection))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -13763,7 +13763,7 @@ func (ec *executionContext) _Mutation_unlockAllTaskListSections(ctx context.Cont
 			return ec.resolvers.Mutation().UnlockAllTaskListSections(rctx, fc.Args["modelPlanID"].(uuid.UUID))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_ADMIN_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_ASSESSMENT")
 			if err != nil {
 				return nil, err
 			}
@@ -13852,7 +13852,7 @@ func (ec *executionContext) _Mutation_updatePlanPayments(ctx context.Context, fi
 			return ec.resolvers.Mutation().UpdatePlanPayments(rctx, fc.Args["id"].(uuid.UUID), fc.Args["changes"].(map[string]interface{}))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}
@@ -34919,7 +34919,7 @@ func (ec *executionContext) _Subscription_onTaskListSectionLocksChanged(ctx cont
 			return ec.resolvers.Subscription().OnTaskListSectionLocksChanged(rctx, fc.Args["modelPlanID"].(uuid.UUID))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_BASE_USER")
+			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -2543,19 +2543,19 @@ type Role string
 
 const (
 	// A basic MINT user
-	RoleMintBaseUser Role = "MINT_BASE_USER"
-	// A MINT admin user
-	RoleMintAdminUser Role = "MINT_ADMIN_USER"
+	RoleMintUser Role = "MINT_USER"
+	// A MINT assessment team user
+	RoleMintAssessment Role = "MINT_ASSESSMENT"
 )
 
 var AllRole = []Role{
-	RoleMintBaseUser,
-	RoleMintAdminUser,
+	RoleMintUser,
+	RoleMintAssessment,
 }
 
 func (e Role) IsValid() bool {
 	switch e {
-	case RoleMintBaseUser, RoleMintAdminUser:
+	case RoleMintUser, RoleMintAssessment:
 		return true
 	}
 	return false

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -1325,84 +1325,84 @@ Mutations definition for the schema
 """
 type Mutation {
 createModelPlan(modelName: String!): ModelPlan!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updateModelPlan(id: UUID!, changes: ModelPlanChanges!): ModelPlan!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 createPlanCollaborator(input: PlanCollaboratorCreateInput!): PlanCollaborator!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanCollaborator(id: UUID!, newRole: TeamRole!): PlanCollaborator!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 deletePlanCollaborator(id: UUID!): PlanCollaborator!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanBasics(id: UUID!, changes: PlanBasicsChanges!): PlanBasics!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanGeneralCharacteristics(id: UUID!, changes: PlanGeneralCharacteristicsChanges!): PlanGeneralCharacteristics!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanBeneficiaries(id: UUID!, changes: PlanBeneficiariesChanges!): PlanBeneficiaries!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanParticipantsAndProviders(id: UUID!, changes: PlanParticipantsAndProvidersChanges!): PlanParticipantsAndProviders!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanItTools(id: UUID!, changes:PlanITToolsChanges!): PlanITTools!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanOpsEvalAndLearning(id: UUID!, changes: PlanOpsEvalAndLearningChanges!): PlanOpsEvalAndLearning!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 generatePresignedUploadURL(input: GeneratePresignedUploadURLInput!): GeneratePresignedUploadURLPayload!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 createPlanDocument(input: PlanDocumentInput!): PlanDocumentPayload!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanDocument(input: PlanDocumentInput!): PlanDocumentPayload!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 deletePlanDocument(input: PlanDocumentInput!): Int!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 createPlanDiscussion(input: PlanDiscussionCreateInput!): PlanDiscussion!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updatePlanDiscussion(id: UUID!, changes: PlanDiscussionChanges!): PlanDiscussion!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 deletePlanDiscussion(id: UUID!): PlanDiscussion!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 createDiscussionReply(input: DiscussionReplyCreateInput!): DiscussionReply!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 updateDiscussionReply(id: UUID!, changes: DiscussionReplyChanges!): DiscussionReply!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 deleteDiscussionReply(id: UUID!): DiscussionReply!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 lockTaskListSection(modelPlanID: UUID!, section: TaskListSection!): Boolean!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 unlockTaskListSection(modelPlanID: UUID!, section: TaskListSection!): Boolean!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 
 unlockAllTaskListSections(modelPlanID: UUID!): [TaskListSectionLockStatus!]!
-@hasRole(role: MINT_ADMIN_USER)
+@hasRole(role: MINT_ASSESSMENT)
 
 updatePlanPayments(id: UUID!, changes: PlanPaymentsChanges!): PlanPayments!
-@hasRole(role: MINT_BASE_USER)
+@hasRole(role: MINT_USER)
 }
 
 type Subscription {
   onTaskListSectionLocksChanged(modelPlanID: UUID!): TaskListSectionLockStatusChanged!
-  @hasRole(role: MINT_BASE_USER)
+  @hasRole(role: MINT_USER)
 }
 
 enum ChangeType {
@@ -2009,10 +2009,10 @@ enum Role {
   """
   A basic MINT user
   """
-  MINT_BASE_USER
+  MINT_USER
 
   """
-  A MINT admin user
+  A MINT assessment team user
   """
-  MINT_ADMIN_USER
+  MINT_ASSESSMENT
 }

--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -58,9 +58,9 @@ func authenticateMiddleware(logger *zap.Logger, next http.Handler) http.Handler 
 
 		logger.Info("Using local authorization middleware and populating EUA ID and job codes")
 		ctx := appcontext.WithPrincipal(r.Context(), &authentication.EUAPrincipal{
-			EUAID:        config.EUA,
-			JobCodeMINT:  true,
-			JobCodeADMIN: swag.ContainsStrings(config.JobCodes, "MINT_D_ADMIN_USER"),
+			EUAID:             config.EUA,
+			JobCodeUSER:       true,
+			JobCodeASSESSMENT: swag.ContainsStrings(config.JobCodes, "MINT_D_ADMIN_USER"),
 		})
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/pkg/okta/authentication_middleware_test.go
+++ b/pkg/okta/authentication_middleware_test.go
@@ -63,7 +63,6 @@ func (s *AuthenticationMiddlewareTestSuite) buildMiddleware(verify func(jwt stri
 	return NewOktaAuthenticationMiddleware(
 		handlers.NewHandlerBase(s.logger),
 		verifier,
-		false,
 	)
 
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -88,7 +88,6 @@ func (s Server) NewCEDARClientCheck() {
 
 // OktaClientConfig is the okta client configuration
 type OktaClientConfig struct {
-	AltJobCodes  bool
 	OktaClientID string
 	OktaIssuer   string
 }
@@ -101,7 +100,6 @@ func (s Server) NewOktaClientConfig() OktaClientConfig {
 	return OktaClientConfig{
 		OktaClientID: s.Config.GetString(appconfig.OktaClientID),
 		OktaIssuer:   s.Config.GetString(appconfig.OktaIssuer),
-		AltJobCodes:  s.Config.GetBool(appconfig.AltJobCodes),
 	}
 }
 

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -49,7 +49,6 @@ func (s *Server) routes(
 	oktaAuthenticationMiddleware := okta.NewOktaAuthenticationMiddleware(
 		handlers.NewHandlerBase(s.logger),
 		jwtVerifier,
-		oktaConfig.AltJobCodes,
 	)
 
 	s.router.Use(
@@ -218,19 +217,4 @@ func (s *Server) routes(
 			return nil
 		})
 	}
-	// endpoint for short-lived backfill process
-	// backfillHandler := handlers.NewBackfillHandler(
-	// 	base,
-	// 	services.NewBackfill(
-	// 		serviceConfig,
-	// 		store.FetchSystemIntakeByID,
-	// 		store.FetchSystemIntakeByLifecycleID,
-	// 		store.CreateSystemIntake,
-	// 		store.UpdateSystemIntake,
-	// 		store.CreateNote,
-	// 		services.AuthorizeHasEASiRole,
-	// 	),
-	// )
-	// api.Handle("/backfill", backfillHandler.Handle())
-
 }

--- a/pkg/services/auth.go
+++ b/pkg/services/auth.go
@@ -14,15 +14,15 @@ func HasRole(ctx context.Context, role model.Role) (bool, error) {
 	logger := appcontext.ZLogger(ctx)
 	principal := appcontext.Principal(ctx)
 	switch role {
-	case model.RoleMintBaseUser:
-		if !principal.AllowMINT() {
+	case model.RoleMintUser:
+		if !principal.AllowUSER() {
 			logger.Info("does not have EASi job code")
 			return false, nil
 		}
 		logger.Info("user authorized as EASi user", zap.Bool("Authorized", true))
 		return true, nil
-	case model.RoleMintAdminUser:
-		if !principal.AllowADMIN() {
+	case model.RoleMintAssessment:
+		if !principal.AllowASSESSMENT() {
 			logger.Info("does not have ADMIN job code")
 			return false, nil
 		}
@@ -32,15 +32,4 @@ func HasRole(ctx context.Context, role model.Role) (bool, error) {
 		logger.With(zap.String("Role", role.String())).Info("Unrecognized user role")
 		return false, nil
 	}
-}
-
-// AuthorizeHasEASiRole authorizes that the user can use EASi
-func AuthorizeHasEASiRole(ctx context.Context) (bool, error) {
-	return HasRole(ctx, model.RoleMintBaseUser)
-}
-
-// AuthorizeRequireADMINJobCode authorizes a user as being a member of the
-// ADMIN (MINT Admin Team)
-func AuthorizeRequireADMINJobCode(ctx context.Context) (bool, error) {
-	return HasRole(ctx, model.RoleMintAdminUser)
 }

--- a/pkg/services/auth_test.go
+++ b/pkg/services/auth_test.go
@@ -10,8 +10,8 @@ import (
 
 func (s *ServicesTestSuite) TestHasRole() {
 	fnAuth := HasRole
-	nonAdmin := authentication.EUAPrincipal{EUAID: "FAKE", JobCodeMINT: true, JobCodeADMIN: false}
-	yesADMIN := authentication.EUAPrincipal{EUAID: "FAKE", JobCodeMINT: true, JobCodeADMIN: true}
+	userPrincipal := authentication.EUAPrincipal{EUAID: "FAKE", JobCodeUSER: true, JobCodeASSESSMENT: false}
+	assessmentPrincipal := authentication.EUAPrincipal{EUAID: "FAKE", JobCodeUSER: false, JobCodeASSESSMENT: true}
 
 	testCases := map[string]struct {
 		ctx     context.Context
@@ -22,18 +22,18 @@ func (s *ServicesTestSuite) TestHasRole() {
 			allowed: false,
 		},
 		"non admin": {
-			ctx:     appcontext.WithPrincipal(context.Background(), &nonAdmin),
+			ctx:     appcontext.WithPrincipal(context.Background(), &userPrincipal),
 			allowed: false,
 		},
 		"has admin": {
-			ctx:     appcontext.WithPrincipal(context.Background(), &yesADMIN),
+			ctx:     appcontext.WithPrincipal(context.Background(), &assessmentPrincipal),
 			allowed: true,
 		},
 	}
 
 	for name, tc := range testCases {
 		s.Run(name, func() {
-			ok, err := fnAuth(tc.ctx, model.RoleMintAdminUser)
+			ok, err := fnAuth(tc.ctx, model.RoleMintAssessment)
 			s.NoError(err)
 			s.Equal(tc.allowed, ok)
 		})

--- a/pkg/testhelpers/authentication.go
+++ b/pkg/testhelpers/authentication.go
@@ -12,13 +12,13 @@ import (
 // NewRequesterPrincipal returns what represents an MINT user
 // that is NOT empowered as a Reviewer
 func NewRequesterPrincipal() authentication.Principal {
-	return &authentication.EUAPrincipal{EUAID: "REQ", JobCodeMINT: true, JobCodeADMIN: false}
+	return &authentication.EUAPrincipal{EUAID: "REQ", JobCodeUSER: true, JobCodeASSESSMENT: false}
 }
 
 // NewReviewerPrincipal returns what represents an MINT user
 // that is empowered as a member of the ADMIN.
 func NewReviewerPrincipal() authentication.Principal {
-	return &authentication.EUAPrincipal{EUAID: "REV", JobCodeMINT: true, JobCodeADMIN: true}
+	return &authentication.EUAPrincipal{EUAID: "REV", JobCodeUSER: true, JobCodeASSESSMENT: true}
 }
 
 // AddAuthPrincipalToGraphQLClientTest returns a function to add an auth principal to a graphql client test
@@ -32,8 +32,8 @@ func AddAuthPrincipalToGraphQLClientTest(principal authentication.EUAPrincipal) 
 // AddAuthWithAllJobCodesToGraphQLClientTest adds authentication for all job codes
 func AddAuthWithAllJobCodesToGraphQLClientTest(euaID string) func(*client.Request) {
 	return AddAuthPrincipalToGraphQLClientTest(authentication.EUAPrincipal{
-		EUAID:        euaID,
-		JobCodeMINT:  true,
-		JobCodeADMIN: true,
+		EUAID:             euaID,
+		JobCodeUSER:       true,
+		JobCodeASSESSMENT: true,
 	})
 }

--- a/src/constants/jobCodes.ts
+++ b/src/constants/jobCodes.ts
@@ -1,7 +1,6 @@
-export const BASIC_PROD = 'MINT_P_USER';
-export const ADMIN_DEV = 'MINT_D_ADMIN';
-export const ADMIN_PROD = 'MINT_P_ADMIN';
+export const BASIC = 'MINT_USER';
+export const ASSESSMENT = 'MINT_ASSESSMENT';
 
-export const JOB_CODES = [BASIC_PROD, ADMIN_DEV, ADMIN_PROD];
+export const JOB_CODES = [BASIC, ASSESSMENT];
 
 export default JOB_CODES;

--- a/src/utils/user.test.ts
+++ b/src/utils/user.test.ts
@@ -1,42 +1,58 @@
-import { ADMIN_DEV, ADMIN_PROD, BASIC_PROD } from 'constants/jobCodes';
+import { ASSESSMENT, BASIC } from 'constants/jobCodes';
 import { Flags } from 'types/flags';
 
-import { isAdmin, isBasicUser } from './user';
+import { isAssessment, isBasicUser } from './user';
 
 describe('user', () => {
-  describe('isAdmin', () => {
-    describe('groups', () => {
-      const flags = {} as Flags;
-      describe('dev job code exists in groups', () => {
-        const groups = [ADMIN_DEV];
-
-        it('returns true', () => {
-          expect(isAdmin(groups, flags)).toBe(true);
-        });
+  describe('isAssessment', () => {
+    const defaultFlags = {} as Flags;
+    describe('only user job code exists in groups', () => {
+      const groups = [BASIC];
+      it('returns false', () => {
+        expect(isAssessment(groups, defaultFlags)).toBe(false);
       });
+    });
 
-      describe('prod job code exists in groups', () => {
-        const groups = [ADMIN_PROD];
-
-        it('returns true', () => {
-          expect(isAdmin(groups, flags)).toBe(true);
-        });
+    describe('only assessment job code', () => {
+      const groups = [ASSESSMENT];
+      it('returns true', () => {
+        expect(isAssessment(groups, defaultFlags)).toBe(true);
       });
+    });
 
-      describe('no admin job code exists in groups', () => {
-        const groups = [BASIC_PROD];
+    describe('both job codes', () => {
+      const groups = [BASIC, ASSESSMENT];
+      it('returns true', () => {
+        expect(isAssessment(groups, defaultFlags)).toBe(true);
+      });
+    });
 
-        it('returns false', () => {
-          expect(isAdmin(groups, flags)).toBe(false);
-        });
+    describe('no job code exists in groups', () => {
+      const groups: Array<String> = [];
+      it('returns false', () => {
+        expect(isAssessment(groups, defaultFlags)).toBe(false);
       });
     });
   });
 
   describe('isBasicUser', () => {
     const defaultFlags = {} as Flags;
-    describe('prod user job code exists in groups', () => {
-      const groups = [BASIC_PROD];
+    describe('only user job code exists in groups', () => {
+      const groups = [BASIC];
+      it('returns true', () => {
+        expect(isBasicUser(groups, defaultFlags)).toBe(true);
+      });
+    });
+
+    describe('only assessment job code', () => {
+      const groups = [ASSESSMENT];
+      it('returns false', () => {
+        expect(isBasicUser(groups, defaultFlags)).toBe(false);
+      });
+    });
+
+    describe('both job codes', () => {
+      const groups = [BASIC, ASSESSMENT];
       it('returns true', () => {
         expect(isBasicUser(groups, defaultFlags)).toBe(true);
       });
@@ -44,8 +60,8 @@ describe('user', () => {
 
     describe('no job code exists in groups', () => {
       const groups: Array<String> = [];
-      it('returns true', () => {
-        expect(isBasicUser(groups, defaultFlags)).toBe(true);
+      it('returns false', () => {
+        expect(isBasicUser(groups, defaultFlags)).toBe(false);
       });
     });
   });

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,8 +1,8 @@
-import { ADMIN_DEV, ADMIN_PROD, BASIC_PROD } from 'constants/jobCodes';
+import { ASSESSMENT, BASIC } from 'constants/jobCodes';
 import { Flags } from 'types/flags';
 
-export const isAdmin = (groups: Array<String> = [], flags: Flags) => {
-  if (groups.includes(ADMIN_DEV) || groups.includes(ADMIN_PROD)) {
+export const isAssessment = (groups: Array<String> = [], flags: Flags) => {
+  if (groups.includes(ASSESSMENT)) {
     return true;
   }
 
@@ -10,20 +10,15 @@ export const isAdmin = (groups: Array<String> = [], flags: Flags) => {
 };
 
 export const isBasicUser = (groups: Array<String> = [], flags: Flags) => {
-  if (groups.includes(BASIC_PROD)) {
+  if (groups.includes(BASIC)) {
     return true;
   }
-  if (groups.length === 0) {
-    return true;
-  }
-  if (!isAdmin(groups, flags)) {
-    return true;
-  }
+
   return false;
 };
 
 const user = {
-  isAdmin,
+  isAssessment,
   isBasicUser
 };
 

--- a/src/views/Home/index.test.tsx
+++ b/src/views/Home/index.test.tsx
@@ -8,7 +8,7 @@ import { mockFlags, resetLDMocks } from 'jest-launchdarkly-mock';
 import configureMockStore from 'redux-mock-store';
 
 import UswdsReactLink from 'components/LinkWrapper';
-import { ADMIN_PROD } from 'constants/jobCodes';
+import { ASSESSMENT } from 'constants/jobCodes';
 import { MessageProvider } from 'hooks/useMessage';
 import { Flags } from 'types/flags';
 import Table from 'views/ModelPlan/Table';
@@ -63,7 +63,7 @@ describe('The home page', () => {
   describe('is a admin user', () => {
     const mockAuthReducer = {
       isUserSet: true,
-      groups: [ADMIN_PROD]
+      groups: [ASSESSMENT]
     };
 
     describe('User is logged in', () => {

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -51,7 +51,7 @@ const Home = () => {
               </p>
               <UswdsReactLink
                 className={classnames('usa-button', {
-                  'usa-button--outline': user.isAdmin(userGroups, flags)
+                  'usa-button--outline': user.isAssessment(userGroups, flags)
                 })}
                 variant="unstyled"
                 to="/models/steps-overview"
@@ -62,7 +62,7 @@ const Home = () => {
             <hr className="home__hr margin-top-4" aria-hidden />
             <div className="mint-header__basic">
               <h2 className="margin-top-4">
-                {user.isAdmin(userGroups, flags)
+                {user.isAssessment(userGroups, flags)
                   ? t('requestsTable.admin.heading')
                   : t('requestsTable.basic.heading')}
               </h2>

--- a/src/views/User/index.tsx
+++ b/src/views/User/index.tsx
@@ -26,7 +26,9 @@ const UserInfo = () => {
           ))}
         </ul>
         <p>User is basic user: {`${user.isBasicUser(userGroups, flags)}`}</p>
-        <p>User is admin user: {`${user.isAdmin(userGroups, flags)}`}</p>
+        <p>
+          User is assessment user: {`${user.isAssessment(userGroups, flags)}`}
+        </p>
 
         <h2>Raw Access Token Claims</h2>
         <pre>


### PR DESCRIPTION
# NOREF

## Changes and Description

- Rename hard-coded job codes to better reflect what we'll create with the IDM team
- Rename GQL roles to match job code names (this doesn't have to happen, but is somewhat nice IMO)

<!-- Put a description here! -->

## How to test this change

1. Use `scripts/dev up` to start up MINT.
2. Login (local auth or the EZOD account, for that matter).
3. Navigate to http://localhost:8085/user-diagnostics to see information about the user.
4. Try different GQL queries/mutations that require different roles.

## What's left to do / open questions
- Should the frontend allow access to Secure routes if `isBasicUser` is `false`? It seems there were some assumptions around "successful Okta auth" being the same as "you're a basic user", but the presence of a job code would make me think that's not a good thing to assume - CC @patrickseguraoddball @StevenWadeOddball 

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
