### PR TITLE
[NOREF] - Fixed discussion rerender/refetch

### DIFF
--- a/src/views/ModelPlan/Discussions/index.tsx
+++ b/src/views/ModelPlan/Discussions/index.tsx
@@ -179,15 +179,16 @@ const Discussions = ({
         if (!response?.errors) {
           if (discussionType === 'reply' && reply?.id) {
             handleUpdateDiscussion(reply.id);
+          } else {
+            refetch().then(() => {
+              setInitQuestion(false);
+              setDiscussionType('discussion');
+            });
           }
           setDiscussionStatus('success');
           setDiscussionStatusMessage(
             discussionType === 'question' ? t('success') : t('successAnswer')
           );
-          refetch().then(() => {
-            setInitQuestion(false);
-            setDiscussionType('discussion');
-          });
         }
       })
       .catch(() => {


### PR DESCRIPTION
# NOREF

## Changes and Description

- Updated the conditional on discussions refetch after the creation of a new discussion

The fixed conditional addresses a race condition between two refetches (now only one should fire)

## How to test this change

Create some discussions and replies.  Ensure the discussions and replies are rendered in the correct category

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Tested user-facing changes with voice-over and the [rotor menu](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac)


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
