### PR TITLE
[NOREF] Fixed failing Cypress test for Favoriting a Model Plan

### DIFF
--- a/cypress/e2e/modelPlan.spec.js
+++ b/cypress/e2e/modelPlan.spec.js
@@ -268,15 +268,12 @@ describe('The Model Plan Form', () => {
   it('favorites and unfavorites a model plan', () => {
     cy.visit('/models');
 
-    cy.get('[data-testid="53054496-6d1f-47f5-b6a0-1edaf73b935e"]').click();
-
-    cy.get('[data-testid="Empty Plan"]').contains('Empty Plan');
-
-    cy.get('[data-testid="Empty Plan"] button').click();
-
-    cy.get('[data-testid="53054496-6d1f-47f5-b6a0-1edaf73b935e"] svg').should(
-      'have.class',
-      'text-gray-30'
+    cy.contains('tr', 'Empty Plan').find(
+      'th button svg[data-cy="unfavorited"]'
     );
+
+    cy.contains('tr', 'Empty Plan').find('th button').click();
+
+    cy.contains('tr', 'Empty Plan').find('th button svg[data-cy="favorited"]');
   });
 });

--- a/src/views/ModelPlan/ReadOnly/Table/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/Table/index.tsx
@@ -61,7 +61,7 @@ const Table = ({ data, updateFavorite }: ModelPlansTableProps) => {
               className="display-block"
               unstyled
             >
-              <IconStar size={3} />
+              <IconStar data-cy="favorited" size={3} />
             </Button>
           ) : (
             <Button
@@ -71,7 +71,11 @@ const Table = ({ data, updateFavorite }: ModelPlansTableProps) => {
               className="display-block"
               unstyled
             >
-              <IconStarOutline size={3} className="text-gray-30" />
+              <IconStarOutline
+                data-cy="unfavorited"
+                size={3}
+                className="text-gray-30"
+              />
             </Button>
           );
         }


### PR DESCRIPTION
# NOREF

## Changes and Description

- Added data-cy to `<svg>` for favorite element to aid cypress tests
- Modified `modelPlan.spec.js` to reference `data-cy` for checking if a table element is favorited or not

## How to test this change

1. `scripts/dev up`
2. Run the Cypress tests
  - If you want to run the whole test suite, simply run `yarn cypress run`
  - If you want to run only the test that changed, open [modelPlan.spec.js](./cypress/e2e/modelPlan.spec.js) and tag the `favorites and unfavorites a model plan` test with `it.only`, then run `yarn cypress run --spec cypress/e2e/modelPlan.spec.js` to run only the Model Plan test spec
## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
