### PR TITLE
[NOREF] Disable email when environment is != local

### DIFF
--- a/cmd/mint/serve.go
+++ b/cmd/mint/serve.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/cmsgov/mint-app/pkg/appconfig"
 	"github.com/cmsgov/mint-app/pkg/server"
 	"github.com/cmsgov/mint-app/pkg/worker"
 )
@@ -15,7 +16,13 @@ var serveCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		config := viper.New()
 		config.AutomaticEnv()
-		go worker.Work()
+		env, err := appconfig.NewEnvironment("ah")
+		if err != nil {
+			panic(err)
+		}
+		if env.Local() {
+			go worker.Work()
+		}
 		server.Serve(config)
 	},
 }

--- a/cmd/mint/serve.go
+++ b/cmd/mint/serve.go
@@ -16,7 +16,7 @@ var serveCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		config := viper.New()
 		config.AutomaticEnv()
-		env, err := appconfig.NewEnvironment("ah")
+		env, err := appconfig.NewEnvironment(config.GetString(appconfig.EnvironmentKey))
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -100,6 +100,7 @@ func (s *Server) routes(
 
 	// Set up Oddball email Service
 	emailServiceConfig := oddmail.GoSimpleMailServiceConfig{}
+	emailServiceConfig.Enabled = s.environment.Local()
 	emailServiceConfig.Host = s.Config.GetString(appconfig.EmailHostKey)
 	emailServiceConfig.Port = s.Config.GetInt(appconfig.EmailPortKey)
 	emailServiceConfig.ClientAddress = s.Config.GetString(appconfig.ClientAddressKey)

--- a/pkg/shared/oddmail/email_service_config.go
+++ b/pkg/shared/oddmail/email_service_config.go
@@ -2,6 +2,7 @@ package oddmail
 
 // EmailServiceConfig is an interface for email services
 type EmailServiceConfig interface {
+	GetEnabled() bool
 	GetHost() string
 	GetClientAddress() string
 	GetPort() int

--- a/pkg/shared/oddmail/go_simple_mail_service.go
+++ b/pkg/shared/oddmail/go_simple_mail_service.go
@@ -15,6 +15,14 @@ type GoSimpleMailService struct {
 
 // NewGoSimpleMailService is a constructor for GoSimpleMailService
 func NewGoSimpleMailService(config GoSimpleMailServiceConfig) (*GoSimpleMailService, error) {
+	if !config.GetEnabled() {
+		return &GoSimpleMailService{
+			smtpServer: nil,
+			smtpClient: nil,
+			config:     &config,
+		}, nil
+	}
+
 	smtpServer := &mail.SMTPServer{
 		Authentication: config.Authentication,
 		Encryption:     config.Encryption,
@@ -59,6 +67,9 @@ func (g GoSimpleMailService) setEmailBody(email *mail.Email, contentType string,
 
 // Send uses the GoSimpleMailService to dispatch an email with the provided settings
 func (g GoSimpleMailService) Send(from string, toAddresses []string, ccAddresses []string, subject string, contentType string, body string) error {
+	if !g.config.GetEnabled() {
+		return nil
+	}
 	email := mail.NewMSG()
 	email.SetFrom(from).
 		SetSubject(subject)
@@ -81,6 +92,9 @@ func (g GoSimpleMailService) Send(from string, toAddresses []string, ccAddresses
 
 // SendEmail is a GoSimpleMail specific method allowing for dispatching an email using a mail.Email object
 func (g GoSimpleMailService) SendEmail(email *mail.Email) error {
+	if !g.config.GetEnabled() {
+		return nil
+	}
 	return email.Send(g.smtpClient)
 }
 

--- a/pkg/shared/oddmail/go_simple_mail_service_config.go
+++ b/pkg/shared/oddmail/go_simple_mail_service_config.go
@@ -9,6 +9,7 @@ import (
 
 // GoSimpleMailServiceConfig is a configuration structure to define the behavior of a GoSimpleMailService
 type GoSimpleMailServiceConfig struct {
+	Enabled        bool
 	Helo           string
 	Host           string
 	ClientAddress  string
@@ -92,4 +93,9 @@ func (g *GoSimpleMailServiceConfig) GetKeepAlive() bool {
 // GetTLSConfig returns the TLSConfig configuration
 func (g *GoSimpleMailServiceConfig) GetTLSConfig() *tls.Config {
 	return g.TLSConfig
+}
+
+// GetEnabled returns the Enabled configuration
+func (g *GoSimpleMailServiceConfig) GetEnabled() bool {
+	return g.Enabled
 }


### PR DESCRIPTION
# NOREF

## Changes and Description

- Disable email client (will just early return and do nothing) when not running locally.

This change was introduced because running the app in a deployed environment results in the app immedaitely crashing because we don't yet have a set of proper SMTP credentials.

## How to test this change

Make sure nothing breaks, but this shouldn't affect/change anything when running locally, in theory!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
