### PR TITLE
Easi 2114/warning remove self as collaborator

### DIFF
--- a/cypress/e2e/modelPlan.spec.js
+++ b/cypress/e2e/modelPlan.spec.js
@@ -21,7 +21,7 @@ describe('The Model Plan Form', () => {
     cy.contains('button', 'Next').click();
 
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/\/models\/new-plan\/.{36}\/collaborators/);
+      expect(loc.pathname).to.match(/\/models\/.{36}\/collaborators/);
     });
 
     cy.get('[data-testid="continue-to-tasklist"]').click();
@@ -43,7 +43,7 @@ describe('The Model Plan Form', () => {
     cy.contains('button', 'Next').click();
 
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/\/models\/new-plan\/.{36}\/collaborators/);
+      expect(loc.pathname).to.match(/\/models\/.{36}\/collaborators/);
     });
     cy.get('[data-testid="continue-to-tasklist"]').click();
     cy.contains('h1', 'Model Plan task list');
@@ -233,7 +233,7 @@ describe('The Model Plan Form', () => {
     cy.contains('button', 'Next').click();
 
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/\/models\/new-plan\/.{36}\/collaborators/);
+      expect(loc.pathname).to.match(/\/models\/.{36}\/collaborators/);
     });
     cy.get('[data-testid="continue-to-tasklist"]').click();
 

--- a/src/components/Modal/index.scss
+++ b/src/components/Modal/index.scss
@@ -6,7 +6,7 @@
     left: 0;
     right: 0;
     background-color: rgba(0, 0, 0, 0.6);
-    z-index: 400;
+    z-index: 400;    
   }
 
   &__content {
@@ -20,6 +20,7 @@
     z-index: 1;
     font-size: 1.375em;
     line-height: 1.6em;
+    border-radius: .5rem;
 
     @media screen and (min-width: $tablet) {
       width: 668px;

--- a/src/i18n/en-US/draftModelPlan/newModel.ts
+++ b/src/i18n/en-US/draftModelPlan/newModel.ts
@@ -1,6 +1,7 @@
 const newModel = {
   heading: 'Model name',
   breadcrumb: 'Start a new Model Plan',
+  teamBreadcrumb: 'Add model team members',
   modeName: 'What is the name of your model?',
   modelNameInfo:
     'This is not a permanent name. If needed, you may update it later.',
@@ -38,12 +39,24 @@ const newModel = {
     'Don’t edit a team member and return to the previous page',
   addAnotherMember: 'Add another team member',
   modal: {
-    heading: 'Are you sure you want to remove ',
+    heading: 'Are you sure you want to remove {{-collaborator}}?',
     subheading:
       'This team member will not be able to accesss this model plan after they have been removed.',
     confirm: 'Yes, remove team member',
     no: 'No, keep team member',
     remove: 'Remove'
+  },
+  selfModal: {
+    heading: 'Are you sure you want to remove yourself?',
+    subheading:
+      'You will not be able to access this Model Plan after you have been removed.',
+    confirm: 'Remove yourself',
+    no: 'Keep yourself'
+  },
+  success: {
+    heading: 'Success! You have removed yourself from {{-modelName}}.',
+    message:
+      'If you need to access the Model Plan in the future, please contact a member of the model team or the Model Assessment Team.'
   }
 };
 

--- a/src/queries/Collaborators/GetModelCollaborators.ts
+++ b/src/queries/Collaborators/GetModelCollaborators.ts
@@ -4,6 +4,7 @@ export default gql`
   query GetModelCollaborators($id: UUID!) {
     modelPlan(id: $id) {
       id
+      modelName
       collaborators {
         id
         fullName

--- a/src/queries/Collaborators/types/GetModelCollaborators.ts
+++ b/src/queries/Collaborators/types/GetModelCollaborators.ts
@@ -23,6 +23,7 @@ export interface GetModelCollaborators_modelPlan_collaborators {
 export interface GetModelCollaborators_modelPlan {
   __typename: "ModelPlan";
   id: UUID;
+  modelName: string;
   collaborators: GetModelCollaborators_modelPlan_collaborators[];
 }
 

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -101,7 +101,6 @@ const AppRoutes = () => {
       <SecureRoute path="/models/new-plan" component={NewPlan} />
       <SecureRoute
         path="/models/:modelID/collaborators"
-        exact
         component={Collaborators}
       />
       <SecureRoute path="/models/:modelID/documents" component={Documents} />

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -2,12 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import {
-  Alert,
-  Grid,
-  GridContainer,
-  SummaryBox
-} from '@trussworks/react-uswds';
+import { Grid, GridContainer, SummaryBox } from '@trussworks/react-uswds';
 import classnames from 'classnames';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 
@@ -38,11 +33,8 @@ const Home = () => {
         <>
           <NDABanner collapsable />
           <GridContainer>
-            {message && (
-              <Alert type="success" slim role="alert" className="margin-top-6">
-                {message}
-              </Alert>
-            )}
+            {message && message}
+
             <Grid>
               <PageHeading>{t('title')}</PageHeading>
               <p className="line-height-body-5 font-body-lg text-light margin-bottom-6">

--- a/src/views/ModelPlan/Collaborators/AddCollaborator/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/Collaborators/AddCollaborator/__snapshots__/index.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`Adding a collaborator page matches snapshot 1`] = `
         </form>
         <a
           class="usa-link"
-          href="/models/new-plan/f11eb129-2c80-4080-9440-439cbe1a286f/collaborators"
+          href="/models/f11eb129-2c80-4080-9440-439cbe1a286f/collaborators"
         >
           <span>
             ← 

--- a/src/views/ModelPlan/Collaborators/AddCollaborator/index.test.tsx
+++ b/src/views/ModelPlan/Collaborators/AddCollaborator/index.test.tsx
@@ -10,11 +10,11 @@ describe('Adding a collaborator page', () => {
     const { asFragment } = render(
       <MemoryRouter
         initialEntries={[
-          'models/new-plan/f11eb129-2c80-4080-9440-439cbe1a286f/add-collaborator'
+          'models/f11eb129-2c80-4080-9440-439cbe1a286f/collaborators/add-collaborator'
         ]}
       >
         <MockedProvider>
-          <Route path="models/new-plan/:modelID/add-collaborator">
+          <Route path="models/:modelID/collaborators/add-collaborator">
             <AddCollaborator />
           </Route>
         </MockedProvider>

--- a/src/views/ModelPlan/Collaborators/AddCollaborator/index.tsx
+++ b/src/views/ModelPlan/Collaborators/AddCollaborator/index.tsx
@@ -79,7 +79,7 @@ const Collaborators = () => {
       })
         .then(response => {
           if (!response?.errors) {
-            history.push(`/models/new-plan/${modelID}/collaborators`);
+            history.push(`/models/${modelID}/collaborators`);
           }
         })
         .catch(errors => {
@@ -99,7 +99,7 @@ const Collaborators = () => {
       })
         .then(response => {
           if (!response?.errors) {
-            history.push(`/models/new-plan/${modelID}/collaborators`);
+            history.push(`/models/${modelID}/collaborators`);
           }
         })
         .catch(errors => {
@@ -298,7 +298,7 @@ const Collaborators = () => {
               );
             }}
           </Formik>
-          <UswdsReactLink to={`/models/new-plan/${modelID}/collaborators`}>
+          <UswdsReactLink to={`/models/${modelID}/collaborators`}>
             <span>&larr; </span>{' '}
             {!collaboratorId
               ? t('dontAddTeamMember')

--- a/src/views/ModelPlan/Collaborators/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/Collaborators/__snapshots__/index.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Collaborator/Team Member page w/table matches snapshot 1`] = `
                 aria-current="page"
                 class="usa-breadcrumb__list-item usa-current"
               >
-                Start a new Model Plan
+                Add model team members
               </li>
             </ol>
           </nav>
@@ -66,7 +66,7 @@ exports[`Collaborator/Team Member page w/table matches snapshot 1`] = `
           </h4>
           <a
             class="usa-button margin-bottom-2"
-            href="/models/new-plan/f11eb129-2c80-4080-9440-439cbe1a286f/add-collaborator"
+            href="/models/f11eb129-2c80-4080-9440-439cbe1a286f/collaborators/add-collaborator"
           >
             Add team member
           </a>

--- a/src/views/ModelPlan/Collaborators/index.test.tsx
+++ b/src/views/ModelPlan/Collaborators/index.test.tsx
@@ -1,11 +1,24 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
 import { render, screen, waitFor } from '@testing-library/react';
+import configureMockStore from 'redux-mock-store';
 
+import { ASSESSMENT } from 'constants/jobCodes';
+import { MessageProvider } from 'hooks/useMessage';
 import GetModelPlanCollaborators from 'queries/Collaborators/GetModelCollaborators';
 
-import Collaborators from './index';
+import { CollaboratorsContent } from './index';
+
+const mockAuthReducer = {
+  isUserSet: true,
+  groups: [ASSESSMENT],
+  euaId: 'ABCD'
+};
+
+const mockStore = configureMockStore();
+const store = mockStore({ auth: mockAuthReducer });
 
 describe('Collaborator/Team Member page w/table', () => {
   const mocks = [
@@ -18,6 +31,7 @@ describe('Collaborator/Team Member page w/table', () => {
         data: {
           modelPlan: {
             id: '123',
+            modelName: 'My Model',
             collaborators: [
               {
                 id: '61c7b30c-969d-4dd4-b13b-a5065f43be43',
@@ -38,13 +52,17 @@ describe('Collaborator/Team Member page w/table', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          'models/new-plan/f11eb129-2c80-4080-9440-439cbe1a286f/collaborators'
+          'models/f11eb129-2c80-4080-9440-439cbe1a286f/collaborators'
         ]}
       >
         <MockedProvider mocks={mocks} addTypename={false}>
-          <Route path="models/new-plan/:modelID/collaborators">
-            <Collaborators />
-          </Route>
+          <Provider store={store}>
+            <MessageProvider>
+              <Route path="models/:modelID/collaborators">
+                <CollaboratorsContent />
+              </Route>
+            </MessageProvider>
+          </Provider>
         </MockedProvider>
       </MemoryRouter>
     );
@@ -64,13 +82,17 @@ describe('Collaborator/Team Member page w/table', () => {
     const { asFragment } = render(
       <MemoryRouter
         initialEntries={[
-          'models/new-plan/f11eb129-2c80-4080-9440-439cbe1a286f/collaborators'
+          'models/f11eb129-2c80-4080-9440-439cbe1a286f/collaborators'
         ]}
       >
         <MockedProvider mocks={mocks} addTypename={false}>
-          <Route path="models/new-plan/:modelID/collaborators">
-            <Collaborators />
-          </Route>
+          <Provider store={store}>
+            <MessageProvider>
+              <Route path="models/:modelID/collaborators">
+                <CollaboratorsContent />
+              </Route>
+            </MessageProvider>
+          </Provider>
         </MockedProvider>
       </MemoryRouter>
     );

--- a/src/views/ModelPlan/Collaborators/index.tsx
+++ b/src/views/ModelPlan/Collaborators/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RootStateOrAny, useSelector } from 'react-redux';
-import { Link, useHistory, useParams } from 'react-router-dom';
+import { Link, Route, Switch, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
   Breadcrumb,
@@ -28,7 +28,9 @@ import {
   GetModelCollaborators,
   GetModelCollaborators_modelPlan_collaborators as GetCollaboratorsType
 } from 'queries/Collaborators/types/GetModelCollaborators';
+import NotFound from 'views/NotFound';
 
+import AddCollaborator from './AddCollaborator';
 import CollaboratorsTable from './table';
 
 // Checking if there is only one collaborator with role of MODEL_LEAD - can't edit or remove if so
@@ -61,7 +63,7 @@ const SuccessRemovalMessage = ({
   );
 };
 
-const Collaborators = () => {
+export const CollaboratorsContent = () => {
   const { modelID } = useParams<{ modelID: string }>();
   const { t: h } = useTranslation('draftModelPlan');
   const { t } = useTranslation('newModel');
@@ -189,7 +191,7 @@ const Collaborators = () => {
             <UswdsReactLink
               className="usa-button margin-bottom-2"
               variant="unstyled"
-              to={`/models/new-plan/${modelID}/add-collaborator`}
+              to={`/models/${modelID}/collaborators/add-collaborator`}
             >
               {t('addTeamMemberButton')}
             </UswdsReactLink>
@@ -221,6 +223,26 @@ const Collaborators = () => {
         </Grid>
       </GridContainer>
     </MainContent>
+  );
+};
+
+const Collaborators = () => {
+  return (
+    <Switch>
+      <Route
+        path="/models/:modelID/collaborators"
+        exact
+        render={() => <CollaboratorsContent />}
+      />
+      <Route
+        path="/models/:modelID/collaborators/add-collaborator/:collaboratorId?"
+        exact
+        render={() => <AddCollaborator />}
+      />
+
+      {/* 404 */}
+      <Route path="*" render={() => <NotFound />} />
+    </Switch>
   );
 };
 

--- a/src/views/ModelPlan/Collaborators/index.tsx
+++ b/src/views/ModelPlan/Collaborators/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useParams } from 'react-router-dom';
+import { RootStateOrAny, useSelector } from 'react-redux';
+import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
   Breadcrumb,
@@ -16,6 +17,7 @@ import MainContent from 'components/MainContent';
 import Modal from 'components/Modal';
 import PageHeading from 'components/PageHeading';
 import Alert from 'components/shared/Alert';
+import useMessage from 'hooks/useMessage';
 import DeleteModelPlanCollaborator from 'queries/Collaborators/DeleteModelPlanCollaborator';
 import GetModelPlanCollaborators from 'queries/Collaborators/GetModelCollaborators';
 import {
@@ -37,16 +39,47 @@ const isLastModelLead = (collaborators: GetCollaboratorsType[]) => {
   return !(modelLeads.length > 1);
 };
 
+const SuccessRemovalMessage = ({
+  modelName
+}: {
+  modelName: string | undefined;
+}) => {
+  const { t } = useTranslation('newModel');
+  return (
+    <Alert
+      type="success"
+      data-testid="mandatory-fields-alert"
+      className="margin-y-4"
+      heading={t('success.heading', {
+        modelName
+      })}
+    >
+      <span className="mandatory-fields-alert__text">
+        {t('success.message')}
+      </span>
+    </Alert>
+  );
+};
+
 const Collaborators = () => {
   const { modelID } = useParams<{ modelID: string }>();
   const { t: h } = useTranslation('draftModelPlan');
   const { t } = useTranslation('newModel');
+
+  const history = useHistory();
+
+  const { showMessageOnNextPage } = useMessage();
+
   const [isModalOpen, setModalOpen] = useState(false);
   const [isLastLead, setIsLastLead] = useState(false);
+
   const [
     removeCollaborator,
     setRemoveCollaborator
   ] = useState<ModelPlanCollaboratorType>();
+
+  // Current user's EUA id - to warn about removing yourself from model plan
+  const { euaId } = useSelector((state: RootStateOrAny) => state.auth);
 
   const [mutate] = useMutation<DeleteModelPlanCollaboratorType>(
     DeleteModelPlanCollaborator
@@ -81,7 +114,14 @@ const Collaborators = () => {
       .then(response => {
         if (!response?.errors) {
           setModalOpen(false);
-          refetch();
+          if (collaborator.euaUserID === euaId) {
+            showMessageOnNextPage(
+              <SuccessRemovalMessage modelName={data?.modelPlan?.modelName} />
+            );
+            history.push('/');
+          } else {
+            refetch();
+          }
         }
       })
       .catch(errors => {
@@ -91,13 +131,20 @@ const Collaborators = () => {
   };
 
   // Modal control for removing a collaborator
+  // Conditional rendering if attempting to remove yourself from model plan
   const RemoveCollaborator = () => {
+    // i18n key for conditionally rendering text
+    const selfOrCollaborator: string =
+      removeCollaborator?.euaUserID === euaId ? 'selfModal' : 'modal';
+
     return (
       <Modal isOpen={isModalOpen} closeModal={() => setModalOpen(false)}>
         <PageHeading headingLevel="h2" className="margin-top-0">
-          {t('modal.heading')} {removeCollaborator?.fullName}?
+          {t(`${selfOrCollaborator}.heading`, {
+            collaborator: removeCollaborator?.fullName
+          })}
         </PageHeading>
-        <p>{t('modal.subheading')}</p>
+        <p>{t(`${selfOrCollaborator}.subheading`)}</p>
         <Button
           type="button"
           className="margin-right-4"
@@ -105,10 +152,10 @@ const Collaborators = () => {
             removeCollaborator && handleRemoveCollaborator(removeCollaborator)
           }
         >
-          {t('modal.confirm')}
+          {t(`${selfOrCollaborator}.confirm`)}
         </Button>
         <Button type="button" unstyled onClick={() => setModalOpen(false)}>
-          {t('modal.no')}
+          {t(`${selfOrCollaborator}.no`)}
         </Button>
       </Modal>
     );
@@ -130,7 +177,7 @@ const Collaborators = () => {
                   <span>{h('home')}</span>
                 </BreadcrumbLink>
               </Breadcrumb>
-              <Breadcrumb current>{t('breadcrumb')}</Breadcrumb>
+              <Breadcrumb current>{t('teamBreadcrumb')}</Breadcrumb>
             </BreadcrumbBar>
             <PageHeading className="margin-top-4 margin-bottom-2">
               {t('headingTeamMembers')}

--- a/src/views/ModelPlan/Collaborators/table.tsx
+++ b/src/views/ModelPlan/Collaborators/table.tsx
@@ -66,7 +66,7 @@ const CollaboratorsTable = ({
             <>
               <UswdsReactLink
                 className="margin-right-2"
-                to={`/models/new-plan/${modelID}/add-collaborator/${row.original.id}`}
+                to={`/models/${modelID}/collaborators/add-collaborator/${row.original.id}`}
               >
                 {t('table.edit')}
               </UswdsReactLink>

--- a/src/views/ModelPlan/Documents/table.tsx
+++ b/src/views/ModelPlan/Documents/table.tsx
@@ -256,7 +256,7 @@ const Table = ({
         }
       }
     ];
-  }, [t, handleDownload]);
+  }, [t, handleDownload, isCollaborator]);
 
   const {
     getTableProps,

--- a/src/views/ModelPlan/NewPlan/index.tsx
+++ b/src/views/ModelPlan/NewPlan/index.tsx
@@ -26,9 +26,6 @@ import flattenErrors from 'utils/flattenErrors';
 import NewModelPlanValidationSchema from 'validations/newModelPlan';
 import NotFound from 'views/NotFound';
 
-import Collaborators from '../Collaborators';
-import AddCollaborator from '../Collaborators/AddCollaborator';
-
 const NewPlanContent = () => {
   const { t: h } = useTranslation('draftModelPlan');
   const { t } = useTranslation('newModel');
@@ -44,7 +41,7 @@ const NewPlanContent = () => {
     }).then(response => {
       if (!response?.errors) {
         const { id } = response?.data?.createModelPlan;
-        history.push(`/models/new-plan/${id}/collaborators`);
+        history.push(`/models/${id}/collaborators`);
       }
     });
   };
@@ -157,14 +154,6 @@ const NewPlan = () => {
     <Switch>
       {/* New Plan Pages */}
       <Route path="/models/new-plan" exact render={() => <NewPlanContent />} />
-      <Route
-        path="/models/new-plan/:modelID/collaborators"
-        render={() => <Collaborators />}
-      />
-      <Route
-        path="/models/new-plan/:modelID/add-collaborator/:collaboratorId?"
-        render={() => <AddCollaborator />}
-      />
 
       {/* 404 */}
       <Route path="*" render={() => <NotFound />} />

--- a/src/views/ModelPlan/ReadOnly/Team/index.test.tsx
+++ b/src/views/ModelPlan/ReadOnly/Team/index.test.tsx
@@ -43,6 +43,7 @@ const mocks = [
       data: {
         modelPlan: {
           id: modelID,
+          modelName: 'My Model',
           collaborators: mockData
         }
       }

--- a/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.test.tsx
+++ b/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.test.tsx
@@ -17,11 +17,11 @@ describe('The TaskListSideNavActions', () => {
     const { asFragment } = render(
       <MemoryRouter
         initialEntries={[
-          'models/new-plan/f11eb129-2c80-4080-9440-439cbe1a286f/task-list'
+          'models/f11eb129-2c80-4080-9440-439cbe1a286f/task-list'
         ]}
       >
         <MockedProvider>
-          <Route path="models/new-plan/:modelID/task-list">
+          <Route path="models/:modelID/task-list">
             <TaskListSideNav modelPlan={modelPlan} collaborators={[]} />
           </Route>
         </MockedProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11885,12 +11885,7 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
-
-jsonparse@^1.2.0, jsonparse@^1.3.1:
+jsonparse@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=


### PR DESCRIPTION
# EASI-2114

## Changes and Description

- Warning modal when adding yourself as a collaborator
- Message on home screen once user booted from model plan
- Rework collaborator route structure from `/new-plan` to `/collaborators`
- Cypress testing

During working on this ticket I realized our routing for collaborators needed to be reworked, and it was relevant to this ticket.  I decided to include it in here.

Previously all collaborator components were rendering. under `/new-plan` routing, which also affected the access control wrapper.  The change in here is to standardize collaborators route to adhere to conventions throughout the rest of the application

![Screen Shot 2022-10-05 at 1 49 58 PM](https://user-images.githubusercontent.com/95709965/194127682-70a57e44-62aa-4b77-9112-38d90d6bede6.png)

![Screen Shot 2022-10-05 at 1 49 35 PM](https://user-images.githubusercontent.com/95709965/194127598-84a09022-5783-4cea-b8f4-bba483d9e644.png)


## How to test this change

- Log in with only `MINT_USER` role
- Create a model plan
- Add another user with role of model lead
- Remove yourself
- Confirm you are sent to home with Success message appearing
- Attempt to go back (browser back) and you are reidrected to readonly (No longer a part of model plan)

If a user has a role of `MINT_ASSESSMENT` they will still be able to access the model plan/task-list even if not collaborator

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
