### PR TITLE
[NOREF] Query All models or just "My" models

### DIFF
--- a/pkg/graph/resolvers/model_plan.go
+++ b/pkg/graph/resolvers/model_plan.go
@@ -150,11 +150,17 @@ func ModelPlanGetByID(logger *zap.Logger, id uuid.UUID, store *storage.Store) (*
 }
 
 // ModelPlanCollection implements resolver logic to get a list of model plans by who's a collaborator on them (TODO)
-func ModelPlanCollection(logger *zap.Logger, principal authentication.Principal, store *storage.Store) ([]*models.ModelPlan, error) {
-	plans, err := store.ModelPlanCollection(logger, false)
+func ModelPlanCollection(logger *zap.Logger, principal authentication.Principal, store *storage.Store, includeAll bool) ([]*models.ModelPlan, error) {
+	var modelPlans []*models.ModelPlan
+	var err error
+	if includeAll {
+		modelPlans, err = store.ModelPlanCollection(logger, false)
+	} else {
+		modelPlans, err = store.ModelPlanCollectionCollaboratorOnly(logger, false, principal.ID())
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	return plans, err
+	return modelPlans, err
 }

--- a/pkg/graph/resolvers/model_plan_test.go
+++ b/pkg/graph/resolvers/model_plan_test.go
@@ -1,6 +1,7 @@
 package resolvers
 
 import (
+	"github.com/cmsgov/mint-app/pkg/authentication"
 	"github.com/cmsgov/mint-app/pkg/models"
 )
 
@@ -49,13 +50,44 @@ func (suite *ResolverSuite) TestModelPlanGetByID() {
 	suite.EqualValues(plan, result)
 }
 
-func (suite *ResolverSuite) TestModelPlanCollectionByUser() {
-	plan := suite.createModelPlan("Test Plan")
+func (suite *ResolverSuite) TestModelPlanCollection() {
+	// Create 3 plans without additional collaborators (TEST is the only one, by default)
+	_ = suite.createModelPlan("Test Plan")
+	_ = suite.createModelPlan("Test Plan 2")
+	_ = suite.createModelPlan("Test Plan 3")
 
-	result, err := ModelPlanCollection(suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store)
+	// Create a plan that has CLAB as a collaborator (along with TEST)
+	planWithCollab := suite.createModelPlan("Test Plan 4 (Collab)")
+	suite.createPlanCollaborator(planWithCollab, "CLAB", "Clab Rater", models.TeamRoleEvaluation, "clab.rater@gmail.com")
 
+	// Get plan collection as CLAB
+	clabPrincipal := &authentication.EUAPrincipal{
+		EUAID:             "CLAB",
+		JobCodeUSER:       true,
+		JobCodeASSESSMENT: false,
+	}
+
+	// Assert that CLAB only sees 1 model plan with includeAll = false
+	result, err := ModelPlanCollection(suite.testConfigs.Logger, clabPrincipal, suite.testConfigs.Store, false)
 	suite.NoError(err)
 	suite.NotNil(result)
 	suite.Len(result, 1)
-	suite.EqualValues(plan, result[0])
+
+	// Assert that CLAB sees all 4 model plans with includeAll = true
+	result, err = ModelPlanCollection(suite.testConfigs.Logger, clabPrincipal, suite.testConfigs.Store, true)
+	suite.NoError(err)
+	suite.NotNil(result)
+	suite.Len(result, 4)
+
+	// Assert that TEST only sees all 4 model plans with includeAll = false (as they're a collaborator on all of them)
+	result, err = ModelPlanCollection(suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, false)
+	suite.NoError(err)
+	suite.NotNil(result)
+	suite.Len(result, 4)
+
+	// Assert that TEST sees all 4 model plans with includeAll = true
+	result, err = ModelPlanCollection(suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, true)
+	suite.NoError(err)
+	suite.NotNil(result)
+	suite.Len(result, 4)
 }

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -1368,7 +1368,7 @@ type Query {
   planDocument(id: UUID!): PlanDocument!
   planDocumentDownloadURL(id: UUID!): PlanDocumentPayload!
   readPlanDocumentByModelID(id: UUID!): [PlanDocument!]!
-  modelPlanCollection: [ModelPlan!]!
+  modelPlanCollection(includeAll: Boolean! = false): [ModelPlan!]!
   existingModelCollection: [ExistingModel!]!
   cedarPersonsByCommonName(commonName: String!): [UserInfo!]!
   planCollaboratorByID(id: UUID!): PlanCollaborator!

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -805,10 +805,10 @@ func (r *queryResolver) ReadPlanDocumentByModelID(ctx context.Context, id uuid.U
 }
 
 // ModelPlanCollection is the resolver for the modelPlanCollection field.
-func (r *queryResolver) ModelPlanCollection(ctx context.Context) ([]*models.ModelPlan, error) {
+func (r *queryResolver) ModelPlanCollection(ctx context.Context, includeAll bool) ([]*models.ModelPlan, error) {
 	principal := appcontext.Principal(ctx)
 	logger := appcontext.ZLogger(ctx)
-	return resolvers.ModelPlanCollection(logger, principal, r.store)
+	return resolvers.ModelPlanCollection(logger, principal, r.store, includeAll)
 }
 
 // ExistingModelCollection is the resolver for the existingModelCollection field.

--- a/pkg/storage/SQL/model_plan_collection_by_collaborator.sql
+++ b/pkg/storage/SQL/model_plan_collection_by_collaborator.sql
@@ -1,0 +1,13 @@
+SELECT
+    model_plan.id,
+    model_plan.model_name,
+    model_plan.status,
+    model_plan.archived,
+    model_plan.created_by,
+    model_plan.created_dts,
+    model_plan.modified_by,
+    model_plan.modified_dts
+FROM model_plan
+INNER JOIN plan_collaborator ON plan_collaborator.model_plan_id = model_plan.id
+
+WHERE plan_collaborator.eua_user_id = :euaID AND model_plan.archived = :archived

--- a/pkg/storage/model_planStore.go
+++ b/pkg/storage/model_planStore.go
@@ -28,6 +28,9 @@ var modelPlanGetByIDSQL string
 //go:embed SQL/model_plan_collection.sql
 var modelPlanCollectionSQL string
 
+//go:embed SQL/model_plan_collection_by_collaborator.sql
+var modelPlanCollectionByCollaboratorSQL string
+
 //go:embed SQL/model_plan_delete_by_id.sql
 var modelPlanDeleteByID string
 
@@ -123,7 +126,7 @@ func (s *Store) ModelPlanGetByID(logger *zap.Logger, id uuid.UUID) (*models.Mode
 
 }
 
-// ModelPlanCollection returns a list of all model plans
+// ModelPlanCollection returns a list of all model plans (whether or not you're a collaborator)
 func (s *Store) ModelPlanCollection(logger *zap.Logger, archived bool) ([]*models.ModelPlan, error) {
 	modelPlans := []*models.ModelPlan{}
 
@@ -133,6 +136,36 @@ func (s *Store) ModelPlanCollection(logger *zap.Logger, archived bool) ([]*model
 	}
 	arg := map[string]interface{}{
 		"archived": archived,
+	}
+
+	err = stmt.Select(&modelPlans, arg)
+
+	if err != nil {
+		logger.Error(
+			"Failed to fetch model plans",
+			zap.Error(err),
+		)
+		return nil, &apperrors.QueryError{
+			Err:       err,
+			Model:     models.ModelPlan{},
+			Operation: apperrors.QueryFetch,
+		}
+	}
+
+	return modelPlans, nil
+}
+
+// ModelPlanCollectionCollaboratorOnly returns a list of all model plans for which the euaID supplied is a collaborator.
+func (s *Store) ModelPlanCollectionCollaboratorOnly(logger *zap.Logger, archived bool, euaID string) ([]*models.ModelPlan, error) {
+	modelPlans := []*models.ModelPlan{}
+
+	stmt, err := s.db.PrepareNamed(modelPlanCollectionByCollaboratorSQL)
+	if err != nil {
+		return nil, err
+	}
+	arg := map[string]interface{}{
+		"archived": archived,
+		"euaID":    euaID,
 	}
 
 	err = stmt.Select(&modelPlans, arg)

--- a/src/queries/GetModelPlans.ts
+++ b/src/queries/GetModelPlans.ts
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client';
 
 export default gql`
   query GetModelPlans {
-    modelPlanCollection {
+    modelPlanCollection(includeAll: false) {
       id
       modelName
       status

--- a/src/queries/ReadOnly/GetAllModelPlans.ts
+++ b/src/queries/ReadOnly/GetAllModelPlans.ts
@@ -2,11 +2,12 @@ import { gql } from '@apollo/client';
 
 export default gql`
   query GetAllModelPlans {
-    modelPlanCollection {
+    modelPlanCollection(includeAll: true) {
       id
       modelName
       status
       isFavorite
+      isCollaborator
       basics {
         applicationsStart
         modelCategory

--- a/src/queries/ReadOnly/types/GetAllModelPlans.ts
+++ b/src/queries/ReadOnly/types/GetAllModelPlans.ts
@@ -28,6 +28,7 @@ export interface GetAllModelPlans_modelPlanCollection {
   modelName: string;
   status: ModelStatus;
   isFavorite: boolean;
+  isCollaborator: boolean;
   basics: GetAllModelPlans_modelPlanCollection_basics;
   collaborators: GetAllModelPlans_modelPlanCollection_collaborators[];
 }


### PR DESCRIPTION
# NOREF

## Changes and Description

- Introduces a `Boolean!` parameter to `modelPlanCollection()` GQL query that allows for querying all model plans (or just "my" model plans)
- Modifications to existing queries in the frontend to use this new parameter.

## How to test this change

- `scripts/dev up`
- `scripts/dev db:seed`
- Sign in as `BTAL`
- Navigate to the home page, you should only see one model plans.
- Navigate to the "all models" page, you should see 4 model plans.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
