### PR TITLE
[NOREF] Modify the key that the groups are stored in in the JWT from Okta

### DIFF
--- a/pkg/okta/authentication_middleware.go
+++ b/pkg/okta/authentication_middleware.go
@@ -34,7 +34,7 @@ func (f oktaMiddlewareFactory) jwt(logger *zap.Logger, authHeader string) (*jwtv
 }
 
 func jwtGroupsContainsJobCode(jwt *jwtverifier.Jwt, jobCode string) bool {
-	list, ok := jwt.Claims["groups"]
+	list, ok := jwt.Claims["mint-groups"]
 	if !ok {
 		return false
 	}

--- a/pkg/okta/authentication_middleware_test.go
+++ b/pkg/okta/authentication_middleware_test.go
@@ -41,8 +41,8 @@ func TestAuthenticationMiddlewareTestSuite(t *testing.T) {
 func validJwt() *jwtverifier.Jwt {
 	return &jwtverifier.Jwt{
 		Claims: map[string]interface{}{
-			"groups": []string{},
-			"sub":    "EASI",
+			"mint-groups": []string{},
+			"sub":         "EASI",
 		},
 	}
 }
@@ -134,7 +134,7 @@ func TestJobCodes(t *testing.T) {
 	payload := `
 	{
 		"sub":"NASA",
-		"groups":[
+		"mint-groups":[
 			"EX_SPACE",
 			"EX_HOUSTON",
 			"EX_MARS"


### PR DESCRIPTION
# NOREF

## Changes and Description

- Update the field name that holds the groups in the JWT from Okta

Access token example

```json
"accessToken": {
		"accessToken": "nixed for 'security'",
		"claims": {
			"ver": 1,
			"jti": "AT.IJOYrBia76YLdXA_3VzDgIyZwhNYzK9QmvbgQxuz0kQ",
			"iss": "https://test.idp.idm.cms.gov/oauth2/ausd980kt2CBBzStG297",
			"aud": "mint",
			"iat": 1668112241,
			"exp": 1668114041,
			"cid": "0oad9awvebnsMwWNa297",
			"uid": "00uaog8skmOPJ7D2m297",
			"scp": [
				"profile",
				"email",
				"openid"
			],
			"auth_time": 1668112232,
			"sub": "BC0V",
			"mint-groups": [
				"MINT_ASSESSMENT_NONPROD",
				"MINT_USER_NONPROD"
			]
		},
		"expiresAt": 1668114041,
		"tokenType": "Bearer",
		"scopes": [
			"profile",
			"email",
			"openid"
		],
		"authorizeUrl": "https://test.idp.idm.cms.gov/oauth2/ausd980kt2CBBzStG297/v1/authorize",
		"userinfoUrl": "https://test.idp.idm.cms.gov/oauth2/ausd980kt2CBBzStG297/v1/userinfo"
	}
```

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
