### PR TITLE
[NOREF] - Fixed issue where READY status was in final page mutation

### DIFF
--- a/src/utils/status.ts
+++ b/src/utils/status.ts
@@ -1,0 +1,10 @@
+// Util functions for status of Model plan and task list sections
+
+import { TaskStatus } from 'types/graphql-global-types';
+
+// Util function for prepping TaskStatus for mutation input of TaskStatusInput
+const sanitizeStatus = (status: TaskStatus) => {
+  return status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status;
+};
+
+export default sanitizeStatus;

--- a/src/utils/status.ts
+++ b/src/utils/status.ts
@@ -1,10 +1,12 @@
 // Util functions for status of Model plan and task list sections
 
-import { TaskStatus } from 'types/graphql-global-types';
+import { TaskStatus, TaskStatusInput } from 'types/graphql-global-types';
 
 // Util function for prepping TaskStatus for mutation input of TaskStatusInput
-const sanitizeStatus = (status: TaskStatus) => {
-  return status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status;
+const sanitizeStatus = (status: TaskStatus): TaskStatusInput => {
+  return status === TaskStatus.READY
+    ? TaskStatusInput.IN_PROGRESS
+    : TaskStatusInput[status];
 };
 
 export default sanitizeStatus;

--- a/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
@@ -31,8 +31,8 @@ import {
 } from 'queries/Basics/types/GetMilestones';
 import { UpdatePlanBasicsVariables } from 'queries/Basics/types/UpdatePlanBasics';
 import UpdatePlanBasics from 'queries/Basics/UpdatePlanBasics';
-import { TaskStatus } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import sanitizeStatus from 'utils/status';
 import planBasicsSchema from 'validations/planBasics';
 import { NotFoundPartial } from 'views/NotFound';
 
@@ -126,7 +126,7 @@ const Milestones = () => {
     highLevelNote: highLevelNote ?? '',
     phasedIn: phasedIn ?? null,
     phasedInNote: phasedInNote ?? '',
-    status: status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status
+    status: sanitizeStatus(status)
   };
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {

--- a/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
@@ -31,6 +31,7 @@ import {
 } from 'queries/Basics/types/GetMilestones';
 import { UpdatePlanBasicsVariables } from 'queries/Basics/types/UpdatePlanBasics';
 import UpdatePlanBasics from 'queries/Basics/UpdatePlanBasics';
+import { TaskStatus } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
 import planBasicsSchema from 'validations/planBasics';
 import { NotFoundPartial } from 'views/NotFound';
@@ -125,7 +126,7 @@ const Milestones = () => {
     highLevelNote: highLevelNote ?? '',
     phasedIn: phasedIn ?? null,
     phasedInNote: phasedInNote ?? '',
-    status
+    status: status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status
   };
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {

--- a/src/views/ModelPlan/TaskList/Beneficiaries/Frequency/index.tsx
+++ b/src/views/ModelPlan/TaskList/Beneficiaries/Frequency/index.tsx
@@ -35,17 +35,14 @@ import {
 } from 'queries/Beneficiaries/types/GetFrequency';
 import { UpdateModelPlanBeneficiariesVariables } from 'queries/Beneficiaries/types/UpdateModelPlanBeneficiaries';
 import UpdateModelPlanBeneficiaries from 'queries/Beneficiaries/UpdateModelPlanBeneficiaries';
-import {
-  FrequencyType,
-  OverlapType,
-  TaskStatus
-} from 'types/graphql-global-types';
+import { FrequencyType, OverlapType } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
 import {
   sortOtherEnum,
   translateFrequencyType,
   translateOverlapType
 } from 'utils/modelPlan';
+import sanitizeStatus from 'utils/status';
 import { NotFoundPartial } from 'views/NotFound';
 
 const Frequency = () => {
@@ -127,7 +124,7 @@ const Frequency = () => {
     beneficiaryOverlap: beneficiaryOverlap ?? null,
     beneficiaryOverlapNote: beneficiaryOverlapNote ?? '',
     precedenceRules: precedenceRules ?? '',
-    status: status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status
+    status: sanitizeStatus(status)
   };
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {

--- a/src/views/ModelPlan/TaskList/Beneficiaries/Frequency/index.tsx
+++ b/src/views/ModelPlan/TaskList/Beneficiaries/Frequency/index.tsx
@@ -35,7 +35,11 @@ import {
 } from 'queries/Beneficiaries/types/GetFrequency';
 import { UpdateModelPlanBeneficiariesVariables } from 'queries/Beneficiaries/types/UpdateModelPlanBeneficiaries';
 import UpdateModelPlanBeneficiaries from 'queries/Beneficiaries/UpdateModelPlanBeneficiaries';
-import { FrequencyType, OverlapType } from 'types/graphql-global-types';
+import {
+  FrequencyType,
+  OverlapType,
+  TaskStatus
+} from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
 import {
   sortOtherEnum,
@@ -123,7 +127,7 @@ const Frequency = () => {
     beneficiaryOverlap: beneficiaryOverlap ?? null,
     beneficiaryOverlapNote: beneficiaryOverlapNote ?? '',
     precedenceRules: precedenceRules ?? '',
-    status
+    status: status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status
   };
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/Authority/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/Authority/index.tsx
@@ -34,7 +34,11 @@ import {
 } from 'queries/GeneralCharacteristics/types/GetAuthority';
 import { UpdatePlanGeneralCharacteristicsVariables } from 'queries/GeneralCharacteristics/types/UpdatePlanGeneralCharacteristics';
 import UpdatePlanGeneralCharacteristics from 'queries/GeneralCharacteristics/UpdatePlanGeneralCharacteristics';
-import { AuthorityAllowance, WaiverType } from 'types/graphql-global-types';
+import {
+  AuthorityAllowance,
+  TaskStatus,
+  WaiverType
+} from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
 import {
   sortOtherEnum,
@@ -127,7 +131,7 @@ const Authority = () => {
     waiversRequired: waiversRequired ?? null,
     waiversRequiredTypes: waiversRequiredTypes ?? [],
     waiversRequiredNote: waiversRequiredNote ?? '',
-    status
+    status: status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status
   };
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/Authority/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/Authority/index.tsx
@@ -34,17 +34,14 @@ import {
 } from 'queries/GeneralCharacteristics/types/GetAuthority';
 import { UpdatePlanGeneralCharacteristicsVariables } from 'queries/GeneralCharacteristics/types/UpdatePlanGeneralCharacteristics';
 import UpdatePlanGeneralCharacteristics from 'queries/GeneralCharacteristics/UpdatePlanGeneralCharacteristics';
-import {
-  AuthorityAllowance,
-  TaskStatus,
-  WaiverType
-} from 'types/graphql-global-types';
+import { AuthorityAllowance, WaiverType } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
 import {
   sortOtherEnum,
   translateAuthorityAllowance,
   translateWaiverTypes
 } from 'utils/modelPlan';
+import sanitizeStatus from 'utils/status';
 import { NotFoundPartial } from 'views/NotFound';
 
 const Authority = () => {
@@ -131,7 +128,7 @@ const Authority = () => {
     waiversRequired: waiversRequired ?? null,
     waiversRequiredTypes: waiversRequiredTypes ?? [],
     waiversRequiredNote: waiversRequiredNote ?? '',
-    status: status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status
+    status: sanitizeStatus(status)
   };
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Learning/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Learning/index.tsx
@@ -43,6 +43,7 @@ import {
   sortOtherEnum,
   translateModelLearningSystemType
 } from 'utils/modelPlan';
+import sanitizeStatus from 'utils/status';
 import { NotFoundPartial } from 'views/NotFound';
 
 import { isCCWInvolvement, renderCurrentPage, renderTotalPages } from '..';
@@ -133,7 +134,7 @@ const Learning = () => {
     modelLearningSystemsOther: modelLearningSystemsOther ?? '',
     modelLearningSystemsNote: modelLearningSystemsNote ?? '',
     anticipatedChallenges: anticipatedChallenges ?? '',
-    status: status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status
+    status: sanitizeStatus(status)
   };
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Learning/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Learning/index.tsx
@@ -133,7 +133,7 @@ const Learning = () => {
     modelLearningSystemsOther: modelLearningSystemsOther ?? '',
     modelLearningSystemsNote: modelLearningSystemsNote ?? '',
     anticipatedChallenges: anticipatedChallenges ?? '',
-    status
+    status: status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status
   };
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ProviderOptions/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ProviderOptions/index.tsx
@@ -39,8 +39,7 @@ import {
   FrequencyType,
   OverlapType,
   ProviderAddType,
-  ProviderLeaveType,
-  TaskStatus
+  ProviderLeaveType
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
 import {
@@ -51,6 +50,7 @@ import {
   translateProviderAddType,
   translateProviderLeaveType
 } from 'utils/modelPlan';
+import sanitizeStatus from 'utils/status';
 import { NotFoundPartial } from 'views/NotFound';
 
 export const ProviderOptions = () => {
@@ -145,7 +145,7 @@ export const ProviderOptions = () => {
     providerOverlap: providerOverlap ?? null,
     providerOverlapHierarchy: providerOverlapHierarchy ?? '',
     providerOverlapNote: providerOverlapNote ?? '',
-    status: status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status
+    status: sanitizeStatus(status)
   };
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ProviderOptions/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ProviderOptions/index.tsx
@@ -39,7 +39,8 @@ import {
   FrequencyType,
   OverlapType,
   ProviderAddType,
-  ProviderLeaveType
+  ProviderLeaveType,
+  TaskStatus
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
 import {
@@ -144,7 +145,7 @@ export const ProviderOptions = () => {
     providerOverlap: providerOverlap ?? null,
     providerOverlapHierarchy: providerOverlapHierarchy ?? '',
     providerOverlapNote: providerOverlapNote ?? '',
-    status
+    status: status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status
   };
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {

--- a/src/views/ModelPlan/TaskList/Payment/Recover/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/Recover/index.tsx
@@ -44,6 +44,7 @@ import {
   TaskStatus
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import sanitizeStatus from 'utils/status';
 import { NotFoundPartial } from 'views/NotFound';
 
 import { renderCurrentPage, renderTotalPages } from '..';
@@ -151,7 +152,7 @@ const Recover = () => {
       anticipateReconcilingPaymentsRetrospectivelyNote ?? '',
     paymentStartDate: paymentStartDate ?? '',
     paymentStartDateNote: paymentStartDateNote ?? '',
-    status: status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status
+    status: sanitizeStatus(status)
   };
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {

--- a/src/views/ModelPlan/TaskList/Payment/Recover/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/Recover/index.tsx
@@ -151,7 +151,7 @@ const Recover = () => {
       anticipateReconcilingPaymentsRetrospectivelyNote ?? '',
     paymentStartDate: paymentStartDate ?? '',
     paymentStartDateNote: paymentStartDateNote ?? '',
-    status
+    status: status === TaskStatus.READY ? TaskStatus.IN_PROGRESS : status
   };
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {


### PR DESCRIPTION
# NOREF

## Changes and Description

- Ensured that the final pages of task list sections were not autosaving with `READY` status

There was a case where a user would land on the final page of a task list section without ever visiting the previous pages via IT Tools redirect.  The section would then have a status of ready, and attempting to send mutation with that status.  This PR addresses final pages of section to ensure that the status converts to IN_PROGRESS if status is READY.

## How to test this change

- Enter an empty plan and navigate to IT Tools, page seven, question two
- Redirect to the corresponding question and wait for the autosave (or save quickly).  
- Verify no gql errors with mutation


## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
