### PR TITLE
[NOREF] Introduce RDS IAM authentication logic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,8 @@ services:
       - PGHOST=db
       - PGPORT=5432
       - PGDATABASE=postgres
-      - PGUSER=app_user
-      - PGPASS=supersecretapp
+      - PGUSER=postgres
+      - PGPASS=mysecretpassword
       - PGSSLMODE=disable
       - DB_MAX_CONNECTIONS=20
       - FLAG_SOURCE

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -26,7 +26,9 @@ func (s Server) NewDBConfig() storage.DBConfig {
 	s.checkRequiredConfig(appconfig.DBNameConfigKey)
 	s.checkRequiredConfig(appconfig.DBUsernameConfigKey)
 	s.checkRequiredConfig(appconfig.DBMaxConnections)
-	if s.environment.Deployed() {
+
+	useIAM := s.environment.Deployed()
+	if !useIAM { // If not using IAM, fall back to using PGPASS
 		s.checkRequiredConfig(appconfig.DBPasswordConfigKey)
 	}
 	s.checkRequiredConfig(appconfig.DBSSLModeConfigKey)
@@ -37,6 +39,7 @@ func (s Server) NewDBConfig() storage.DBConfig {
 		Username:       s.Config.GetString(appconfig.DBUsernameConfigKey),
 		Password:       s.Config.GetString(appconfig.DBPasswordConfigKey),
 		SSLMode:        s.Config.GetString(appconfig.DBSSLModeConfigKey),
+		UseIAM:         useIAM,
 		MaxConnections: s.Config.GetInt(appconfig.DBMaxConnections),
 	}
 }

--- a/pkg/storage/iam_db.go
+++ b/pkg/storage/iam_db.go
@@ -1,0 +1,77 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/rds/rdsutils"
+	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
+)
+
+// iamDb is a custom struct that satisfies the driver.Connector so that it can be used with sql.OpenDB.
+// It implements a custom Connect() function that will get a new IAM auth token for each connection.
+type iamDb struct {
+	config     DBConfig
+	awsSession *session.Session
+}
+
+// Connect implements the functionality that is executed each time a new connection is made to the database
+// For this reason, each new connection actually generates a new auth token, as each auth token only lasts 15 minutes
+// Connections made with an auth token will _NOT_ drop when the token expires, so the 15 minute expiry should never matter
+// This function helps satisfy the driver.Connector interface
+func (idb *iamDb) Connect(ctx context.Context) (driver.Conn, error) {
+	awsRegion := *idb.awsSession.Config.Region
+	awsCreds := idb.awsSession.Config.Credentials
+	dbEndpoint := fmt.Sprintf("%s:%s", idb.config.Host, idb.config.Port)
+
+	authToken, err := rdsutils.BuildAuthToken(dbEndpoint, awsRegion, idb.config.Username, awsCreds)
+	if err != nil {
+		return nil, err
+	}
+
+	psqlURL := url.URL{
+		Scheme: "postgres",
+		Host:   dbEndpoint,
+		User:   url.UserPassword(idb.config.Username, authToken),
+		Path:   idb.config.Database,
+	}
+
+	q := psqlURL.Query()
+	q.Add("sslmode", idb.config.SSLMode)
+
+	psqlURL.RawQuery = q.Encode()
+
+	psqlDriver := &pq.Driver{}
+	connector, err := psqlDriver.Open(psqlURL.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return connector, nil
+}
+
+// Driver returns IAM DB instance, as it satisfies the driver.Driver interface
+// This function helps satisfy the driver.Connector interface
+func (idb *iamDb) Driver() driver.Driver {
+	return idb
+}
+
+// Open would normally return a new connection to the DB, but this custom IAM DB
+// doesn't support it in favor of using `sql.OpenDB` in `newConnectionPoolWithIam`
+// This function helps satisfy the driver.Driver interface
+func (idb *iamDb) Open(name string) (driver.Conn, error) {
+	return nil, errors.New("driver open method not supported")
+}
+
+// newConnectionPoolWithIam opens a sql.DB using the custom iamDb as a connector.
+// It will wrap that sql.DB and return it as a *sqlx.DB
+func newConnectionPoolWithIam(awsSession *session.Session, config DBConfig) *sqlx.DB {
+	db := sql.OpenDB(&iamDb{config, awsSession})
+	return sqlx.NewDb(db, "postgres")
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/facebookgo/clock"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq" // required for postgres driver in sql
@@ -28,10 +29,16 @@ type DBConfig struct {
 	Username       string
 	Password       string
 	SSLMode        string
+	UseIAM         bool
 	MaxConnections int
 }
 
-// NewStore is a constructor for a store
+// NewStore creates a new Store struct
+// The `db` property on the Store will always be a *sqlx.DB, but a notable difference in the DB is that if
+// config.UseIAM is true, that DB instance will be backed by a custom connector in iam_db.go that generates
+// IAM auth tokens when making new connections to the database.
+// If config.UseIAM is false, it will connect using the "postgres" driver that SQLx registers in its init() function
+// https://github.com/jmoiron/sqlx/blob/75a7ebf246fd757c9c7742da7dc4d26c6fdb6b5b/bind.go#L33-L40
 func NewStore(
 	logger *zap.Logger,
 	config DBConfig,
@@ -43,20 +50,34 @@ func NewStore(
 		return nil, err
 	}
 
-	dataSourceName := fmt.Sprintf(
-		"host=%s port=%s user=%s "+
-			"password=%s dbname=%s sslmode=%s",
-		config.Host,
-		config.Port,
-		config.Username,
-		config.Password,
-		config.Database,
-		config.SSLMode,
-	)
-	db, err := sqlx.Connect("postgres", dataSourceName)
-	if err != nil {
-		return nil, err
+	var db *sqlx.DB
+	if config.UseIAM {
+		// Connect using the IAM DB package
+		sess := session.Must(session.NewSession())
+		db = newConnectionPoolWithIam(sess, config)
+		err = db.Ping()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Connect via normal user/pass
+		dataSourceName := fmt.Sprintf(
+			"host=%s port=%s user=%s "+
+				"password=%s dbname=%s sslmode=%s",
+			config.Host,
+			config.Port,
+			config.Username,
+			config.Password,
+			config.Database,
+			config.SSLMode,
+		)
+
+		db, err = sqlx.Connect("postgres", dataSourceName)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	db.SetMaxOpenConns(config.MaxConnections)
 
 	return &Store{


### PR DESCRIPTION
# NOREF

## Changes and Description

- Introduces logic to authenticate the backend to the DB with IAM (Using `rdsutils` to build a token)
- Changes local execution of the app to use `postgres` instead of `app_user`
- Modifies initial migration to create an IAM user for RDS instead of a traditional app user.

This change is similar (almost identical) to the changes made in the following PRs in the EASi repository:
- https://github.com/CMSgov/easi-app/pull/1677
- https://github.com/CMSgov/easi-app/pull/1694


## How to test this change

Ensure the app runs locally as expected!

- `scripts/dev up`
- Play around in the frontend (create some stuff, modify some stuff!)
- `scripts/dev test:go`

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
