### PR TITLE
Collaborator Added Email Fix: fixed style and word linking on "unfollow it"

### DIFF
--- a/pkg/email/templates/added_as_collaborator_body.template
+++ b/pkg/email/templates/added_as_collaborator_body.template
@@ -22,7 +22,7 @@
       <p style="text-indent: 0pt;text-align: left;"><br/></p>
       <p style="padding-top: 12pt;padding-left: 5pt;text-indent: 0pt;line-height: 140%;text-align: left;">If you have not already been given access to MINT or if you cannot log in with your EUA credentials, please contact the Model Assessment Team at <a href="mailto:MINTTeam@cms.hhs.gov" class="a" target="_blank">MINTTeam@cms.hhs.gov</a>.</p>
       <p style="text-indent: 0pt;text-align: left;"><br/></p>
-      <p style="padding-top: 13pt;padding-left: 5pt;text-indent: 0pt;line-height: 140%;text-align: left;">You&#39;re automatically following this model. To stop receiving notifications about this model, <span style=" color: #005BA0;"><a href="{{.ClientAddress}}/unfollow/?modelID={{.ModelID}}">unfollow</a> it.</span></p>
+      <p style="padding-top: 13pt;padding-left: 5pt;text-indent: 0pt;line-height: 140%;text-align: left;">You&#39;re automatically following this model. To stop receiving notifications about this model, <a href="{{.ClientAddress}}/unfollow/?modelID={{.ModelID}}">unfollow it</a>.</p>
       <p style="text-indent: 0pt;text-align: left;"><span/></p>
    </body>
 </html>


### PR DESCRIPTION
# NOREF

## Changes and Description

- The link was only active on the word "unfollow" rather than FIGMA spec of "unfollow it"
- The words "unfollow it" were incorrectly under a color style span

<!-- Put a description here! -->

## How to test this change

Add a collaborator to a model plan and check the corresponding email in MailCatcher (http://localhost:1085/)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
