### PR TITLE
[NOREF] Prepare for clearance statuses + GQL

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -6,12 +6,19 @@ ignore = parsing
 
 # Ignoring L014 because it seems to want to uppercase column names if there are capitalized enums defined before the table (like in V11__Add_Plan_General_Characteristics)
 # Ignoring L016 because we break line-length requirements in a few places with comments
-exclude_rules = L014, L016
+# Ignoring L031 so we can use table aliases
+# Ignoreing L034 becase we like to order SQL statements similarly across files
+exclude_rules = L014, L016, L031, L034
 
 [sqlfluff:rules:L010]
 # Inconsistent capitalisation of keywords.
 # https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L010
 capitalisation_policy = upper
+
+[sqlfluff:rules:L031]
+# Avoid table aliases in from clauses and join conditions.
+# https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.Rule_L031
+force_enable = False
 
 [sqlfluff:rules:L040]
 # Inconsistent capitalisation of boolean/null literal.

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -138,6 +138,7 @@ type ComplexityRoot struct {
 		OpsEvalAndLearning       func(childComplexity int) int
 		ParticipantsAndProviders func(childComplexity int) int
 		Payments                 func(childComplexity int) int
+		PrepareForClearance      func(childComplexity int) int
 		Status                   func(childComplexity int) int
 	}
 
@@ -716,6 +717,11 @@ type ComplexityRoot struct {
 		WillRecoverPaymentsNote                           func(childComplexity int) int
 	}
 
+	PrepareForClearance struct {
+		LatestClearanceDts func(childComplexity int) int
+		Status             func(childComplexity int) int
+	}
+
 	Query struct {
 		AuditChanges             func(childComplexity int, tableName string, primaryKey uuid.UUID) int
 		CedarPersonsByCommonName func(childComplexity int, commonName string) int
@@ -774,6 +780,7 @@ type ModelPlanResolver interface {
 	IsFavorite(ctx context.Context, obj *models.ModelPlan) (bool, error)
 	IsCollaborator(ctx context.Context, obj *models.ModelPlan) (bool, error)
 	CrTdls(ctx context.Context, obj *models.ModelPlan) ([]*models.PlanCrTdl, error)
+	PrepareForClearance(ctx context.Context, obj *models.ModelPlan) (*model.PrepareForClearance, error)
 	NameHistory(ctx context.Context, obj *models.ModelPlan, sort models.SortDirection) ([]string, error)
 }
 type MutationResolver interface {
@@ -1410,6 +1417,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ModelPlan.Payments(childComplexity), true
+
+	case "ModelPlan.prepareForClearance":
+		if e.complexity.ModelPlan.PrepareForClearance == nil {
+			break
+		}
+
+		return e.complexity.ModelPlan.PrepareForClearance(childComplexity), true
 
 	case "ModelPlan.status":
 		if e.complexity.ModelPlan.Status == nil {
@@ -5294,6 +5308,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PlanPayments.WillRecoverPaymentsNote(childComplexity), true
 
+	case "PrepareForClearance.latestClearanceDts":
+		if e.complexity.PrepareForClearance.LatestClearanceDts == nil {
+			break
+		}
+
+		return e.complexity.PrepareForClearance.LatestClearanceDts(childComplexity), true
+
+	case "PrepareForClearance.status":
+		if e.complexity.PrepareForClearance.Status == nil {
+			break
+		}
+
+		return e.complexity.PrepareForClearance.Status(childComplexity), true
+
 	case "Query.auditChanges":
 		if e.complexity.Query.AuditChanges == nil {
 			break
@@ -5673,6 +5701,7 @@ type ModelPlan {
   isFavorite: Boolean!
   isCollaborator: Boolean!
   crTdls: [PlanCrTdl!]!
+  prepareForClearance: PrepareForClearance!
   nameHistory(sort: SortDirection! = DESC): [String!]!
 }
 
@@ -6967,6 +6996,10 @@ input PlanCrTdlChanges @goModel(model: "map[string]interface{}") {
     note: String
 }
 
+type PrepareForClearance {
+  status: PrepareForClearanceStatus!
+  latestClearanceDts: Time
+}
 
 type AuditChange {
   id: Int!
@@ -7109,6 +7142,14 @@ enum TaskStatus {
   READY_FOR_REVIEW
   READY_FOR_CLEARANCE
 }
+
+enum PrepareForClearanceStatus {
+  CANNOT_START
+  READY
+  IN_PROGRESS
+  READY_FOR_CLEARANCE
+}
+
 enum TaskStatusInput {
   IN_PROGRESS
   READY_FOR_REVIEW
@@ -12132,6 +12173,56 @@ func (ec *executionContext) fieldContext_ModelPlan_crTdls(ctx context.Context, f
 	return fc, nil
 }
 
+func (ec *executionContext) _ModelPlan_prepareForClearance(ctx context.Context, field graphql.CollectedField, obj *models.ModelPlan) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ModelPlan_prepareForClearance(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ModelPlan().PrepareForClearance(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.PrepareForClearance)
+	fc.Result = res
+	return ec.marshalNPrepareForClearance2ᚖgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐPrepareForClearance(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ModelPlan_prepareForClearance(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ModelPlan",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "status":
+				return ec.fieldContext_PrepareForClearance_status(ctx, field)
+			case "latestClearanceDts":
+				return ec.fieldContext_PrepareForClearance_latestClearanceDts(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PrepareForClearance", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ModelPlan_nameHistory(ctx context.Context, field graphql.CollectedField, obj *models.ModelPlan) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ModelPlan_nameHistory(ctx, field)
 	if err != nil {
@@ -12292,6 +12383,8 @@ func (ec *executionContext) fieldContext_Mutation_createModelPlan(ctx context.Co
 				return ec.fieldContext_ModelPlan_isCollaborator(ctx, field)
 			case "crTdls":
 				return ec.fieldContext_ModelPlan_crTdls(ctx, field)
+			case "prepareForClearance":
+				return ec.fieldContext_ModelPlan_prepareForClearance(ctx, field)
 			case "nameHistory":
 				return ec.fieldContext_ModelPlan_nameHistory(ctx, field)
 			}
@@ -12417,6 +12510,8 @@ func (ec *executionContext) fieldContext_Mutation_updateModelPlan(ctx context.Co
 				return ec.fieldContext_ModelPlan_isCollaborator(ctx, field)
 			case "crTdls":
 				return ec.fieldContext_ModelPlan_crTdls(ctx, field)
+			case "prepareForClearance":
+				return ec.fieldContext_ModelPlan_prepareForClearance(ctx, field)
 			case "nameHistory":
 				return ec.fieldContext_ModelPlan_nameHistory(ctx, field)
 			}
@@ -36920,6 +37015,91 @@ func (ec *executionContext) fieldContext_PlanPayments_status(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _PrepareForClearance_status(ctx context.Context, field graphql.CollectedField, obj *model.PrepareForClearance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PrepareForClearance_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.PrepareForClearanceStatus)
+	fc.Result = res
+	return ec.marshalNPrepareForClearanceStatus2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐPrepareForClearanceStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PrepareForClearance_status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PrepareForClearance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type PrepareForClearanceStatus does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PrepareForClearance_latestClearanceDts(ctx context.Context, field graphql.CollectedField, obj *model.PrepareForClearance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PrepareForClearance_latestClearanceDts(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LatestClearanceDts, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PrepareForClearance_latestClearanceDts(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PrepareForClearance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_currentUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_currentUser(ctx, field)
 	if err != nil {
@@ -37049,6 +37229,8 @@ func (ec *executionContext) fieldContext_Query_modelPlan(ctx context.Context, fi
 				return ec.fieldContext_ModelPlan_isCollaborator(ctx, field)
 			case "crTdls":
 				return ec.fieldContext_ModelPlan_crTdls(ctx, field)
+			case "prepareForClearance":
+				return ec.fieldContext_ModelPlan_prepareForClearance(ctx, field)
 			case "nameHistory":
 				return ec.fieldContext_ModelPlan_nameHistory(ctx, field)
 			}
@@ -37243,6 +37425,8 @@ func (ec *executionContext) fieldContext_Query_modelPlanCollection(ctx context.C
 				return ec.fieldContext_ModelPlan_isCollaborator(ctx, field)
 			case "crTdls":
 				return ec.fieldContext_ModelPlan_crTdls(ctx, field)
+			case "prepareForClearance":
+				return ec.fieldContext_ModelPlan_prepareForClearance(ctx, field)
 			case "nameHistory":
 				return ec.fieldContext_ModelPlan_nameHistory(ctx, field)
 			}
@@ -41417,6 +41601,26 @@ func (ec *executionContext) _ModelPlan(ctx context.Context, sel ast.SelectionSet
 				return innerFunc(ctx)
 
 			})
+		case "prepareForClearance":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ModelPlan_prepareForClearance(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		case "nameHistory":
 			field := field
 
@@ -45315,6 +45519,38 @@ func (ec *executionContext) _PlanPayments(ctx context.Context, sel ast.Selection
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var prepareForClearanceImplementors = []string{"PrepareForClearance"}
+
+func (ec *executionContext) _PrepareForClearance(ctx context.Context, sel ast.SelectionSet, obj *model.PrepareForClearance) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, prepareForClearanceImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("PrepareForClearance")
+		case "status":
+
+			out.Values[i] = ec._PrepareForClearance_status(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "latestClearanceDts":
+
+			out.Values[i] = ec._PrepareForClearance_latestClearanceDts(ctx, field, obj)
+
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -50857,6 +51093,30 @@ func (ec *executionContext) marshalNPpToAdvertiseType2ᚕgithubᚗcomᚋcmsgov�
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalNPrepareForClearance2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐPrepareForClearance(ctx context.Context, sel ast.SelectionSet, v model.PrepareForClearance) graphql.Marshaler {
+	return ec._PrepareForClearance(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNPrepareForClearance2ᚖgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐPrepareForClearance(ctx context.Context, sel ast.SelectionSet, v *model.PrepareForClearance) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._PrepareForClearance(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNPrepareForClearanceStatus2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐPrepareForClearanceStatus(ctx context.Context, v interface{}) (model.PrepareForClearanceStatus, error) {
+	var res model.PrepareForClearanceStatus
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNPrepareForClearanceStatus2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐPrepareForClearanceStatus(ctx context.Context, sel ast.SelectionSet, v model.PrepareForClearanceStatus) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) unmarshalNProviderAddType2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐProviderAddType(ctx context.Context, v interface{}) (model.ProviderAddType, error) {

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -69,6 +69,11 @@ type PlanDocumentInput struct {
 	OptionalNotes        *string             `json:"optionalNotes"`
 }
 
+type PrepareForClearance struct {
+	Status             PrepareForClearanceStatus `json:"status"`
+	LatestClearanceDts *time.Time                `json:"latestClearanceDts"`
+}
+
 type TaskListSectionLockStatus struct {
 	ModelPlanID  uuid.UUID       `json:"modelPlanID"`
 	Section      TaskListSection `json:"section"`
@@ -2469,6 +2474,51 @@ func (e *PpToAdvertiseType) UnmarshalGQL(v interface{}) error {
 }
 
 func (e PpToAdvertiseType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type PrepareForClearanceStatus string
+
+const (
+	PrepareForClearanceStatusCannotStart       PrepareForClearanceStatus = "CANNOT_START"
+	PrepareForClearanceStatusReady             PrepareForClearanceStatus = "READY"
+	PrepareForClearanceStatusInProgress        PrepareForClearanceStatus = "IN_PROGRESS"
+	PrepareForClearanceStatusReadyForClearance PrepareForClearanceStatus = "READY_FOR_CLEARANCE"
+)
+
+var AllPrepareForClearanceStatus = []PrepareForClearanceStatus{
+	PrepareForClearanceStatusCannotStart,
+	PrepareForClearanceStatusReady,
+	PrepareForClearanceStatusInProgress,
+	PrepareForClearanceStatusReadyForClearance,
+}
+
+func (e PrepareForClearanceStatus) IsValid() bool {
+	switch e {
+	case PrepareForClearanceStatusCannotStart, PrepareForClearanceStatusReady, PrepareForClearanceStatusInProgress, PrepareForClearanceStatusReadyForClearance:
+		return true
+	}
+	return false
+}
+
+func (e PrepareForClearanceStatus) String() string {
+	return string(e)
+}
+
+func (e *PrepareForClearanceStatus) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = PrepareForClearanceStatus(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid PrepareForClearanceStatus", str)
+	}
+	return nil
+}
+
+func (e PrepareForClearanceStatus) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/pkg/graph/resolvers/prepare_for_clearance.go
+++ b/pkg/graph/resolvers/prepare_for_clearance.go
@@ -1,0 +1,58 @@
+package resolvers
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/cmsgov/mint-app/pkg/graph/model"
+	"github.com/cmsgov/mint-app/pkg/models"
+	"github.com/cmsgov/mint-app/pkg/storage"
+)
+
+// ReadyForClearanceRead handles requests to read a information about a Model Plan's "Ready for Clearance" section
+func ReadyForClearanceRead(
+	logger *zap.Logger,
+	store *storage.Store,
+	modelPlanID uuid.UUID,
+) (*model.PrepareForClearance, error) {
+	clearanceData, err := store.ReadyForClearanceGetByModelPlanID(logger, modelPlanID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := model.PrepareForClearance{
+		Status:             calculateStatus(clearanceData, time.Now()),
+		LatestClearanceDts: clearanceData.MostRecentClearanceDts,
+	}
+
+	return &result, nil
+}
+
+func calculateStatus(clearanceData *models.PrepareForClearanceResponse, now time.Time) model.PrepareForClearanceStatus {
+	// If we don't yet have a clearance date, we cannot start this section yet!
+	if clearanceData.BasicsClearanceStarts == nil {
+		return model.PrepareForClearanceStatusCannotStart
+	}
+
+	// We have a clearance date, so we can calculate 20 days prior to that date
+	// If we're before that calculated date, we can't start the section.
+	twentyDaysBeforeClearance := clearanceData.BasicsClearanceStarts.Add(-time.Hour * 24 * 20)
+	if now.Before(twentyDaysBeforeClearance) {
+		return model.PrepareForClearanceStatusCannotStart
+	}
+
+	// If every section is ready for clearance, the status is ready for clearance no matter what!
+	if clearanceData.AllReadyForClearance {
+		return model.PrepareForClearanceStatusReadyForClearance
+	}
+
+	// If there's anything in-progress (i.e. our latest clearance-time is not null) we're in progress
+	if clearanceData.MostRecentClearanceDts != nil {
+		return model.PrepareForClearanceStatusInProgress
+	}
+
+	// Otherwise, we haven't started yet!
+	return model.PrepareForClearanceStatusReady
+}

--- a/pkg/graph/resolvers/prepare_for_clearance_test.go
+++ b/pkg/graph/resolvers/prepare_for_clearance_test.go
@@ -1,0 +1,192 @@
+package resolvers
+
+import (
+	"time"
+
+	"github.com/cmsgov/mint-app/pkg/graph/model"
+	"github.com/cmsgov/mint-app/pkg/models"
+)
+
+type testDates struct {
+	jan25 time.Time
+	jan15 time.Time
+	jan05 time.Time
+	jan01 time.Time
+}
+
+func getTestDates() *testDates {
+	jan25, _ := time.Parse(time.RFC3339, "2022-01-25T12:00:00Z")
+	jan15, _ := time.Parse(time.RFC3339, "2022-01-15T12:00:00Z")
+	jan05, _ := time.Parse(time.RFC3339, "2022-01-05T12:00:00Z")
+	jan01, _ := time.Parse(time.RFC3339, "2022-01-01T12:00:00Z")
+	return &testDates{
+		jan25: jan25,
+		jan15: jan15,
+		jan05: jan05,
+		jan01: jan01,
+	}
+}
+
+// TestReadyForClearanceRead tests ReadyForClearanceRead
+func (suite *ResolverSuite) TestReadyForClearanceRead() {
+	// TODO: Write this out :)
+}
+
+// TestCalculateStatusNoClearanceDate tests calculateStatus in the case that it should return a status of
+// "Cannot Start" due to there not being a clearance start date
+func (suite *ResolverSuite) TestCalculateStatusNoClearanceDate() {
+	td := getTestDates()
+
+	status := calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: nil,
+		BasicsClearanceStarts:  nil, // No clearance date
+		AllReadyForClearance:   true,
+	}, td.jan01)
+	suite.EqualValues(model.PrepareForClearanceStatusCannotStart, status)
+
+	status = calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: &td.jan15,
+		BasicsClearanceStarts:  nil, // No clearance date
+		AllReadyForClearance:   true,
+	}, td.jan25)
+	suite.EqualValues(model.PrepareForClearanceStatusCannotStart, status)
+
+	status = calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: &td.jan15,
+		BasicsClearanceStarts:  nil, // No clearance date
+		AllReadyForClearance:   false,
+	}, td.jan25)
+	suite.EqualValues(model.PrepareForClearanceStatusCannotStart, status)
+}
+
+// TestCalculateStatusTooEarly tests calculateStatus in the case that it should return a status of
+// "Cannot Start" due to being more than twenty days from the clearance date
+func (suite *ResolverSuite) TestCalculateStatusTooEarly() {
+	td := getTestDates()
+
+	status := calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: nil,
+		BasicsClearanceStarts:  &td.jan25,
+		AllReadyForClearance:   true,
+	}, td.jan01)
+	suite.EqualValues(model.PrepareForClearanceStatusCannotStart, status)
+
+	status = calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: &td.jan15,
+		BasicsClearanceStarts:  &td.jan25,
+		AllReadyForClearance:   true,
+	}, td.jan01)
+	suite.EqualValues(model.PrepareForClearanceStatusCannotStart, status)
+
+	status = calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: &td.jan15,
+		BasicsClearanceStarts:  &td.jan25,
+		AllReadyForClearance:   false,
+	}, td.jan01)
+	suite.EqualValues(model.PrepareForClearanceStatusCannotStart, status)
+}
+
+// TestCalculateStatusAllReady tests calculateStatus in the case that it should return a status of
+// "Ready for Clearance" due to it being less than 20 days from the clearance start and all sections
+// being ready for clearance
+func (suite *ResolverSuite) TestCalculateStatusAllReady() {
+	td := getTestDates()
+
+	status := calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: nil,
+		BasicsClearanceStarts:  &td.jan25,
+		AllReadyForClearance:   true,
+	}, td.jan05)
+	suite.EqualValues(model.PrepareForClearanceStatusReadyForClearance, status)
+
+	status = calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: &td.jan15,
+		BasicsClearanceStarts:  &td.jan25,
+		AllReadyForClearance:   true,
+	}, td.jan15)
+	suite.EqualValues(model.PrepareForClearanceStatusReadyForClearance, status)
+
+	status = calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: &td.jan15,
+		BasicsClearanceStarts:  &td.jan25,
+		AllReadyForClearance:   true,
+	}, td.jan25)
+	suite.EqualValues(model.PrepareForClearanceStatusReadyForClearance, status)
+
+	status = calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: &td.jan15,
+		BasicsClearanceStarts:  &td.jan15,
+		AllReadyForClearance:   true,
+	}, td.jan25)
+	suite.EqualValues(model.PrepareForClearanceStatusReadyForClearance, status)
+}
+
+// TestCalculateStatusInProgress tests calculateStatus in the case that it should return a status of
+// "In Progress" due to it being less than 20 days from the clearance start, not all sections are ready for clearance,
+// and the most recent clearance dts is not nil
+func (suite *ResolverSuite) TestCalculateStatusInProgress() {
+	td := getTestDates()
+
+	status := calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: &td.jan01,
+		BasicsClearanceStarts:  &td.jan25,
+		AllReadyForClearance:   false,
+	}, td.jan05)
+	suite.EqualValues(model.PrepareForClearanceStatusInProgress, status)
+
+	status = calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: &td.jan15,
+		BasicsClearanceStarts:  &td.jan25,
+		AllReadyForClearance:   false,
+	}, td.jan15)
+	suite.EqualValues(model.PrepareForClearanceStatusInProgress, status)
+
+	status = calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: &td.jan15,
+		BasicsClearanceStarts:  &td.jan25,
+		AllReadyForClearance:   false,
+	}, td.jan25)
+	suite.EqualValues(model.PrepareForClearanceStatusInProgress, status)
+
+	status = calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: &td.jan15,
+		BasicsClearanceStarts:  &td.jan15,
+		AllReadyForClearance:   false,
+	}, td.jan25)
+	suite.EqualValues(model.PrepareForClearanceStatusInProgress, status)
+}
+
+// TestCalculateStatusReady tests calculateStatus in the case that it should return a status of
+// "Ready to Start" due to it being less than 20 days from the clearance start, not all sections are ready for clearance,
+// and the most recent clearance dts is nil
+func (suite *ResolverSuite) TestCalculateStatusReady() {
+	td := getTestDates()
+
+	status := calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: nil,
+		BasicsClearanceStarts:  &td.jan25,
+		AllReadyForClearance:   false,
+	}, td.jan05)
+	suite.EqualValues(model.PrepareForClearanceStatusReady, status)
+
+	status = calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: nil,
+		BasicsClearanceStarts:  &td.jan25,
+		AllReadyForClearance:   false,
+	}, td.jan15)
+	suite.EqualValues(model.PrepareForClearanceStatusReady, status)
+
+	status = calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: nil,
+		BasicsClearanceStarts:  &td.jan25,
+		AllReadyForClearance:   false,
+	}, td.jan25)
+	suite.EqualValues(model.PrepareForClearanceStatusReady, status)
+
+	status = calculateStatus(&models.PrepareForClearanceResponse{
+		MostRecentClearanceDts: nil,
+		BasicsClearanceStarts:  &td.jan15,
+		AllReadyForClearance:   false,
+	}, td.jan25)
+	suite.EqualValues(model.PrepareForClearanceStatusReady, status)
+}

--- a/pkg/graph/resolvers/prepare_for_clearance_test.go
+++ b/pkg/graph/resolvers/prepare_for_clearance_test.go
@@ -29,7 +29,131 @@ func getTestDates() *testDates {
 
 // TestReadyForClearanceRead tests ReadyForClearanceRead
 func (suite *ResolverSuite) TestReadyForClearanceRead() {
-	// TODO: Write this out :)
+	plan := suite.createModelPlan("Plan for Clearance")
+
+	// No updates to model plan - shouldn't be ready to start
+	planClearance, err := ReadyForClearanceRead(suite.testConfigs.Logger, suite.testConfigs.Store, plan.ID)
+	suite.NoError(err)
+	suite.EqualValues(model.PrepareForClearanceStatusCannotStart, planClearance.Status)
+	suite.Nil(planClearance.LatestClearanceDts)
+
+	// Update the basics to have a clearance date set that's too far out (more than 20 days)
+	basics, err := PlanBasicsGetByModelPlanID(suite.testConfigs.Logger, plan.ID, suite.testConfigs.Store)
+	suite.NoError(err)
+	_, err = UpdatePlanBasics(suite.testConfigs.Logger, basics.ID, map[string]interface{}{
+		"clearanceStarts": time.Now().Add(time.Hour * 24 * 21).Format(time.RFC3339), // 21 days from now
+	}, suite.testConfigs.Principal, suite.testConfigs.Store)
+	suite.NoError(err)
+	// Clearance start date is 21 days out, still shouldn't be ready to start
+	planClearance, err = ReadyForClearanceRead(suite.testConfigs.Logger, suite.testConfigs.Store, plan.ID)
+	suite.NoError(err)
+	suite.EqualValues(model.PrepareForClearanceStatusCannotStart, planClearance.Status)
+	suite.Nil(planClearance.LatestClearanceDts)
+
+	// Update the basics to have a clearance date set that's within the date range (15 days)
+	basics, err = PlanBasicsGetByModelPlanID(suite.testConfigs.Logger, plan.ID, suite.testConfigs.Store)
+	suite.NoError(err)
+	_, err = UpdatePlanBasics(suite.testConfigs.Logger, basics.ID, map[string]interface{}{
+		"clearanceStarts": time.Now().Add(time.Hour * 24 * 15).Format(time.RFC3339), // 15 days from now
+	}, suite.testConfigs.Principal, suite.testConfigs.Store)
+	suite.NoError(err)
+	// Clearance start date is 15 days out - should be "Ready to Start"
+	planClearance, err = ReadyForClearanceRead(suite.testConfigs.Logger, suite.testConfigs.Store, plan.ID)
+	suite.NoError(err)
+	suite.EqualValues(model.PrepareForClearanceStatusReady, planClearance.Status)
+	suite.Nil(planClearance.LatestClearanceDts)
+
+	// Update the basics to be marked ready for clearance
+	basics, err = PlanBasicsGetByModelPlanID(suite.testConfigs.Logger, plan.ID, suite.testConfigs.Store)
+	suite.NoError(err)
+	_, err = UpdatePlanBasics(suite.testConfigs.Logger, basics.ID, map[string]interface{}{
+		"status": model.TaskStatusInputReadyForClearance,
+	}, suite.testConfigs.Principal, suite.testConfigs.Store)
+	suite.NoError(err)
+	// Clearance start date is 15 days out & we've started by marking Basics as ready for clearance - should be "In Progress"
+	planClearance, err = ReadyForClearanceRead(suite.testConfigs.Logger, suite.testConfigs.Store, plan.ID)
+	suite.NoError(err)
+	suite.EqualValues(model.PrepareForClearanceStatusInProgress, planClearance.Status)
+	suite.NotNil(planClearance.LatestClearanceDts)
+	// Save the latest clearance DTS, as the next time we update one, it should be later than this one
+	// Yes, this _IS_ sketchy, as it's possible this test flakes if both the previous setting of the clearanceDts and the next
+	// happen within the same millisecond. I just assume that's not going to happen :)
+	previousLatestClearanceDts := *planClearance.LatestClearanceDts
+
+	// Update the general characteristics to be marked ready for clearance
+	genChar, err := FetchPlanGeneralCharacteristicsByModelPlanID(suite.testConfigs.Logger, plan.ID, suite.testConfigs.Store)
+	suite.NoError(err)
+	_, err = UpdatePlanGeneralCharacteristics(suite.testConfigs.Logger, genChar.ID, map[string]interface{}{
+		"status": model.TaskStatusInputReadyForClearance,
+	}, suite.testConfigs.Principal, suite.testConfigs.Store)
+	suite.NoError(err)
+	// Clearance start date is 15 days out & we've marked General Characteristics as ready for clearance - should still be "In Progress"
+	planClearance, err = ReadyForClearanceRead(suite.testConfigs.Logger, suite.testConfigs.Store, plan.ID)
+	suite.NoError(err)
+	suite.EqualValues(model.PrepareForClearanceStatusInProgress, planClearance.Status)
+	suite.NotNil(planClearance.LatestClearanceDts)
+	suite.True(planClearance.LatestClearanceDts.After(previousLatestClearanceDts)) // this new clearanceDts should be after the last one we saw
+	previousLatestClearanceDts = *planClearance.LatestClearanceDts
+
+	// Update the participants and providers to be marked ready for clearance
+	participants, err := PlanParticipantsAndProvidersGetByModelPlanID(suite.testConfigs.Logger, plan.ID, suite.testConfigs.Store)
+	suite.NoError(err)
+	_, err = PlanParticipantsAndProvidersUpdate(suite.testConfigs.Logger, participants.ID, map[string]interface{}{
+		"status": model.TaskStatusInputReadyForClearance,
+	}, suite.testConfigs.Principal, suite.testConfigs.Store)
+	suite.NoError(err)
+	// Clearance start date is 15 days out & we've marked Participants & Providers as ready for clearance - should still be "In Progress"
+	planClearance, err = ReadyForClearanceRead(suite.testConfigs.Logger, suite.testConfigs.Store, plan.ID)
+	suite.NoError(err)
+	suite.EqualValues(model.PrepareForClearanceStatusInProgress, planClearance.Status)
+	suite.NotNil(planClearance.LatestClearanceDts)
+	suite.True(planClearance.LatestClearanceDts.After(previousLatestClearanceDts)) // this new clearanceDts should be after the last one we saw
+	previousLatestClearanceDts = *planClearance.LatestClearanceDts
+
+	// Update the participants and providers to be marked ready for clearance
+	benes, err := PlanBeneficiariesGetByModelPlanID(suite.testConfigs.Logger, plan.ID, suite.testConfigs.Store)
+	suite.NoError(err)
+	_, err = PlanBeneficiariesUpdate(suite.testConfigs.Logger, benes.ID, map[string]interface{}{
+		"status": model.TaskStatusInputReadyForClearance,
+	}, suite.testConfigs.Principal, suite.testConfigs.Store)
+	suite.NoError(err)
+	// Clearance start date is 15 days out & we've marked Beneficiaries as ready for clearance - should still be "In Progress"
+	planClearance, err = ReadyForClearanceRead(suite.testConfigs.Logger, suite.testConfigs.Store, plan.ID)
+	suite.NoError(err)
+	suite.EqualValues(model.PrepareForClearanceStatusInProgress, planClearance.Status)
+	suite.NotNil(planClearance.LatestClearanceDts)
+	suite.True(planClearance.LatestClearanceDts.After(previousLatestClearanceDts)) // this new clearanceDts should be after the last one we saw
+	previousLatestClearanceDts = *planClearance.LatestClearanceDts
+
+	// Update the ops, eval, & learning to be marked ready for clearance
+	opsEvalLearning, err := PlanOpsEvalAndLearningGetByModelPlanID(suite.testConfigs.Logger, plan.ID, suite.testConfigs.Store)
+	suite.NoError(err)
+	_, err = PlanOpsEvalAndLearningUpdate(suite.testConfigs.Logger, opsEvalLearning.ID, map[string]interface{}{
+		"status": model.TaskStatusInputReadyForClearance,
+	}, suite.testConfigs.Principal, suite.testConfigs.Store)
+	suite.NoError(err)
+	// Clearance start date is 15 days out & we've marked ops, eval, & learning as ready for clearance - should still be "In Progress"
+	planClearance, err = ReadyForClearanceRead(suite.testConfigs.Logger, suite.testConfigs.Store, plan.ID)
+	suite.NoError(err)
+	suite.EqualValues(model.PrepareForClearanceStatusInProgress, planClearance.Status)
+	suite.NotNil(planClearance.LatestClearanceDts)
+	suite.True(planClearance.LatestClearanceDts.After(previousLatestClearanceDts)) // this new clearanceDts should be after the last one we saw
+	previousLatestClearanceDts = *planClearance.LatestClearanceDts
+
+	// Update the payments to be marked ready for clearance
+	// NOTE: This is the final section, so we expect the status to change!
+	payments, err := PlanPaymentsReadByModelPlan(suite.testConfigs.Logger, suite.testConfigs.Store, plan.ID)
+	suite.NoError(err)
+	_, err = PlanPaymentsUpdate(suite.testConfigs.Logger, suite.testConfigs.Store, payments.ID, map[string]interface{}{
+		"status": model.TaskStatusInputReadyForClearance,
+	}, suite.testConfigs.Principal)
+	suite.NoError(err)
+	// Clearance start date is 15 days out & we've marked payments as ready for clearance - should finally be "Ready for Clearance"
+	planClearance, err = ReadyForClearanceRead(suite.testConfigs.Logger, suite.testConfigs.Store, plan.ID)
+	suite.NoError(err)
+	suite.EqualValues(model.PrepareForClearanceStatusReadyForClearance, planClearance.Status)
+	suite.NotNil(planClearance.LatestClearanceDts)
+	suite.True(planClearance.LatestClearanceDts.After(previousLatestClearanceDts)) // this new clearanceDts should be after the last one we saw
 }
 
 // TestCalculateStatusNoClearanceDate tests calculateStatus in the case that it should return a status of

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -64,6 +64,7 @@ type ModelPlan {
   isFavorite: Boolean!
   isCollaborator: Boolean!
   crTdls: [PlanCrTdl!]!
+  prepareForClearance: PrepareForClearance!
   nameHistory(sort: SortDirection! = DESC): [String!]!
 }
 
@@ -1358,6 +1359,10 @@ input PlanCrTdlChanges @goModel(model: "map[string]interface{}") {
     note: String
 }
 
+type PrepareForClearance {
+  status: PrepareForClearanceStatus!
+  latestClearanceDts: Time
+}
 
 type AuditChange {
   id: Int!
@@ -1500,6 +1505,14 @@ enum TaskStatus {
   READY_FOR_REVIEW
   READY_FOR_CLEARANCE
 }
+
+enum PrepareForClearanceStatus {
+  CANNOT_START
+  READY
+  IN_PROGRESS
+  READY_FOR_CLEARANCE
+}
+
 enum TaskStatusInput {
   IN_PROGRESS
   READY_FOR_REVIEW

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -116,6 +116,12 @@ func (r *modelPlanResolver) CrTdls(ctx context.Context, obj *models.ModelPlan) (
 	return resolvers.PlanCrTdlsGetByModelPlanID(logger, obj.ID, r.store)
 }
 
+// PrepareForClearance is the resolver for the prepareForClearance field.
+func (r *modelPlanResolver) PrepareForClearance(ctx context.Context, obj *models.ModelPlan) (*model.PrepareForClearance, error) {
+	logger := appcontext.ZLogger(ctx)
+	return resolvers.ReadyForClearanceRead(logger, r.store, obj.ID)
+}
+
 // NameHistory is the resolver for the nameHistory field.
 func (r *modelPlanResolver) NameHistory(ctx context.Context, obj *models.ModelPlan, sort models.SortDirection) ([]string, error) {
 	logger := appcontext.ZLogger(ctx)

--- a/pkg/models/prepare_for_clearance.go
+++ b/pkg/models/prepare_for_clearance.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+// PrepareForClearanceResponse represents a response from the ReadyForClearanceGetByModelPlanID store method
+// It does _NOT_ represent anything in the GraphQL response, it only exists to calculate values for the GraphQL resolver.
+type PrepareForClearanceResponse struct {
+	MostRecentClearanceDts *time.Time `db:"most_recent_clearance_dts"`
+	BasicsClearanceStarts  *time.Time `db:"clearance_starts"`
+	AllReadyForClearance   bool       `db:"all_ready_for_clearance"`
+}

--- a/pkg/storage/SQL/prepare_for_clearance_get_by_model_plan_id.sql
+++ b/pkg/storage/SQL/prepare_for_clearance_get_by_model_plan_id.sql
@@ -1,0 +1,36 @@
+SELECT
+    GREATEST(
+        basics.ready_for_clearance_dts,
+        charact.ready_for_clearance_dts,
+        part.ready_for_clearance_dts,
+        bene.ready_for_clearance_dts,
+        ops.ready_for_clearance_dts,
+        pay.ready_for_clearance_dts
+    ) AS most_recent_clearance_dts,
+    basics.clearance_starts,
+    (
+        GREATEST(
+            basics.status,
+            charact.status,
+            part.status,
+            bene.status,
+            ops.status,
+            pay.status
+        ) = LEAST(
+            basics.status,
+            charact.status,
+            part.status,
+            bene.status,
+            ops.status,
+            pay.status
+        )
+    )
+    AND basics.status = 'READY_FOR_CLEARANCE' AS all_ready_for_clearance
+FROM model_plan AS mp
+LEFT JOIN plan_basics AS basics ON basics.model_plan_id = mp.id
+LEFT JOIN plan_general_characteristics AS charact ON charact.model_plan_id = mp.id
+LEFT JOIN plan_participants_and_providers AS part ON part.model_plan_id = mp.id
+LEFT JOIN plan_beneficiaries AS bene ON bene.model_plan_id = mp.id
+LEFT JOIN plan_ops_eval_and_learning AS ops ON ops.model_plan_id = mp.id
+LEFT JOIN plan_payments AS pay ON pay.model_plan_id = mp.id
+WHERE mp.id = :model_plan_id

--- a/pkg/storage/prepare_for_clearance.go
+++ b/pkg/storage/prepare_for_clearance.go
@@ -1,0 +1,32 @@
+package storage
+
+import (
+	_ "embed"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/cmsgov/mint-app/pkg/models"
+	"github.com/cmsgov/mint-app/pkg/shared/utilitySQL"
+)
+
+//go:embed SQL/prepare_for_clearance_get_by_model_plan_id.sql
+var prepareForClearanceGetByModelPlanID string
+
+// ReadyForClearanceGetByModelPlanID reads information about a model plan's clearance
+func (s *Store) ReadyForClearanceGetByModelPlanID(logger *zap.Logger, modelPlanID uuid.UUID) (*models.PrepareForClearanceResponse, error) {
+	dbResult := &models.PrepareForClearanceResponse{}
+
+	statement, err := s.db.PrepareNamed(prepareForClearanceGetByModelPlanID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = statement.Get(dbResult, utilitySQL.CreateModelPlanIDQueryMap(modelPlanID))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return dbResult, nil
+}


### PR DESCRIPTION
# NOREF

## Changes and Description

- Introduce new types and resolvers to GraphQL
  - Added `type PrepareForClearance` to the schema. This represents information helpful for rendering the "Prepare for Clearance" task list section.
    - This type has resolvers that dynamically calculate the status of the prepare for clearance section by querying multiple different data sources: The "Clearance Start Date" of the Plan Basics section, as well as the whether or not (and the last time) that each section (minus IT Tools) was marked "Ready for Clearance"
    - The logic for this happens in 2 places: [This helper function](https://github.com/CMSgov/mint-app/blob/f54678e5ff26bdf178581450c212a232fb2a160a/pkg/graph/resolvers/prepare_for_clearance.go#L33-L58) in the resolvers, and the [SQL that selects the data](https://github.com/CMSgov/mint-app/blob/a63c607496400d1f96c4e97f12302dba3cac20d6/pkg/storage/SQL/prepare_for_clearance_get_by_model_plan_id.sql)
  - Added `prepareForClearance: PrepareForClearance!` to `type ModelPlan`

## How to test this change

1. Start the app with `scripts/dev up`
2. Within the app:
  - Create a model plan
  - Query `prepareForClearance` on the model plan (should be not ready to start)
  - Modify the basics to have a clearance date within 20 days
  - Query `prepareForClearance` on the model plan (should be ready to start)
  - Update the basics to be marked ready for clearance by calling GQL to update the basics with `"status":"READY_FOR_CLEARANCE"`
  - Query `prepareForClearance` on the model plan (should be in progress)
  - Update each other section with the same update (`READY_FOR_CLEARANCE`)
  - Query `prepareForClearance` on the model plan (should be complete once all are marked ready for clearance)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
