### PR TITLE
[EASI-2237] - Updated Okta widget sign in text

### DIFF
--- a/src/components/shared/OktaSignInWidget/index.tsx
+++ b/src/components/shared/OktaSignInWidget/index.tsx
@@ -1,7 +1,7 @@
 // src/OktaSignInWidget.js
 // okta-signin-widget has no typescript support yet.  If becomes available, install and remove disable
-
 import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 // @ts-expect-error
 import OktaSignIn from '@okta/okta-signin-widget';
 
@@ -13,6 +13,7 @@ type OktaSignInWidgetProps = {
 };
 
 const OktaSignInWidget = ({ onSuccess, onError }: OktaSignInWidgetProps) => {
+  const { t } = useTranslation('general');
   const widgetRef = useRef(null);
 
   useEffect(() => {
@@ -20,6 +21,11 @@ const OktaSignInWidget = ({ onSuccess, onError }: OktaSignInWidgetProps) => {
     if (widgetRef.current) {
       signIn = new OktaSignIn({
         el: widgetRef.current,
+        i18n: {
+          en: {
+            'primaryauth.title': t('oktaWidget')
+          }
+        },
         baseUrl: process.env.REACT_APP_OKTA_DOMAIN,
         clientId: process.env.REACT_APP_OKTA_CLIENT_ID,
         authParams: {

--- a/src/i18n/en-US/general.ts
+++ b/src/i18n/en-US/general.ts
@@ -12,7 +12,8 @@ const general = {
   },
   edit: 'Edit',
   remove: 'Remove',
-  pageLoading: 'Loading the page'
+  pageLoading: 'Loading the page',
+  oktaWidget: 'Sign in with your EUA or IDM credentials.'
 };
 
 export default general;


### PR DESCRIPTION
# EASI-2237

## Changes and Description

- Updated Okta widget sign in text

![Screenshot 2022-11-10 at 10 32 22 AM](https://user-images.githubusercontent.com/95709965/201137347-844d1869-d77c-40f5-92cf-82634761074a.png)

## How to test this change

- Navigate to login screen and verify widget text reads - 'Sign in with your EUA or IDM credentials.'

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
