### PR TITLE
[EASI-2189] - Add date warning milestones

### DIFF
--- a/src/components/shared/DatePicker/index.tsx
+++ b/src/components/shared/DatePicker/index.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Alert, DatePicker, Label } from '@trussworks/react-uswds';
+import classNames from 'classnames';
+import { Field } from 'formik';
+
+import { isDateInPast } from 'utils/date';
+
+import DatePickerWarning from '../DatePickerWarning';
+import FieldErrorMsg from '../FieldErrorMsg';
+import FieldGroup from '../FieldGroup';
+
+interface ITToolsFormComponentType {
+  id: string;
+  className?: string;
+  fieldName: string;
+  label: string;
+  boldLabel?: boolean;
+  subLabel?: string;
+  placeHolder?: boolean;
+  handleOnBlur: (e: React.ChangeEvent<HTMLInputElement>, field: string) => void;
+  value: string | null;
+  formikValue: string | null;
+  error: string;
+  warning?: boolean;
+}
+
+export const MINTDatePicker = ({
+  id,
+  className,
+  fieldName,
+  label,
+  boldLabel = true,
+  subLabel,
+  placeHolder = false,
+  handleOnBlur,
+  value,
+  formikValue,
+  error,
+  warning = true
+}: ITToolsFormComponentType) => {
+  const { t: h } = useTranslation('draftModelPlan');
+
+  return (
+    <>
+      <FieldGroup
+        scrollElement={fieldName}
+        error={!!error}
+        className={classNames(className)}
+      >
+        <Label
+          htmlFor={id}
+          className={classNames('usa-legend margin-top-0', {
+            'text-normal': !boldLabel
+          })}
+        >
+          {label}
+        </Label>
+        {subLabel && (
+          <p className="text-normal margin-bottom-1 margin-top-0 ">
+            {subLabel}
+          </p>
+        )}
+        {placeHolder && (
+          <div className="usa-hint" id="appointment-date-hint">
+            {h('datePlaceholder')}
+          </div>
+        )}
+        <FieldErrorMsg>{error}</FieldErrorMsg>
+        <div className="width-card-lg position-relative">
+          <Field
+            as={DatePicker}
+            error={+!!error}
+            id={id}
+            maxLength={50}
+            name={fieldName}
+            defaultValue={value}
+            onBlur={(e: React.ChangeEvent<HTMLInputElement>) => {
+              handleOnBlur(e, fieldName);
+            }}
+          />
+          {isDateInPast(formikValue) && (
+            <DatePickerWarning label={h('dateWarning')} />
+          )}
+        </div>
+      </FieldGroup>
+
+      {warning && isDateInPast(formikValue) && (
+        <Alert type="warning" className="margin-top-4">
+          {h('dateWarning')}
+        </Alert>
+      )}
+    </>
+  );
+};
+
+export default MINTDatePicker;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -75,3 +75,10 @@ export const getTimeElapsed = (discussionCreated: string) => {
 
   return dateString;
 };
+
+export const isDateInPast = (date: string | null): boolean => {
+  if (date && new Date() > new Date(date)) {
+    return true;
+  }
+  return false;
+};

--- a/src/validations/planBasics.ts
+++ b/src/validations/planBasics.ts
@@ -1,10 +1,5 @@
 import * as Yup from 'yup';
 
-const datePickerSchema = Yup.date()
-  .nullable()
-  .notRequired()
-  .min(new Date(), 'Date cannot be in the past');
-
 const planBasicsSchema = {
   pageOneSchema: Yup.object().shape({
     modelName: Yup.string().trim().required('Enter the Model Name'),
@@ -77,15 +72,6 @@ const planBasicsSchema = {
   }),
 
   pageThreeSchema: Yup.object().shape({
-    completeICIP: datePickerSchema,
-    clearanceStarts: datePickerSchema,
-    clearanceEnds: datePickerSchema,
-    announced: datePickerSchema,
-    applicationsStart: datePickerSchema,
-    applicationsEnd: datePickerSchema,
-    performancePeriodStarts: datePickerSchema,
-    performancePeriodEnds: datePickerSchema,
-    wrapUpEnds: datePickerSchema,
     phasedIn: Yup.boolean().nullable().required('Please answer question')
   })
 };

--- a/src/views/ModelPlan/TaskList/Basics/Milestones/index.scss
+++ b/src/views/ModelPlan/TaskList/Basics/Milestones/index.scss
@@ -3,5 +3,6 @@
     display: flex;
     grid-gap: units(3);
     align-items: flex-end;
+    flex-wrap: wrap;
   }
 }

--- a/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
@@ -33,19 +33,13 @@ import {
 } from 'queries/Basics/types/GetMilestones';
 import { UpdatePlanBasicsVariables } from 'queries/Basics/types/UpdatePlanBasics';
 import UpdatePlanBasics from 'queries/Basics/UpdatePlanBasics';
+import { isDateInPast } from 'utils/date';
 import flattenErrors from 'utils/flattenErrors';
 import sanitizeStatus from 'utils/status';
 import planBasicsSchema from 'validations/planBasics';
 import { NotFoundPartial } from 'views/NotFound';
 
 import './index.scss';
-
-const isDateInPast = (date: string | null): boolean => {
-  if (date && new Date() > new Date(date)) {
-    return true;
-  }
-  return false;
-};
 
 const Milestones = () => {
   const { t } = useTranslation('basics');
@@ -203,6 +197,7 @@ const Milestones = () => {
 
             const handleOnBlur = (e: string, field: string) => {
               if (e === '') {
+                setFieldValue(field, null);
                 return;
               }
               try {

--- a/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
+  Alert,
   Breadcrumb,
   BreadcrumbBar,
   BreadcrumbLink,
@@ -20,6 +21,7 @@ import AskAQuestion from 'components/AskAQuestion';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
 import ReadyForReview from 'components/ReadyForReview';
+import DatePickerWarning from 'components/shared/DatePickerWarning';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
@@ -37,6 +39,13 @@ import planBasicsSchema from 'validations/planBasics';
 import { NotFoundPartial } from 'views/NotFound';
 
 import './index.scss';
+
+const isDateInPast = (date: string | null): boolean => {
+  if (date && new Date() > new Date(date)) {
+    return true;
+  }
+  return false;
+};
 
 const Milestones = () => {
   const { t } = useTranslation('basics');
@@ -245,18 +254,29 @@ const Milestones = () => {
                       {h('datePlaceholder')}
                     </div>
                     <FieldErrorMsg>{flatErrors.completeICIP}</FieldErrorMsg>
-                    <Field
-                      as={DatePicker}
-                      error={+!!flatErrors.completeICIP}
-                      id="Milestone-completeICIP"
-                      maxLength={50}
-                      name="completeICIP"
-                      defaultValue={completeICIP}
-                      onBlur={(e: any) =>
-                        handleOnBlur(e.target.value, 'completeICIP')
-                      }
-                    />
+                    <div className="position-relative">
+                      <Field
+                        as={DatePicker}
+                        error={+!!flatErrors.completeICIP}
+                        id="Milestone-completeICIP"
+                        maxLength={50}
+                        name="completeICIP"
+                        defaultValue={completeICIP}
+                        onBlur={(e: any) =>
+                          handleOnBlur(e.target.value, 'completeICIP')
+                        }
+                      />
+                      {isDateInPast(values.completeICIP) && (
+                        <DatePickerWarning label={h('dateWarning')} />
+                      )}
+                    </div>
                   </FieldGroup>
+
+                  {isDateInPast(values.completeICIP) && (
+                    <Alert type="warning" className="margin-top-4">
+                      {h('dateWarning')}
+                    </Alert>
+                  )}
 
                   <legend className="usa-label margin-bottom-1">
                     {t('clearance')}
@@ -280,17 +300,22 @@ const Milestones = () => {
                       <FieldErrorMsg>
                         {flatErrors.clearanceStarts}
                       </FieldErrorMsg>
-                      <Field
-                        as={DatePicker}
-                        error={+!!flatErrors.clearanceStarts}
-                        id="Milestone-clearanceStarts"
-                        maxLength={50}
-                        name="clearanceStarts"
-                        defaultValue={clearanceStarts}
-                        onBlur={(e: any) =>
-                          handleOnBlur(e.target.value, 'clearanceStarts')
-                        }
-                      />
+                      <div className="position-relative">
+                        <Field
+                          as={DatePicker}
+                          error={+!!flatErrors.clearanceStarts}
+                          id="Milestone-clearanceStarts"
+                          maxLength={50}
+                          name="clearanceStarts"
+                          defaultValue={clearanceStarts}
+                          onBlur={(e: any) =>
+                            handleOnBlur(e.target.value, 'clearanceStarts')
+                          }
+                        />
+                        {isDateInPast(values.clearanceStarts) && (
+                          <DatePickerWarning label={h('dateWarning')} />
+                        )}
+                      </div>
                     </FieldGroup>
 
                     <FieldGroup
@@ -308,19 +333,31 @@ const Milestones = () => {
                         {h('datePlaceholder')}
                       </div>
                       <FieldErrorMsg>{flatErrors.clearanceEnds}</FieldErrorMsg>
-                      <Field
-                        as={DatePicker}
-                        error={+!!flatErrors.clearanceEnds}
-                        id="Milestone-clearanceEnds"
-                        maxLength={50}
-                        name="clearanceEnds"
-                        defaultValue={clearanceEnds}
-                        onBlur={(e: any) =>
-                          handleOnBlur(e.target.value, 'clearanceEnds')
-                        }
-                      />
+                      <div className="position-relative">
+                        <Field
+                          as={DatePicker}
+                          error={+!!flatErrors.clearanceEnds}
+                          id="Milestone-clearanceEnds"
+                          maxLength={50}
+                          name="clearanceEnds"
+                          defaultValue={clearanceEnds}
+                          onBlur={(e: any) =>
+                            handleOnBlur(e.target.value, 'clearanceEnds')
+                          }
+                        />
+                        {isDateInPast(values.clearanceEnds) && (
+                          <DatePickerWarning label={h('dateWarning')} />
+                        )}
+                      </div>
                     </FieldGroup>
                   </div>
+
+                  {(isDateInPast(values.clearanceStarts) ||
+                    isDateInPast(values.clearanceEnds)) && (
+                    <Alert type="warning" className="margin-top-4">
+                      {h('dateWarning')}
+                    </Alert>
+                  )}
 
                   <FieldGroup
                     scrollElement="announced"
@@ -334,18 +371,29 @@ const Milestones = () => {
                       {h('datePlaceholder')}
                     </div>
                     <FieldErrorMsg>{flatErrors.announced}</FieldErrorMsg>
-                    <Field
-                      as={DatePicker}
-                      error={+!!flatErrors.announced}
-                      id="Milestone-announced"
-                      maxLength={50}
-                      name="announced"
-                      defaultValue={announced}
-                      onBlur={(e: any) =>
-                        handleOnBlur(e.target.value, 'announced')
-                      }
-                    />
+                    <div className="position-relative">
+                      <Field
+                        as={DatePicker}
+                        error={+!!flatErrors.announced}
+                        id="Milestone-announced"
+                        maxLength={50}
+                        name="announced"
+                        defaultValue={announced}
+                        onBlur={(e: any) =>
+                          handleOnBlur(e.target.value, 'announced')
+                        }
+                      />
+                      {isDateInPast(values.announced) && (
+                        <DatePickerWarning label={h('dateWarning')} />
+                      )}
+                    </div>
                   </FieldGroup>
+
+                  {isDateInPast(values.announced) && (
+                    <Alert type="warning" className="margin-top-4">
+                      {h('dateWarning')}
+                    </Alert>
+                  )}
 
                   <legend className="usa-label margin-bottom-1">
                     {t('applicationPeriod')}
@@ -369,17 +417,22 @@ const Milestones = () => {
                       <FieldErrorMsg>
                         {flatErrors.applicationsStart}
                       </FieldErrorMsg>
-                      <Field
-                        as={DatePicker}
-                        error={+!!flatErrors.applicationsStart}
-                        id="Milestone-applicationsStart"
-                        maxLength={50}
-                        name="applicationsStart"
-                        defaultValue={applicationsStart}
-                        onBlur={(e: any) =>
-                          handleOnBlur(e.target.value, 'applicationsStart')
-                        }
-                      />
+                      <div className="position-relative">
+                        <Field
+                          as={DatePicker}
+                          error={+!!flatErrors.applicationsStart}
+                          id="Milestone-applicationsStart"
+                          maxLength={50}
+                          name="applicationsStart"
+                          defaultValue={applicationsStart}
+                          onBlur={(e: any) =>
+                            handleOnBlur(e.target.value, 'applicationsStart')
+                          }
+                        />
+                        {isDateInPast(values.applicationsStart) && (
+                          <DatePickerWarning label={h('dateWarning')} />
+                        )}
+                      </div>
                     </FieldGroup>
 
                     <FieldGroup
@@ -399,19 +452,31 @@ const Milestones = () => {
                       <FieldErrorMsg>
                         {flatErrors.applicationsEnd}
                       </FieldErrorMsg>
-                      <Field
-                        as={DatePicker}
-                        error={+!!flatErrors.applicationsEnd}
-                        id="Milestone-applicationsEnd"
-                        maxLength={50}
-                        name="applicationsEnd"
-                        defaultValue={applicationsEnd}
-                        onBlur={(e: any) =>
-                          handleOnBlur(e.target.value, 'applicationsEnd')
-                        }
-                      />
+                      <div className="position-relative">
+                        <Field
+                          as={DatePicker}
+                          error={+!!flatErrors.applicationsEnd}
+                          id="Milestone-applicationsEnd"
+                          maxLength={50}
+                          name="applicationsEnd"
+                          defaultValue={applicationsEnd}
+                          onBlur={(e: any) =>
+                            handleOnBlur(e.target.value, 'applicationsEnd')
+                          }
+                        />
+                        {isDateInPast(values.applicationsEnd) && (
+                          <DatePickerWarning label={h('dateWarning')} />
+                        )}
+                      </div>
                     </FieldGroup>
                   </div>
+
+                  {(isDateInPast(values.applicationsStart) ||
+                    isDateInPast(values.applicationsEnd)) && (
+                    <Alert type="warning" className="margin-top-4">
+                      {h('dateWarning')}
+                    </Alert>
+                  )}
 
                   <legend className="usa-label margin-bottom-1">
                     {t('demonstrationPerformance')}
@@ -435,21 +500,27 @@ const Milestones = () => {
                       <FieldErrorMsg>
                         {flatErrors.performancePeriodStarts}
                       </FieldErrorMsg>
-                      <Field
-                        as={DatePicker}
-                        error={+!!flatErrors.performancePeriodStarts}
-                        id="Milestone-performancePeriodStarts"
-                        maxLength={50}
-                        name="performancePeriodStarts"
-                        defaultValue={performancePeriodStarts}
-                        onBlur={(e: any) =>
-                          handleOnBlur(
-                            e.target.value,
-                            'performancePeriodStarts'
-                          )
-                        }
-                      />
+                      <div className="position-relative">
+                        <Field
+                          as={DatePicker}
+                          error={+!!flatErrors.performancePeriodStarts}
+                          id="Milestone-performancePeriodStarts"
+                          maxLength={50}
+                          name="performancePeriodStarts"
+                          defaultValue={performancePeriodStarts}
+                          onBlur={(e: any) =>
+                            handleOnBlur(
+                              e.target.value,
+                              'performancePeriodStarts'
+                            )
+                          }
+                        />
+                        {isDateInPast(values.performancePeriodStarts) && (
+                          <DatePickerWarning label={h('dateWarning')} />
+                        )}
+                      </div>
                     </FieldGroup>
+
                     <FieldGroup
                       scrollElement="performancePeriodEnds"
                       error={!!flatErrors.performancePeriodEnds}
@@ -467,19 +538,34 @@ const Milestones = () => {
                       <FieldErrorMsg>
                         {flatErrors.performancePeriodEnds}
                       </FieldErrorMsg>
-                      <Field
-                        as={DatePicker}
-                        error={+!!flatErrors.performancePeriodEnds}
-                        id="Milestone-performancePeriodEnds"
-                        maxLength={50}
-                        name="performancePeriodEnds"
-                        defaultValue={performancePeriodEnds}
-                        onBlur={(e: any) =>
-                          handleOnBlur(e.target.value, 'performancePeriodEnds')
-                        }
-                      />
+                      <div className="position-relative">
+                        <Field
+                          as={DatePicker}
+                          error={+!!flatErrors.performancePeriodEnds}
+                          id="Milestone-performancePeriodEnds"
+                          maxLength={50}
+                          name="performancePeriodEnds"
+                          defaultValue={performancePeriodEnds}
+                          onBlur={(e: any) =>
+                            handleOnBlur(
+                              e.target.value,
+                              'performancePeriodEnds'
+                            )
+                          }
+                        />
+                        {isDateInPast(values.performancePeriodEnds) && (
+                          <DatePickerWarning label={h('dateWarning')} />
+                        )}
+                      </div>
                     </FieldGroup>
                   </div>
+
+                  {(isDateInPast(values.performancePeriodStarts) ||
+                    isDateInPast(values.performancePeriodEnds)) && (
+                    <Alert type="warning" className="margin-top-4">
+                      {h('dateWarning')}
+                    </Alert>
+                  )}
 
                   <FieldGroup
                     scrollElement="wrapUpEnds"
@@ -493,18 +579,29 @@ const Milestones = () => {
                       {h('datePlaceholder')}
                     </div>
                     <FieldErrorMsg>{flatErrors.wrapUpEnds}</FieldErrorMsg>
-                    <Field
-                      as={DatePicker}
-                      error={+!!flatErrors.wrapUpEnds}
-                      id="Milestone-wrapUpEnds"
-                      maxLength={50}
-                      name="wrapUpEnds"
-                      defaultValue={wrapUpEnds}
-                      onBlur={(e: any) =>
-                        handleOnBlur(e.target.value, 'wrapUpEnds')
-                      }
-                    />
+                    <div className="position-relative">
+                      <Field
+                        as={DatePicker}
+                        error={+!!flatErrors.wrapUpEnds}
+                        id="Milestone-wrapUpEnds"
+                        maxLength={50}
+                        name="wrapUpEnds"
+                        defaultValue={wrapUpEnds}
+                        onBlur={(e: any) =>
+                          handleOnBlur(e.target.value, 'wrapUpEnds')
+                        }
+                      />
+                      {isDateInPast(values.wrapUpEnds) && (
+                        <DatePickerWarning label={h('dateWarning')} />
+                      )}
+                    </div>
                   </FieldGroup>
+
+                  {isDateInPast(values.wrapUpEnds) && (
+                    <Alert type="warning" className="margin-top-4">
+                      {h('dateWarning')}
+                    </Alert>
+                  )}
 
                   <AddNote id="ModelType-HighLevelNote" field="highLevelNote" />
 

--- a/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
@@ -8,7 +8,6 @@ import {
   BreadcrumbBar,
   BreadcrumbLink,
   Button,
-  DatePicker,
   Fieldset,
   IconArrowBack,
   Label,
@@ -21,7 +20,7 @@ import AskAQuestion from 'components/AskAQuestion';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
 import ReadyForReview from 'components/ReadyForReview';
-import DatePickerWarning from 'components/shared/DatePickerWarning';
+import MINTDatePicker from 'components/shared/DatePicker';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
@@ -195,13 +194,16 @@ const Milestones = () => {
             } = formikProps;
             const flatErrors = flattenErrors(errors);
 
-            const handleOnBlur = (e: string, field: string) => {
-              if (e === '') {
+            const handleOnBlur = (
+              e: React.ChangeEvent<HTMLInputElement>,
+              field: string
+            ) => {
+              if (e.target.value === '') {
                 setFieldValue(field, null);
                 return;
               }
               try {
-                setFieldValue(field, new Date(e).toISOString());
+                setFieldValue(field, new Date(e.target.value).toISOString());
                 delete errors[field as keyof InitialValueType];
               } catch (err) {
                 setFieldError(field, t('validDate'));
@@ -237,233 +239,99 @@ const Milestones = () => {
                   <PageHeading headingLevel="h3" className="margin-bottom-4">
                     {t('highLevelTimeline')}
                   </PageHeading>
-                  <FieldGroup
-                    scrollElement="completeICIP"
-                    error={!!flatErrors.completeICIP}
-                    className="margin-top-0 width-card-lg"
-                  >
-                    <Label htmlFor="Milestone-completeICIP">
-                      {t('completeICIP')}
-                    </Label>
-                    <div className="usa-hint" id="appointment-date-hint">
-                      {h('datePlaceholder')}
-                    </div>
-                    <FieldErrorMsg>{flatErrors.completeICIP}</FieldErrorMsg>
-                    <div className="position-relative">
-                      <Field
-                        as={DatePicker}
-                        error={+!!flatErrors.completeICIP}
-                        id="Milestone-completeICIP"
-                        maxLength={50}
-                        name="completeICIP"
-                        defaultValue={completeICIP}
-                        onBlur={(e: any) =>
-                          handleOnBlur(e.target.value, 'completeICIP')
-                        }
-                      />
-                      {isDateInPast(values.completeICIP) && (
-                        <DatePickerWarning label={h('dateWarning')} />
-                      )}
-                    </div>
-                  </FieldGroup>
 
-                  {isDateInPast(values.completeICIP) && (
-                    <Alert type="warning" className="margin-top-4">
-                      {h('dateWarning')}
-                    </Alert>
-                  )}
+                  <MINTDatePicker
+                    fieldName="completeICIP"
+                    id="Milestone-completeICIP"
+                    label={t('completeICIP')}
+                    placeHolder
+                    handleOnBlur={handleOnBlur}
+                    formikValue={values.completeICIP}
+                    value={completeICIP}
+                    error={flatErrors.completeICIP}
+                  />
 
-                  <legend className="usa-label margin-bottom-1">
+                  <legend className="usa-label margin-bottom-neg-2">
                     {t('clearance')}
                   </legend>
 
                   <div className="fieldGroup__wrapper">
-                    <FieldGroup
-                      scrollElement="clearanceStarts"
-                      error={!!flatErrors.clearanceStarts}
-                      className="margin-top-0 width-card-lg"
-                    >
-                      <label
-                        htmlFor="Milestone-clearanceStarts"
-                        className="usa-legend margin-top-0"
-                      >
-                        {t('clearanceStartDate')}
-                      </label>
-                      <div className="usa-hint" id="appointment-date-hint">
-                        {h('datePlaceholder')}
-                      </div>
-                      <FieldErrorMsg>
-                        {flatErrors.clearanceStarts}
-                      </FieldErrorMsg>
-                      <div className="position-relative">
-                        <Field
-                          as={DatePicker}
-                          error={+!!flatErrors.clearanceStarts}
-                          id="Milestone-clearanceStarts"
-                          maxLength={50}
-                          name="clearanceStarts"
-                          defaultValue={clearanceStarts}
-                          onBlur={(e: any) =>
-                            handleOnBlur(e.target.value, 'clearanceStarts')
-                          }
-                        />
-                        {isDateInPast(values.clearanceStarts) && (
-                          <DatePickerWarning label={h('dateWarning')} />
-                        )}
-                      </div>
-                    </FieldGroup>
+                    <MINTDatePicker
+                      fieldName="clearanceStarts"
+                      id="Milestone-clearanceStarts"
+                      label={t('clearanceStartDate')}
+                      boldLabel={false}
+                      placeHolder
+                      handleOnBlur={handleOnBlur}
+                      formikValue={values.clearanceStarts}
+                      value={clearanceStarts}
+                      error={flatErrors.clearanceStarts}
+                      warning={false}
+                    />
 
-                    <FieldGroup
-                      scrollElement="clearanceEnds"
-                      error={!!flatErrors.clearanceEnds}
-                      className="margin-top-0 width-card-lg"
-                    >
-                      <label
-                        htmlFor="Milestone-clearanceEnds"
-                        className="usa-legend margin-top-0"
-                      >
-                        {t('clearanceEndDate')}
-                      </label>
-                      <div className="usa-hint" id="appointment-date-hint">
-                        {h('datePlaceholder')}
-                      </div>
-                      <FieldErrorMsg>{flatErrors.clearanceEnds}</FieldErrorMsg>
-                      <div className="position-relative">
-                        <Field
-                          as={DatePicker}
-                          error={+!!flatErrors.clearanceEnds}
-                          id="Milestone-clearanceEnds"
-                          maxLength={50}
-                          name="clearanceEnds"
-                          defaultValue={clearanceEnds}
-                          onBlur={(e: any) =>
-                            handleOnBlur(e.target.value, 'clearanceEnds')
-                          }
-                        />
-                        {isDateInPast(values.clearanceEnds) && (
-                          <DatePickerWarning label={h('dateWarning')} />
-                        )}
-                      </div>
-                    </FieldGroup>
+                    <MINTDatePicker
+                      fieldName="clearanceEnds"
+                      id="Milestone-clearanceEnds"
+                      label={t('clearanceEndDate')}
+                      boldLabel={false}
+                      placeHolder
+                      handleOnBlur={handleOnBlur}
+                      formikValue={values.clearanceEnds}
+                      value={clearanceEnds}
+                      error={flatErrors.clearanceEnds}
+                      warning={false}
+                    />
                   </div>
 
-                  {(isDateInPast(values.clearanceStarts) ||
-                    isDateInPast(values.clearanceEnds)) && (
+                  {(isDateInPast(values.clearanceEnds) ||
+                    isDateInPast(values.clearanceStarts)) && (
                     <Alert type="warning" className="margin-top-4">
                       {h('dateWarning')}
                     </Alert>
                   )}
 
-                  <FieldGroup
-                    scrollElement="announced"
-                    error={!!flatErrors.announced}
+                  <MINTDatePicker
+                    fieldName="announced"
                     className="margin-top-4 width-card-lg"
-                  >
-                    <Label htmlFor="Milestone-announced">
-                      {t('annouceModel')}
-                    </Label>
-                    <div className="usa-hint" id="appointment-date-hint">
-                      {h('datePlaceholder')}
-                    </div>
-                    <FieldErrorMsg>{flatErrors.announced}</FieldErrorMsg>
-                    <div className="position-relative">
-                      <Field
-                        as={DatePicker}
-                        error={+!!flatErrors.announced}
-                        id="Milestone-announced"
-                        maxLength={50}
-                        name="announced"
-                        defaultValue={announced}
-                        onBlur={(e: any) =>
-                          handleOnBlur(e.target.value, 'announced')
-                        }
-                      />
-                      {isDateInPast(values.announced) && (
-                        <DatePickerWarning label={h('dateWarning')} />
-                      )}
-                    </div>
-                  </FieldGroup>
+                    id="Milestone-announced"
+                    label={t('annouceModel')}
+                    placeHolder
+                    handleOnBlur={handleOnBlur}
+                    formikValue={values.announced}
+                    value={announced}
+                    error={flatErrors.announced}
+                  />
 
-                  {isDateInPast(values.announced) && (
-                    <Alert type="warning" className="margin-top-4">
-                      {h('dateWarning')}
-                    </Alert>
-                  )}
-
-                  <legend className="usa-label margin-bottom-1">
+                  <legend className="usa-label margin-bottom-neg-2">
                     {t('applicationPeriod')}
                   </legend>
 
                   <div className="fieldGroup__wrapper">
-                    <FieldGroup
-                      scrollElement="applicationsStart"
-                      error={!!flatErrors.applicationsStart}
-                      className="margin-top-0 width-card-lg"
-                    >
-                      <label
-                        htmlFor="Milestone-applicationsStart"
-                        className="usa-legend margin-top-0"
-                      >
-                        {t('applicationStartDate')}
-                      </label>
-                      <div className="usa-hint" id="appointment-date-hint">
-                        {h('datePlaceholder')}
-                      </div>
-                      <FieldErrorMsg>
-                        {flatErrors.applicationsStart}
-                      </FieldErrorMsg>
-                      <div className="position-relative">
-                        <Field
-                          as={DatePicker}
-                          error={+!!flatErrors.applicationsStart}
-                          id="Milestone-applicationsStart"
-                          maxLength={50}
-                          name="applicationsStart"
-                          defaultValue={applicationsStart}
-                          onBlur={(e: any) =>
-                            handleOnBlur(e.target.value, 'applicationsStart')
-                          }
-                        />
-                        {isDateInPast(values.applicationsStart) && (
-                          <DatePickerWarning label={h('dateWarning')} />
-                        )}
-                      </div>
-                    </FieldGroup>
+                    <MINTDatePicker
+                      fieldName="applicationsStart"
+                      id="Milestone-applicationsStart"
+                      label={t('applicationStartDate')}
+                      boldLabel={false}
+                      placeHolder
+                      handleOnBlur={handleOnBlur}
+                      formikValue={values.applicationsStart}
+                      value={applicationsStart}
+                      error={flatErrors.applicationsStart}
+                      warning={false}
+                    />
 
-                    <FieldGroup
-                      scrollElement="applicationsEnd"
-                      error={!!flatErrors.applicationsEnd}
-                      className="margin-top-0 width-card-lg"
-                    >
-                      <label
-                        htmlFor="Milestone-applicationsEnd"
-                        className="usa-legend margin-top-0"
-                      >
-                        {t('applicationEndDate')}
-                      </label>
-                      <div className="usa-hint" id="appointment-date-hint">
-                        {h('datePlaceholder')}
-                      </div>
-                      <FieldErrorMsg>
-                        {flatErrors.applicationsEnd}
-                      </FieldErrorMsg>
-                      <div className="position-relative">
-                        <Field
-                          as={DatePicker}
-                          error={+!!flatErrors.applicationsEnd}
-                          id="Milestone-applicationsEnd"
-                          maxLength={50}
-                          name="applicationsEnd"
-                          defaultValue={applicationsEnd}
-                          onBlur={(e: any) =>
-                            handleOnBlur(e.target.value, 'applicationsEnd')
-                          }
-                        />
-                        {isDateInPast(values.applicationsEnd) && (
-                          <DatePickerWarning label={h('dateWarning')} />
-                        )}
-                      </div>
-                    </FieldGroup>
+                    <MINTDatePicker
+                      fieldName="applicationsEnd"
+                      id="Milestone-applicationsEnd"
+                      label={t('applicationEndDate')}
+                      boldLabel={false}
+                      placeHolder
+                      handleOnBlur={handleOnBlur}
+                      formikValue={values.applicationsEnd}
+                      value={applicationsEnd}
+                      error={flatErrors.applicationsEnd}
+                      warning={false}
+                    />
                   </div>
 
                   {(isDateInPast(values.applicationsStart) ||
@@ -473,86 +341,36 @@ const Milestones = () => {
                     </Alert>
                   )}
 
-                  <legend className="usa-label margin-bottom-1">
+                  <legend className="usa-label margin-bottom-neg-2">
                     {t('demonstrationPerformance')}
                   </legend>
 
                   <div className="fieldGroup__wrapper">
-                    <FieldGroup
-                      scrollElement="performancePeriodStarts"
-                      error={!!flatErrors.performancePeriodStarts}
-                      className="margin-top-0 width-card-lg"
-                    >
-                      <label
-                        htmlFor="Milestone-performancePeriodStarts"
-                        className="usa-legend margin-top-0"
-                      >
-                        {t('performanceStartDate')}
-                      </label>
-                      <div className="usa-hint" id="appointment-date-hint">
-                        {h('datePlaceholder')}
-                      </div>
-                      <FieldErrorMsg>
-                        {flatErrors.performancePeriodStarts}
-                      </FieldErrorMsg>
-                      <div className="position-relative">
-                        <Field
-                          as={DatePicker}
-                          error={+!!flatErrors.performancePeriodStarts}
-                          id="Milestone-performancePeriodStarts"
-                          maxLength={50}
-                          name="performancePeriodStarts"
-                          defaultValue={performancePeriodStarts}
-                          onBlur={(e: any) =>
-                            handleOnBlur(
-                              e.target.value,
-                              'performancePeriodStarts'
-                            )
-                          }
-                        />
-                        {isDateInPast(values.performancePeriodStarts) && (
-                          <DatePickerWarning label={h('dateWarning')} />
-                        )}
-                      </div>
-                    </FieldGroup>
+                    <MINTDatePicker
+                      fieldName="performancePeriodStarts"
+                      id="Milestone-performancePeriodStarts"
+                      label={t('performanceStartDate')}
+                      boldLabel={false}
+                      placeHolder
+                      handleOnBlur={handleOnBlur}
+                      formikValue={values.performancePeriodStarts}
+                      value={performancePeriodStarts}
+                      error={flatErrors.performancePeriodStarts}
+                      warning={false}
+                    />
 
-                    <FieldGroup
-                      scrollElement="performancePeriodEnds"
-                      error={!!flatErrors.performancePeriodEnds}
-                      className="margin-top-0 width-card-lg"
-                    >
-                      <label
-                        htmlFor="Milestone-performancePeriodEnds"
-                        className="usa-legend margin-top-0"
-                      >
-                        {t('performanceEndDate')}
-                      </label>
-                      <div className="usa-hint" id="appointment-date-hint">
-                        {h('datePlaceholder')}
-                      </div>
-                      <FieldErrorMsg>
-                        {flatErrors.performancePeriodEnds}
-                      </FieldErrorMsg>
-                      <div className="position-relative">
-                        <Field
-                          as={DatePicker}
-                          error={+!!flatErrors.performancePeriodEnds}
-                          id="Milestone-performancePeriodEnds"
-                          maxLength={50}
-                          name="performancePeriodEnds"
-                          defaultValue={performancePeriodEnds}
-                          onBlur={(e: any) =>
-                            handleOnBlur(
-                              e.target.value,
-                              'performancePeriodEnds'
-                            )
-                          }
-                        />
-                        {isDateInPast(values.performancePeriodEnds) && (
-                          <DatePickerWarning label={h('dateWarning')} />
-                        )}
-                      </div>
-                    </FieldGroup>
+                    <MINTDatePicker
+                      fieldName="performancePeriodEnds"
+                      id="Milestone-performancePeriodEnds"
+                      label={t('performanceEndDate')}
+                      boldLabel={false}
+                      placeHolder
+                      handleOnBlur={handleOnBlur}
+                      formikValue={values.performancePeriodEnds}
+                      value={performancePeriodEnds}
+                      error={flatErrors.performancePeriodEnds}
+                      warning={false}
+                    />
                   </div>
 
                   {(isDateInPast(values.performancePeriodStarts) ||
@@ -562,41 +380,17 @@ const Milestones = () => {
                     </Alert>
                   )}
 
-                  <FieldGroup
-                    scrollElement="wrapUpEnds"
-                    error={!!flatErrors.wrapUpEnds}
-                    className="margin-top-4  width-card-lg"
-                  >
-                    <Label htmlFor="Milestone-wrapUpEnds">
-                      {t('modelWrapUp')}
-                    </Label>
-                    <div className="usa-hint" id="appointment-date-hint">
-                      {h('datePlaceholder')}
-                    </div>
-                    <FieldErrorMsg>{flatErrors.wrapUpEnds}</FieldErrorMsg>
-                    <div className="position-relative">
-                      <Field
-                        as={DatePicker}
-                        error={+!!flatErrors.wrapUpEnds}
-                        id="Milestone-wrapUpEnds"
-                        maxLength={50}
-                        name="wrapUpEnds"
-                        defaultValue={wrapUpEnds}
-                        onBlur={(e: any) =>
-                          handleOnBlur(e.target.value, 'wrapUpEnds')
-                        }
-                      />
-                      {isDateInPast(values.wrapUpEnds) && (
-                        <DatePickerWarning label={h('dateWarning')} />
-                      )}
-                    </div>
-                  </FieldGroup>
-
-                  {isDateInPast(values.wrapUpEnds) && (
-                    <Alert type="warning" className="margin-top-4">
-                      {h('dateWarning')}
-                    </Alert>
-                  )}
+                  <MINTDatePicker
+                    fieldName="wrapUpEnds"
+                    className="margin-top-4 width-card-lg"
+                    id="Milestone-wrapUpEnds"
+                    label={t('annouceModel')}
+                    placeHolder
+                    handleOnBlur={handleOnBlur}
+                    formikValue={values.wrapUpEnds}
+                    value={wrapUpEnds}
+                    error={flatErrors.wrapUpEnds}
+                  />
 
                   <AddNote id="ModelType-HighLevelNote" field="highLevelNote" />
 

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOC/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOC/__snapshots__/index.test.tsx.snap
@@ -294,17 +294,19 @@ exports[`Model Plan Ops Eval and Learning IDDOC matches snapshot 1`] = `
       />
     </div>
     <div
-      class="usa-form-group margin-top-6 width-half"
+      class="usa-form-group margin-top-6"
       data-scroll="draftIcdDueDate"
     >
       <label
-        class="text-bold"
+        class="usa-label usa-legend margin-top-0"
+        data-testid="label"
         for="ops-eval-and-learning-icd-due-date"
       >
         Draft ICD required by
       </label>
       <div
-        class="usa-hint margin-y-1"
+        class="usa-hint"
+        id="appointment-date-hint"
       >
         mm/dd/yyyy
       </div>
@@ -366,35 +368,35 @@ exports[`Model Plan Ops Eval and Learning IDDOC matches snapshot 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class="margin-top-4 margin-bottom-8"
+    </div>
+    <div
+      class="margin-top-4 margin-bottom-8"
+    >
+      <button
+        class="usa-button usa-button usa-button--unstyled"
+        data-testid="add-note-toggle"
+        type="button"
       >
-        <button
-          class="usa-button usa-button usa-button--unstyled"
-          data-testid="add-note-toggle"
-          type="button"
+        <svg
+          aria-hidden="true"
+          class="usa-icon margin-right-1"
+          focusable="false"
+          height="1em"
+          role="img"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <svg
-            aria-hidden="true"
-            class="usa-icon margin-right-1"
-            focusable="false"
-            height="1em"
-            role="img"
-            viewBox="0 0 24 24"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 0h24v24H0z"
-              fill="none"
-            />
-            <path
-              d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-            />
-          </svg>
-          Add an additional note
-        </button>
-      </div>
+          <path
+            d="M0 0h24v24H0z"
+            fill="none"
+          />
+          <path
+            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+          />
+        </svg>
+        Add an additional note
+      </button>
     </div>
     <div
       class="margin-top-6 margin-bottom-3"

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOC/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOC/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useRef, useState } from 'react';
+import React, { Fragment, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
@@ -34,6 +34,7 @@ import {
 } from 'queries/OpsEvalAndLearning/types/GetIDDOC';
 import { UpdatePlanOpsEvalAndLearningVariables } from 'queries/OpsEvalAndLearning/types/UpdatePlanOpsEvalAndLearning';
 import UpdatePlanOpsEvalAndLearning from 'queries/OpsEvalAndLearning/UpdatePlanOpsEvalAndLearning';
+import { isDateInPast } from 'utils/date';
 import flattenErrors from 'utils/flattenErrors';
 import { NotFoundPartial } from 'views/NotFound';
 
@@ -43,7 +44,6 @@ const IDDOC = () => {
   const { t } = useTranslation('operationsEvaluationAndLearning');
   const { t: h } = useTranslation('draftModelPlan');
   const { modelID } = useParams<{ modelID: string }>();
-  const [dateInPast, setDateInPast] = useState(false);
 
   const formikRef = useRef<FormikProps<IDDOCFormType>>(null);
   const history = useHistory();
@@ -105,14 +105,6 @@ const IDDOC = () => {
         formikRef?.current?.setErrors(errors);
       });
   };
-
-  useEffect(() => {
-    if (draftIcdDueDate && new Date() > new Date(draftIcdDueDate)) {
-      setDateInPast(true);
-    } else {
-      setDateInPast(false);
-    }
-  }, [draftIcdDueDate]);
 
   const initialValues: IDDOCFormType = {
     __typename: 'PlanOpsEvalAndLearning',
@@ -189,18 +181,10 @@ const IDDOC = () => {
           ) => {
             if (e.target.value === '') {
               setFieldValue(field, null);
-              if (e.target.id !== '') {
-                setDateInPast(false);
-              }
               return;
             }
             try {
               setFieldValue(field, new Date(e.target.value).toISOString());
-              if (new Date() > new Date(e.target.value)) {
-                setDateInPast(true);
-              } else {
-                setDateInPast(false);
-              }
               delete errors[field as keyof IDDOCFormType];
             } catch (err) {
               setFieldError(field, t('validDate'));
@@ -389,12 +373,12 @@ const IDDOC = () => {
                           handleOnBlur(e, 'draftIcdDueDate');
                         }}
                       />
-                      {dateInPast && (
+                      {isDateInPast(values.draftIcdDueDate) && (
                         <DatePickerWarning label={h('dateWarning')} />
                       )}
                     </div>
 
-                    {dateInPast && (
+                    {isDateInPast(values.draftIcdDueDate) && (
                       <Alert type="warning" className="margin-top-4">
                         {h('dateWarning')}
                       </Alert>

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOC/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOC/index.tsx
@@ -3,12 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
-  Alert,
   Breadcrumb,
   BreadcrumbBar,
   BreadcrumbLink,
   Button,
-  DatePicker,
   Fieldset,
   IconArrowBack,
   Label,
@@ -22,7 +20,7 @@ import AskAQuestion from 'components/AskAQuestion';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
 import AutoSave from 'components/shared/AutoSave';
-import DatePickerWarning from 'components/shared/DatePickerWarning';
+import MINTDatePicker from 'components/shared/DatePicker';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
@@ -34,7 +32,6 @@ import {
 } from 'queries/OpsEvalAndLearning/types/GetIDDOC';
 import { UpdatePlanOpsEvalAndLearningVariables } from 'queries/OpsEvalAndLearning/types/UpdatePlanOpsEvalAndLearning';
 import UpdatePlanOpsEvalAndLearning from 'queries/OpsEvalAndLearning/UpdatePlanOpsEvalAndLearning';
-import { isDateInPast } from 'utils/date';
 import flattenErrors from 'utils/flattenErrors';
 import { NotFoundPartial } from 'views/NotFound';
 
@@ -346,49 +343,24 @@ const IDDOC = () => {
                 </FieldGroup>
 
                 {!loading && (
-                  <FieldGroup
-                    scrollElement="draftIcdDueDate"
-                    error={!!flatErrors.draftIcdDueDate}
-                    className="margin-top-6 width-half"
-                  >
-                    <label
-                      htmlFor="ops-eval-and-learning-icd-due-date"
-                      className="text-bold"
-                    >
-                      {t('draftIDC')}
-                    </label>
-                    <div className="usa-hint margin-y-1">
-                      {h('datePlaceholder')}
-                    </div>
-                    <FieldErrorMsg>{flatErrors.draftIcdDueDate}</FieldErrorMsg>
-                    <div className="width-card-lg position-relative">
-                      <Field
-                        as={DatePicker}
-                        error={+!!flatErrors.draftIcdDueDate}
-                        id="ops-eval-and-learning-icd-due-date"
-                        maxLength={50}
-                        name="draftIcdDueDate"
-                        defaultValue={draftIcdDueDate}
-                        onBlur={(e: React.ChangeEvent<HTMLInputElement>) => {
-                          handleOnBlur(e, 'draftIcdDueDate');
-                        }}
-                      />
-                      {isDateInPast(values.draftIcdDueDate) && (
-                        <DatePickerWarning label={h('dateWarning')} />
-                      )}
-                    </div>
-
-                    {isDateInPast(values.draftIcdDueDate) && (
-                      <Alert type="warning" className="margin-top-4">
-                        {h('dateWarning')}
-                      </Alert>
-                    )}
+                  <>
+                    <MINTDatePicker
+                      fieldName="draftIcdDueDate"
+                      id="ops-eval-and-learning-icd-due-date"
+                      className="margin-top-6"
+                      label={t('draftIDC')}
+                      placeHolder
+                      handleOnBlur={handleOnBlur}
+                      formikValue={values.draftIcdDueDate}
+                      value={draftIcdDueDate}
+                      error={flatErrors.draftIcdDueDate}
+                    />
 
                     <AddNote
                       id="ops-eval-and-learning-icd-due-date-note"
                       field="icdNote"
                     />
-                  </FieldGroup>
+                  </>
                 )}
 
                 <div className="margin-top-6 margin-bottom-3">

--- a/src/views/ModelPlan/TaskList/Payment/Recover/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/Payment/Recover/__snapshots__/index.test.tsx.snap
@@ -282,18 +282,18 @@ exports[`Model Plan -- Recover matches snapshot 1`] = `
             </div>
           </div>
           <div
-            class="usa-form-group margin-top-4"
+            class="usa-form-group margin-top-6"
             data-scroll="paymentStartDate"
           >
             <label
-              class="usa-label maxw-none"
+              class="usa-label usa-legend margin-top-0"
               data-testid="label"
-              for="paymentStartDate"
+              for="payment-payment-start-date"
             >
               When will payments start? (Enter an approximate date)
             </label>
             <p
-              class="text-normal margin-bottom-1 margin-top-0"
+              class="text-normal margin-bottom-1 margin-top-0 "
             >
               Note: If you are unsure of an approximate date, please select the first day of the approximate month.
             </p>
@@ -314,6 +314,7 @@ exports[`Model Plan -- Recover matches snapshot 1`] = `
                   aria-hidden="true"
                   class="usa-input usa-sr-only usa-date-picker__internal-input"
                   data-testid="date-picker-internal-input"
+                  error="0"
                   maxlength="50"
                   name="paymentStartDate"
                   readonly=""
@@ -328,6 +329,7 @@ exports[`Model Plan -- Recover matches snapshot 1`] = `
                   <input
                     class="usa-input usa-date-picker__external-input"
                     data-testid="date-picker-external-input"
+                    error="0"
                     id="payment-payment-start-date"
                     maxlength="50"
                     type="text"
@@ -359,27 +361,27 @@ exports[`Model Plan -- Recover matches snapshot 1`] = `
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            class="margin-top-4 margin-bottom-8"
+          >
             <div
-              class="margin-top-4 margin-bottom-8"
+              class="usa-form-group"
             >
-              <div
-                class="usa-form-group"
+              <label
+                class="usa-label"
+                for="payment-payment-start-date-note"
               >
-                <label
-                  class="usa-label"
-                  for="payment-payment-start-date-note"
-                >
-                  Notes
-                </label>
-                <textarea
-                  class="usa-textarea height-15"
-                  data-testid="payment-payment-start-date-note"
-                  id="payment-payment-start-date-note"
-                  name="paymentStartDateNote"
-                >
-                  string
-                </textarea>
-              </div>
+                Notes
+              </label>
+              <textarea
+                class="usa-textarea height-15"
+                data-testid="payment-payment-start-date-note"
+                id="payment-payment-start-date-note"
+                name="paymentStartDateNote"
+              >
+                string
+              </textarea>
             </div>
           </div>
           <div

--- a/src/views/ModelPlan/TaskList/Payment/Recover/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/Recover/index.tsx
@@ -3,12 +3,10 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
-  Alert,
   Breadcrumb,
   BreadcrumbBar,
   BreadcrumbLink,
   Button,
-  DatePicker,
   Fieldset,
   Grid,
   GridContainer,
@@ -25,7 +23,7 @@ import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
 import ReadyForReview from 'components/ReadyForReview';
 import AutoSave from 'components/shared/AutoSave';
-import DatePickerWarning from 'components/shared/DatePickerWarning';
+import MINTDatePicker from 'components/shared/DatePicker';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
@@ -43,7 +41,6 @@ import {
   PayType,
   TaskStatus
 } from 'types/graphql-global-types';
-import { isDateInPast } from 'utils/date';
 import flattenErrors from 'utils/flattenErrors';
 import sanitizeStatus from 'utils/status';
 import { NotFoundPartial } from 'views/NotFound';
@@ -345,55 +342,25 @@ const Recover = () => {
                       </FieldGroup>
 
                       {!loading && (
-                        <FieldGroup
-                          scrollElement="paymentStartDate"
-                          error={!!flatErrors.paymentStartDate}
-                          className="margin-top-4"
-                        >
-                          <Label
-                            htmlFor="paymentStartDate"
-                            className="maxw-none"
-                          >
-                            {t('paymentStartDate')}
-                          </Label>
-                          <p className="text-normal margin-bottom-1 margin-top-0">
-                            {t('paymentStartDateSubcopy')}
-                          </p>
-                          <div className="usa-hint" id="appointment-date-hint">
-                            {h('datePlaceholder')}
-                          </div>
-                          <FieldErrorMsg>
-                            {flatErrors.paymentStartDate}
-                          </FieldErrorMsg>
-                          <div className="width-card-lg position-relative">
-                            <Field
-                              as={DatePicker}
-                              error={!!flatErrors.paymentStartDate}
-                              id="payment-payment-start-date"
-                              maxLength={50}
-                              name="paymentStartDate"
-                              defaultValue={paymentStartDate}
-                              onBlur={(
-                                e: React.ChangeEvent<HTMLInputElement>
-                              ) => {
-                                handleOnBlur(e, 'paymentStartDate');
-                              }}
-                            />
-                            {isDateInPast(values.paymentStartDate) && (
-                              <DatePickerWarning label={h('dateWarning')} />
-                            )}
-                          </div>
-                          {isDateInPast(values.paymentStartDate) && (
-                            <Alert type="warning" className="margin-top-4">
-                              {h('dateWarning')}
-                            </Alert>
-                          )}
+                        <>
+                          <MINTDatePicker
+                            fieldName="paymentStartDate"
+                            id="payment-payment-start-date"
+                            className="margin-top-6"
+                            label={t('paymentStartDate')}
+                            subLabel={t('paymentStartDateSubcopy')}
+                            placeHolder
+                            handleOnBlur={handleOnBlur}
+                            formikValue={values.paymentStartDate}
+                            value={paymentStartDate}
+                            error={flatErrors.paymentStartDate}
+                          />
 
                           <AddNote
                             id="payment-payment-start-date-note"
                             field="paymentStartDateNote"
                           />
-                        </FieldGroup>
+                        </>
                       )}
 
                       <ReadyForReview


### PR DESCRIPTION
# EASI-2189
# EASI-2190

## Changes and Description

- Added date warnings for dates in the past
- Ensured dates render on hard refresh
- Updated previous date implementations to not need state and useeffect

This is a small tech debt ticket to add `<DatePickerWarning />` and alerts for date entered in the past.  This is an existing component that needed to be added to Milestones.

![Screen Shot 2022-09-26 at 10 18 47 AM](https://user-images.githubusercontent.com/95709965/192300346-4950abcd-2d15-43b7-8803-f33957282511.png)

## How to test this change

- Navigate to Milestones on Model Basics
- Enter a date in the past and click outside the input (blur)
- Verify a alert icon and banner appear notifying a past date was entered
- Save the form and do a hard refresh to ensure the dates render on refresh

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
