### PR TITLE
[EASI-2399] Added `isAssessment` property to TaskListSectionLockStatus

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -723,9 +723,10 @@ type ComplexityRoot struct {
 	}
 
 	TaskListSectionLockStatus struct {
-		LockedBy    func(childComplexity int) int
-		ModelPlanID func(childComplexity int) int
-		Section     func(childComplexity int) int
+		IsAssessment func(childComplexity int) int
+		LockedBy     func(childComplexity int) int
+		ModelPlanID  func(childComplexity int) int
+		Section      func(childComplexity int) int
 	}
 
 	TaskListSectionLockStatusChanged struct {
@@ -5334,6 +5335,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Subscription.OnTaskListSectionLocksChanged(childComplexity, args["modelPlanID"].(uuid.UUID)), true
 
+	case "TaskListSectionLockStatus.isAssessment":
+		if e.complexity.TaskListSectionLockStatus.IsAssessment == nil {
+			break
+		}
+
+		return e.complexity.TaskListSectionLockStatus.IsAssessment(childComplexity), true
+
 	case "TaskListSectionLockStatus.lockedBy":
 		if e.complexity.TaskListSectionLockStatus.LockedBy == nil {
 			break
@@ -5618,6 +5626,7 @@ type TaskListSectionLockStatus {
   modelPlanID: UUID!
   section: TaskListSection!
   lockedBy: String!
+  isAssessment: Boolean!
 }
 
 """
@@ -14763,6 +14772,8 @@ func (ec *executionContext) fieldContext_Mutation_unlockAllTaskListSections(ctx 
 				return ec.fieldContext_TaskListSectionLockStatus_section(ctx, field)
 			case "lockedBy":
 				return ec.fieldContext_TaskListSectionLockStatus_lockedBy(ctx, field)
+			case "isAssessment":
+				return ec.fieldContext_TaskListSectionLockStatus_isAssessment(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TaskListSectionLockStatus", field.Name)
 		},
@@ -36748,6 +36759,8 @@ func (ec *executionContext) fieldContext_Query_taskListSectionLocks(ctx context.
 				return ec.fieldContext_TaskListSectionLockStatus_section(ctx, field)
 			case "lockedBy":
 				return ec.fieldContext_TaskListSectionLockStatus_lockedBy(ctx, field)
+			case "isAssessment":
+				return ec.fieldContext_TaskListSectionLockStatus_isAssessment(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TaskListSectionLockStatus", field.Name)
 		},
@@ -37622,6 +37635,50 @@ func (ec *executionContext) fieldContext_TaskListSectionLockStatus_lockedBy(ctx 
 	return fc, nil
 }
 
+func (ec *executionContext) _TaskListSectionLockStatus_isAssessment(ctx context.Context, field graphql.CollectedField, obj *model.TaskListSectionLockStatus) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TaskListSectionLockStatus_isAssessment(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsAssessment, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TaskListSectionLockStatus_isAssessment(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskListSectionLockStatus",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TaskListSectionLockStatusChanged_changeType(ctx context.Context, field graphql.CollectedField, obj *model.TaskListSectionLockStatusChanged) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TaskListSectionLockStatusChanged_changeType(ctx, field)
 	if err != nil {
@@ -37711,6 +37768,8 @@ func (ec *executionContext) fieldContext_TaskListSectionLockStatusChanged_lockSt
 				return ec.fieldContext_TaskListSectionLockStatus_section(ctx, field)
 			case "lockedBy":
 				return ec.fieldContext_TaskListSectionLockStatus_lockedBy(ctx, field)
+			case "isAssessment":
+				return ec.fieldContext_TaskListSectionLockStatus_isAssessment(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TaskListSectionLockStatus", field.Name)
 		},
@@ -44795,6 +44854,13 @@ func (ec *executionContext) _TaskListSectionLockStatus(ctx context.Context, sel 
 		case "lockedBy":
 
 			out.Values[i] = ec._TaskListSectionLockStatus_lockedBy(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "isAssessment":
+
+			out.Values[i] = ec._TaskListSectionLockStatus_isAssessment(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -70,9 +70,10 @@ type PlanDocumentInput struct {
 }
 
 type TaskListSectionLockStatus struct {
-	ModelPlanID uuid.UUID       `json:"modelPlanID"`
-	Section     TaskListSection `json:"section"`
-	LockedBy    string          `json:"lockedBy"`
+	ModelPlanID  uuid.UUID       `json:"modelPlanID"`
+	Section      TaskListSection `json:"section"`
+	LockedBy     string          `json:"lockedBy"`
+	IsAssessment bool            `json:"isAssessment"`
 }
 
 type TaskListSectionLockStatusChanged struct {

--- a/pkg/graph/resolvers/plan_task_list_section_locks_test.go
+++ b/pkg/graph/resolvers/plan_task_list_section_locks_test.go
@@ -16,17 +16,16 @@ func (suite *ResolverSuite) TestGetTaskListSectionLocksWithLockedSections() {
 	modelPlanID, _ := uuid.Parse("f11eb129-2c80-4080-9440-439cbe1a286f")
 	lockResolver := NewPlanTaskListSectionLocksResolverImplementation()
 	sections := [...]model.TaskListSection{model.TaskListSectionModelBasics, model.TaskListSectionGeneralCharacteristics}
-	principal := "FAKE"
 
 	ps.EXPECT().Publish(modelPlanID, pubsubevents.TaskListSectionLocksChanged, gomock.Any()).Times(4)
 
 	resultsEmpty, err := lockResolver.GetTaskListSectionLocks(modelPlanID)
 	suite.Assert().NoError(err)
 
-	_, err = lockResolver.LockTaskListSection(ps, modelPlanID, sections[0], principal)
+	_, err = lockResolver.LockTaskListSection(ps, modelPlanID, sections[0], suite.testConfigs.Principal)
 	suite.Assert().NoError(err)
 
-	_, err = lockResolver.LockTaskListSection(ps, modelPlanID, sections[1], principal)
+	_, err = lockResolver.LockTaskListSection(ps, modelPlanID, sections[1], suite.testConfigs.Principal)
 	suite.Assert().NoError(err)
 
 	resultsFilled, err := lockResolver.GetTaskListSectionLocks(modelPlanID)
@@ -39,8 +38,8 @@ func (suite *ResolverSuite) TestGetTaskListSectionLocksWithLockedSections() {
 	assert.Len(suite.T(), resultsFilled, 2)
 	assert.Contains(suite.T(), sections, (*resultsFilled[0]).Section)
 	assert.Contains(suite.T(), sections, (*resultsFilled[1]).Section)
-	assert.Equal(suite.T(), principal, (*resultsFilled[0]).LockedBy)
-	assert.Equal(suite.T(), principal, (*resultsFilled[1]).LockedBy)
+	assert.Equal(suite.T(), "TEST", (*resultsFilled[0]).LockedBy)
+	assert.Equal(suite.T(), "TEST", (*resultsFilled[1]).LockedBy)
 }
 
 func (suite *ResolverSuite) TestLockTaskListSection() {
@@ -48,10 +47,9 @@ func (suite *ResolverSuite) TestLockTaskListSection() {
 	ps := mockpubsub.NewMockPubSub(mockController)
 	modelPlanID, _ := uuid.Parse("f11eb129-2c80-4080-9440-439cbe1a286f")
 	section := model.TaskListSectionModelBasics
-	principal := "FAKE"
 
 	ps.EXPECT().Publish(modelPlanID, pubsubevents.TaskListSectionLocksChanged, gomock.Any())
 
-	_, err := NewPlanTaskListSectionLocksResolverImplementation().LockTaskListSection(ps, modelPlanID, section, principal)
+	_, err := NewPlanTaskListSectionLocksResolverImplementation().LockTaskListSection(ps, modelPlanID, section, suite.testConfigs.Principal)
 	suite.Assert().NoError(err)
 }

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -129,6 +129,7 @@ type TaskListSectionLockStatus {
   modelPlanID: UUID!
   section: TaskListSection!
   lockedBy: String!
+  isAssessment: Boolean!
 }
 
 """

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -282,7 +282,7 @@ func (r *mutationResolver) DeleteDiscussionReply(ctx context.Context, id uuid.UU
 
 // LockTaskListSection is the resolver for the lockTaskListSection field.
 func (r *mutationResolver) LockTaskListSection(ctx context.Context, modelPlanID uuid.UUID, section model.TaskListSection) (bool, error) {
-	principal := appcontext.Principal(ctx).ID()
+	principal := appcontext.Principal(ctx)
 
 	return resolvers.LockTaskListSection(r.pubsub, modelPlanID, section, principal)
 }

--- a/src/queries/TaskListSubscription/GetTaskListSubscriptions.ts
+++ b/src/queries/TaskListSubscription/GetTaskListSubscriptions.ts
@@ -6,6 +6,7 @@ export default gql`
       modelPlanID
       section
       lockedBy
+      isAssessment
     }
   }
 `;

--- a/src/queries/TaskListSubscription/SubscribeToTaskList.ts
+++ b/src/queries/TaskListSubscription/SubscribeToTaskList.ts
@@ -8,6 +8,7 @@ export default gql`
         modelPlanID
         section
         lockedBy
+        isAssessment
       }
       actionType
     }

--- a/src/queries/TaskListSubscription/types/GetTaskListSubscriptions.ts
+++ b/src/queries/TaskListSubscription/types/GetTaskListSubscriptions.ts
@@ -14,6 +14,7 @@ export interface GetTaskListSubscriptions_taskListSectionLocks {
   modelPlanID: UUID;
   section: TaskListSection;
   lockedBy: string;
+  isAssessment: boolean;
 }
 
 export interface GetTaskListSubscriptions {

--- a/src/queries/TaskListSubscription/types/TaskListSubscription.ts
+++ b/src/queries/TaskListSubscription/types/TaskListSubscription.ts
@@ -14,6 +14,7 @@ export interface TaskListSubscription_onLockTaskListSectionContext_lockStatus {
   modelPlanID: UUID;
   section: TaskListSection;
   lockedBy: string;
+  isAssessment: boolean;
 }
 
 export interface TaskListSubscription_onLockTaskListSectionContext {


### PR DESCRIPTION
Co-authored-by: Steven Wade <StevenWadeOddball@users.noreply.github.com>
Co-authored-by: Patrick Segura <patrickseguraoddball@users.noreply.github.com>

# EASI-2399

## Changes and Description

- Added `isAssessment` to TaskListSectionLockStatus. This will make it so the frontend queries can opt to render a different icon next to the lock in this case.

## How to test this change

1. `TODO`

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
