### PR TITLE
Email FROM field now properly set

### DIFF
--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -103,6 +103,7 @@ func (s *Server) routes(
 	emailServiceConfig.Host = s.Config.GetString(appconfig.EmailHostKey)
 	emailServiceConfig.Port = s.Config.GetInt(appconfig.EmailPortKey)
 	emailServiceConfig.ClientAddress = s.Config.GetString(appconfig.ClientAddressKey)
+	emailServiceConfig.DefaultSender = "no-reply@mint.cms.gov"
 
 	var emailService *oddmail.GoSimpleMailService
 	emailService, err = oddmail.NewGoSimpleMailService(emailServiceConfig)


### PR DESCRIPTION
# NOREF/email_from_field_bugfix

## Changes and Description

- DefaultSender now set to no-reply@mint.cms.gov

<!-- Put a description here! -->

## How to test this change

Add a collaborator to a model plan and observe the FROM field in the corresponding email on MailCatcher is set to no-reply@mint.cms.gov

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
