### PR TITLE
[NOREF] Modified conditional to locks section

### DIFF
--- a/src/views/SubscriptionHandler/index.tsx
+++ b/src/views/SubscriptionHandler/index.tsx
@@ -72,6 +72,7 @@ const SubscriptionHandler = ({ children }: SubscriptionHandlerProps) => {
   // Gets the modelID and tasklist section route from any location within the application
   const { pathname } = useLocation();
   const modelID = pathname.split('/')[2];
+  const taskList = pathname.split('/')[3] === 'task-list';
   const taskListRoute = pathname.split('/')[4];
 
   const history = useHistory();
@@ -191,6 +192,7 @@ const SubscriptionHandler = ({ children }: SubscriptionHandlerProps) => {
   // Checks to see if section should be locked and calls mutation to add lock
   if (
     lockState === LockStatus.UNLOCKED &&
+    taskList &&
     taskListSection &&
     validModelID &&
     !addLockLoading &&


### PR DESCRIPTION
NOREF

## Changes and Description

- Modified conditional for checking if section should be locked

Previously, the locking mutation was checking for a valid task-list section.  This conflicted with identical route names for read-only routes.  Added a conditional to ensure the route lives under 'task-list' and not 'read-only'

## How to test this change

-  Navigate to a read-only route
-  Within postman or another browser tab, navigate to the same model's task list
- Ensure the read-only route has not locked the task list

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
