### PR TITLE
[NOREF] Remove default for 'includeAll' parameter in 'modelPlanCollection'

### DIFF
--- a/MINT.postman_collection.json
+++ b/MINT.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "8d2821ca-e485-4358-bea0-58db4b47d8de",
+		"_postman_id": "a5cd6241-63b7-4f2a-b183-8801172232ec",
 		"name": "MINT",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "20320964"
+		"_exporter_id": "12341016"
 	},
 	"item": [
 		{
@@ -28,32 +28,7 @@
 							]
 						}
 					},
-					"response": [
-						{
-							"name": "Create Model Plan",
-							"originalRequest": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "graphql",
-									"graphql": {
-										"query": "mutation createModelPlan ($modelName: String!) {\n    createModelPlan (modelName: $modelName) {\n        id\n        modelName\n        archived\n        createdBy\n        createdDts\n        modifiedBy\n        modifiedDts\n        status\n        isFavorite\n        isCollaborator\n    }\n}",
-										"variables": "{\n  \"modelName\": \"Hooray\"\n}"
-									}
-								},
-								"url": {
-									"raw": "{{url}}",
-									"host": [
-										"{{url}}"
-									]
-								}
-							},
-							"_postman_previewlanguage": null,
-							"header": null,
-							"cookie": [],
-							"body": null
-						}
-					]
+					"response": []
 				},
 				{
 					"name": "Update Model Plan",
@@ -105,8 +80,8 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query modelPlanCollection {\n    modelPlanCollection {\n        id\n        modelName\n        archived\n        createdBy\n        createdDts\n        modifiedBy\n        modifiedDts\n        status\n        isFavorite\n        isCollaborator\n    }\n}",
-								"variables": "{}"
+								"query": "query modelPlanCollection($includeAll: Boolean!) {\n    modelPlanCollection(includeAll: $includeAll) {\n        id\n        modelName\n        archived\n        createdBy\n        createdDts\n        modifiedBy\n        modifiedDts\n        status\n        isFavorite\n        isCollaborator\n    }\n}",
+								"variables": "{\n    \"includeAll\": true\n}"
 							}
 						},
 						"url": {
@@ -1134,34 +1109,7 @@
 							]
 						}
 					},
-					"response": [
-						{
-							"name": "GetAuditChanges",
-							"originalRequest": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "graphql",
-									"graphql": {
-										"query": "query auditChanges{\n  auditChanges(tableName: \"model_plan\",primaryKey: \"eb719f40-579a-4c26-9331-b6c71e0fdd37\")\n   {\n        id\n        primaryKey\n        foreignKey\n        tableName\n        action\n        fields\n        modifiedBy\n        modifiedDts\n  }\n}",
-										"variables": "{\n  \"tableName\": \"model_plan\",\n  \"primaryKey\":\"c748e1bb-f70b-4964-983a-66da135da9b8\"\n}"
-									}
-								},
-								"url": {
-									"raw": "{{url}}",
-									"host": [
-										"{{url}}"
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": null,
-							"cookie": [],
-							"body": "{\n    \"data\": {\n        \"auditChanges\": [\n            {\n                \"id\": 4293,\n                \"primaryKey\": \"c748e1bb-f70b-4964-983a-66da135da9b8\",\n                \"foreignKey\": \"00000000-0000-0000-0000-000000000000\",\n                \"tableName\": \"model_plan\",\n                \"action\": \"I\",\n                \"fields\": {\n                    \"model_name\": {\n                        \"new\": \"Hooray\",\n                        \"old\": null\n                    }\n                },\n                \"modifiedBy\": \"MINT\",\n                \"modifiedDts\": \"2022-09-26T22:14:25.440893Z\"\n            }\n        ]\n    }\n}"
-						}
-					]
+					"response": []
 				},
 				{
 					"name": "ModelPlanGet(NameHistory)",
@@ -1197,32 +1145,7 @@
 							]
 						}
 					},
-					"response": [
-						{
-							"name": "ModelPlanGet(NameHistory)",
-							"originalRequest": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "graphql",
-									"graphql": {
-										"query": "query ModelPlan($id:UUID!){\n  \n  modelPlan(id:$id){\n    id\n    modelName\n    nameHistory\n\n  }\n  \n  \n}",
-										"variables": "{\n    \"id\": \"\"\n}"
-									}
-								},
-								"url": {
-									"raw": "{{url}}",
-									"host": [
-										"{{url}}"
-									]
-								}
-							},
-							"_postman_previewlanguage": null,
-							"header": null,
-							"cookie": [],
-							"body": null
-						}
-					]
+					"response": []
 				}
 			]
 		}

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -6851,7 +6851,7 @@ type Query {
   currentUser: CurrentUser!
   modelPlan(id: UUID!): ModelPlan!
   planDocument(id: UUID!): PlanDocument!
-  modelPlanCollection(includeAll: Boolean! = false): [ModelPlan!]!
+  modelPlanCollection(includeAll: Boolean!): [ModelPlan!]!
   existingModelCollection: [ExistingModel!]!
   cedarPersonsByCommonName(commonName: String!): [UserInfo!]!
   planCollaboratorByID(id: UUID!): PlanCollaborator!

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -1362,7 +1362,7 @@ type Query {
   currentUser: CurrentUser!
   modelPlan(id: UUID!): ModelPlan!
   planDocument(id: UUID!): PlanDocument!
-  modelPlanCollection(includeAll: Boolean! = false): [ModelPlan!]!
+  modelPlanCollection(includeAll: Boolean!): [ModelPlan!]!
   existingModelCollection: [ExistingModel!]!
   cedarPersonsByCommonName(commonName: String!): [UserInfo!]!
   planCollaboratorByID(id: UUID!): PlanCollaborator!

--- a/src/queries/GetAllModelData.ts
+++ b/src/queries/GetAllModelData.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 // This is a query to get ALL data for ALL models, used for exporting/reporting features
 export default gql`
-  query GetAllModelData {
-    modelPlanCollection(includeAll: true) {
+  query GetAllModelData($includeAll: Boolean!) {
+    modelPlanCollection(includeAll: $includeAll) {
       id
       modelName
       archived

--- a/src/queries/GetAllModelData.ts
+++ b/src/queries/GetAllModelData.ts
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client';
 // This is a query to get ALL data for ALL models, used for exporting/reporting features
 export default gql`
   query GetAllModelData {
-    modelPlanCollection {
+    modelPlanCollection(includeAll: true) {
       id
       modelName
       archived

--- a/src/queries/GetModelPlans.ts
+++ b/src/queries/GetModelPlans.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client';
 
 export default gql`
-  query GetModelPlans {
-    modelPlanCollection(includeAll: false) {
+  query GetModelPlans($includeAll: Boolean!) {
+    modelPlanCollection(includeAll: $includeAll) {
       id
       modelName
       status

--- a/src/queries/types/GetAllModelData.ts
+++ b/src/queries/types/GetAllModelData.ts
@@ -493,3 +493,7 @@ export interface GetAllModelData_modelPlanCollection {
 export interface GetAllModelData {
   modelPlanCollection: GetAllModelData_modelPlanCollection[];
 }
+
+export interface GetAllModelDataVariables {
+  includeAll: boolean;
+}

--- a/src/queries/types/GetModelPlans.ts
+++ b/src/queries/types/GetModelPlans.ts
@@ -42,3 +42,7 @@ export interface GetModelPlans_modelPlanCollection {
 export interface GetModelPlans {
   modelPlanCollection: GetModelPlans_modelPlanCollection[];
 }
+
+export interface GetModelPlansVariables {
+  includeAll: boolean;
+}

--- a/src/utils/export/CsvExportLink.tsx
+++ b/src/utils/export/CsvExportLink.tsx
@@ -40,11 +40,22 @@ const downloadFile = (data: string) => {
   element.click();
 };
 
-export const CsvExportLink = (): React.ReactElement => {
+type CsvExportLinkType = {
+  includeAll: boolean;
+};
+
+export const CsvExportLink = ({
+  includeAll
+}: CsvExportLinkType): React.ReactElement => {
   const { t } = useTranslation('home');
 
   const [fetchModelCSVData] = useLazyQuery<GetAllModelDataType>(
-    GetAllModelPlans
+    GetAllModelPlans,
+    {
+      variables: {
+        includeAll
+      }
+    }
   );
 
   const fetchData = async () => {

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -73,7 +73,9 @@ const Home = () => {
                     : t('requestsTable.basic.heading')}
                 </h2>
               </div>
-              <DraftModelPlansTable />
+              <DraftModelPlansTable
+                isAssessment={user.isAssessment(userGroups, flags)}
+              />
               <SummaryBox
                 heading=""
                 className="bg-base-lightest border-0 radius-0 padding-2 padding-bottom-3 margin-top-6"

--- a/src/views/ModelPlan/Table/index.tsx
+++ b/src/views/ModelPlan/Table/index.tsx
@@ -39,9 +39,10 @@ import './index.scss';
 type TableProps = {
   data: DraftModelPlanType[];
   hiddenColumns?: string[];
+  showDownloadButton: boolean;
 };
 
-const Table = ({ data, hiddenColumns }: TableProps) => {
+const Table = ({ data, hiddenColumns, showDownloadButton }: TableProps) => {
   const { t } = useTranslation('home');
 
   const columns = useMemo(() => {
@@ -166,9 +167,11 @@ const Table = ({ data, hiddenColumns }: TableProps) => {
           className="margin-bottom-4"
         />
 
-        <div className="flex-align-self-center">
-          <CsvExportLink />
-        </div>
+        {showDownloadButton && (
+          <div className="flex-align-self-center">
+            <CsvExportLink includeAll />
+          </div>
+        )}
       </div>
 
       <TableResults
@@ -288,11 +291,16 @@ const Table = ({ data, hiddenColumns }: TableProps) => {
 
 type DraftModelTableProps = {
   hiddenColumns?: string[];
+  isAssessment: boolean;
 };
 
-const DraftModelPlansTable = ({ hiddenColumns }: DraftModelTableProps) => {
+const DraftModelPlansTable = ({
+  hiddenColumns,
+  isAssessment
+}: DraftModelTableProps) => {
   const { error, loading, data: modelPlans } = useQuery<GetDraftModelPlansType>(
-    GetDraftModelPlans
+    GetDraftModelPlans,
+    { variables: { includeAll: isAssessment } }
   );
 
   const data = (modelPlans?.modelPlanCollection ?? []) as DraftModelPlanType[];
@@ -305,7 +313,13 @@ const DraftModelPlansTable = ({ hiddenColumns }: DraftModelTableProps) => {
     return <div>{JSON.stringify(error)}</div>;
   }
 
-  return <Table data={data} hiddenColumns={hiddenColumns} />;
+  return (
+    <Table
+      data={data}
+      hiddenColumns={hiddenColumns}
+      showDownloadButton={isAssessment}
+    />
+  );
 };
 
 export default DraftModelPlansTable;


### PR DESCRIPTION
# NOREF

## Changes and Description

- Remove `includeAll` default (previously `False`) from the `modelPlanCollection` query
- Update all GQL queries (postman, `src/*`) to pass the parameter if they weren't already.
  - **Note**: For some reason, exported "examples" from the postman collection were not retained when importing/exporting the collection. Feel free to try this yourself by checking out the collection from `main`, importing it, and then immediately exporting it with no changes. For now, I think we should just not have examples in the collection to avoid this.

This change was made because the query that was used to download model plans as CSV was supposed to be downloading ALL model plans, but was instead only downloading the current user's model plans. Additionally, this feature was only intended to show up for assessment users, so additional modifications were made to the code to do this.

## How to test this change

### Validate the Change Locally
1. Start the application with `scripts/dev up`
2. Seed the database with `scripts/dev db:seed`
3. Log in (using local log-in) as `BTAL` (as a regular `MINT_USER`)
  - You should see a single model plan in the "My Model Plans" page
  - You should NOT see a "Download all plans as CSV" button
4. Click the "Models" tab
  - You should see all models, again, with no download button
5. Sign out and back in as `BTAL` (this time with `MINT_USER` and `MINT_ASSESSMENT`)
6. Visit the home page
  - You should see all model plans on the home page
  - You should see a button that says "Download all plans as CSV"
8. Click "Download all plans as CSV"
  - You should see ALL model plans in the downloaded CSV, not just the single one you saw on the page.
9. Click the "Models" tab
  - You should see all models again, this time with no download button

### Validate my changes in the code
- Please double check that I didn't miss any uses of `modelPlanCollection`. Hopefully, typescript would catch this for the frontend, but there could very well be other places I might have missed it (though I think I did a pretty thorough job!)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
