### PR TITLE
[EASI-2213] Model Plan Read Only: Operational Needs

### DIFF
--- a/src/i18n/en-US/draftModelPlan/itSolutions.ts
+++ b/src/i18n/en-US/draftModelPlan/itSolutions.ts
@@ -36,6 +36,7 @@ const itSolutions = {
     viewDetails: 'View details',
     updateNeed: 'Update operational need',
     selectSolution: 'Select a solution',
+    noSolutionSelected: 'No solution selected',
     error: {
       heading: 'There is a problem',
       body: 'Failed to fetch Model Plan operational needs'

--- a/src/i18n/en-US/draftModelPlan/itSolutions.ts
+++ b/src/i18n/en-US/draftModelPlan/itSolutions.ts
@@ -1,5 +1,6 @@
 const itSolutions = {
   heading: 'IT solutions and implementation status tracker',
+  headingReadOnly: 'IT solutions',
   breadcrumb: 'IT solutions tracker',
   summaryBox: {
     useTracker: 'Use this tracker to',

--- a/src/i18n/en-US/readOnly/modelSummary.ts
+++ b/src/i18n/en-US/readOnly/modelSummary.ts
@@ -17,7 +17,7 @@ const modelSummary = {
     'operations-evaluation-and-learning':
       'Operations, evaluation, and learning',
     payment: 'Payment',
-    'it-tools': 'IT tools',
+    'it-solutions': 'IT solutions',
     team: 'Team',
     discussions: 'Discussions',
     documents: 'Documents',

--- a/src/queries/ITSolutions/GetOperationalNeeds.ts
+++ b/src/queries/ITSolutions/GetOperationalNeeds.ts
@@ -13,6 +13,7 @@ export default gql`
         key
         nameOther
         needed
+        modifiedDts
         solutions {
           id
           status

--- a/src/queries/ITSolutions/types/GetOperationalNeeds.ts
+++ b/src/queries/ITSolutions/types/GetOperationalNeeds.ts
@@ -33,6 +33,7 @@ export interface GetOperationalNeeds_modelPlan_operationalNeeds {
   key: OperationalNeedKey | null;
   nameOther: string | null;
   needed: boolean | null;
+  modifiedDts: Time | null;
   solutions: GetOperationalNeeds_modelPlan_operationalNeeds_solutions[];
 }
 

--- a/src/views/ModelPlan/ReadOnly/OperationalNeeds/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/OperationalNeeds/index.tsx
@@ -9,6 +9,7 @@ import {
 } from 'queries/ITSolutions/types/GetOperationalNeeds';
 import { TaskStatus } from 'types/graphql-global-types';
 import { TaskListStatusTag } from 'views/ModelPlan/TaskList/_components/TaskListItem';
+import OperationalNeedsTable from 'views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable';
 import { NotFoundPartial } from 'views/NotFound';
 
 const ReadOnlyOperationalNeeds = ({ modelID }: { modelID: string }) => {
@@ -48,6 +49,8 @@ const ReadOnlyOperationalNeeds = ({ modelID }: { modelID: string }) => {
           <TaskListStatusTag status={getITSolutionsStatus(operationalNeeds)} />
         )}
       </div>
+
+      <OperationalNeedsTable modelID={modelID} type="needs" readOnly />
     </div>
   );
 };

--- a/src/views/ModelPlan/ReadOnly/OperationalNeeds/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/OperationalNeeds/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { RootStateOrAny, useSelector } from 'react-redux';
 import { useQuery } from '@apollo/client';
 
 import GetOperationalNeeds from 'queries/ITSolutions/GetOperationalNeeds';
@@ -23,6 +24,12 @@ const ReadOnlyOperationalNeeds = ({ modelID }: { modelID: string }) => {
       }
     }
   );
+
+  const isCollaborator = data?.modelPlan?.isCollaborator;
+
+  const { groups } = useSelector((state: RootStateOrAny) => state.auth);
+
+  const hasEditAccess: boolean = isCollaborator || isAssessment(groups);
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {
     return <NotFoundPartial />;

--- a/src/views/ModelPlan/ReadOnly/OperationalNeeds/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/OperationalNeeds/index.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@apollo/client';
+
+import GetOperationalNeeds from 'queries/ITSolutions/GetOperationalNeeds';
+import {
+  GetOperationalNeeds as GetOperationalNeedsType,
+  GetOperationalNeeds_modelPlan_operationalNeeds as OperationalNeedsType
+} from 'queries/ITSolutions/types/GetOperationalNeeds';
+import { TaskStatus } from 'types/graphql-global-types';
+import { TaskListStatusTag } from 'views/ModelPlan/TaskList/_components/TaskListItem';
+import { NotFoundPartial } from 'views/NotFound';
+
+const ReadOnlyOperationalNeeds = ({ modelID }: { modelID: string }) => {
+  const { t } = useTranslation('itSolutions');
+
+  const { data, loading, error } = useQuery<GetOperationalNeedsType>(
+    GetOperationalNeeds,
+    {
+      variables: {
+        id: modelID
+      }
+    }
+  );
+
+  if ((!loading && error) || (!loading && !data?.modelPlan)) {
+    return <NotFoundPartial />;
+  }
+
+  const getITSolutionsStatus = (
+    operationalNeedsArray: OperationalNeedsType[]
+  ) => {
+    const inProgress = operationalNeedsArray.find(need => need.modifiedDts);
+    return inProgress ? TaskStatus.IN_PROGRESS : TaskStatus.READY;
+  };
+
+  const { operationalNeeds } = data?.modelPlan || {};
+
+  return (
+    <div
+      className="read-only-model-plan--operational-needs"
+      data-testid="read-only-model-plan--operational-needs"
+    >
+      <div className="display-flex flex-justify flex-align-start">
+        <h2 className="margin-top-0 margin-bottom-4">{t('headingReadOnly')}</h2>
+
+        {operationalNeeds && (
+          <TaskListStatusTag status={getITSolutionsStatus(operationalNeeds)} />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ReadOnlyOperationalNeeds;

--- a/src/views/ModelPlan/ReadOnly/OperationalNeeds/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/OperationalNeeds/index.tsx
@@ -50,7 +50,12 @@ const ReadOnlyOperationalNeeds = ({ modelID }: { modelID: string }) => {
         )}
       </div>
 
-      <OperationalNeedsTable modelID={modelID} type="needs" readOnly />
+      <OperationalNeedsTable
+        modelID={modelID}
+        type="needs"
+        readOnly
+        hiddenColumns={['Subtasks']}
+      />
     </div>
   );
 };

--- a/src/views/ModelPlan/ReadOnly/OperationalNeeds/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/OperationalNeeds/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { RootStateOrAny, useSelector } from 'react-redux';
 import { useQuery } from '@apollo/client';
 
 import GetOperationalNeeds from 'queries/ITSolutions/GetOperationalNeeds';
@@ -24,12 +23,6 @@ const ReadOnlyOperationalNeeds = ({ modelID }: { modelID: string }) => {
       }
     }
   );
-
-  const isCollaborator = data?.modelPlan?.isCollaborator;
-
-  const { groups } = useSelector((state: RootStateOrAny) => state.auth);
-
-  const hasEditAccess: boolean = isCollaborator || isAssessment(groups);
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {
     return <NotFoundPartial />;

--- a/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
@@ -436,10 +436,10 @@ exports[`Read Only Model Plan Summary matches snapshot 1`] = `
                   class="usa-sidenav__item"
                 >
                   <a
-                    class="nav-group-border"
-                    href="/models/ce3405a0-3399-4e3a-88d7-3cfc613d2905/read-only/it-tools"
+                    class=""
+                    href="/models/ce3405a0-3399-4e3a-88d7-3cfc613d2905/read-only/it-solutions"
                   >
-                    IT tools
+                    IT solutions
                   </a>
                 </li>
                 <li

--- a/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
@@ -436,7 +436,7 @@ exports[`Read Only Model Plan Summary matches snapshot 1`] = `
                   class="usa-sidenav__item"
                 >
                   <a
-                    class=""
+                    class="nav-group-border"
                     href="/models/ce3405a0-3399-4e3a-88d7-3cfc613d2905/read-only/it-solutions"
                   >
                     IT solutions

--- a/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
@@ -26,7 +26,7 @@ const SideNav = ({ subComponents, isHelpArticle }: SideNavProps) => {
         }
         key={key}
         activeClassName="usa-current"
-        className={key === 'it-tools' ? 'nav-group-border' : ''}
+        className={key === 'it-solutions' ? 'nav-group-border' : ''}
       >
         {t(`navigation.${key}`)}
       </NavLink>

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -52,6 +52,7 @@ import ReadOnlyBeneficiaries from './Beneficiaries';
 import ReadOnlyCRTDLs from './CRTDLs';
 import ReadOnlyDiscussions from './Discussions';
 import ReadOnlyDocuments from './Documents';
+import ReadOnlyOperationalNeeds from './OperationalNeeds';
 import ReadOnlyPayments from './Payments';
 import ReadOnlyTeamInfo from './Team';
 
@@ -208,7 +209,7 @@ const ReadOnly = () => {
     },
     'it-tools': {
       route: `/models/${modelID}/read-only/it-tools`,
-      component: <h1>itTools</h1>
+      component: <ReadOnlyOperationalNeeds modelID={modelID} />
     },
     team: {
       route: `/models/${modelID}/read-only/team`,
@@ -420,7 +421,9 @@ const ReadOnly = () => {
                     <Grid
                       desktop={{
                         col:
-                          subinfo === 'documents' || subinfo === 'crs-and-tdl'
+                          subinfo === 'documents' ||
+                          subinfo === 'crs-and-tdl' ||
+                          subinfo === 'it-tools'
                             ? 12
                             : 8
                       }}
@@ -428,17 +431,19 @@ const ReadOnly = () => {
                       {subComponent.component}
                     </Grid>
                     {/* Contact info sidebar */}
-                    {subinfo !== 'documents' && subinfo !== 'crs-and-tdl' && (
-                      <Grid
-                        desktop={{ col: 4 }}
-                        className={classnames({
-                          'sticky-nav': !isMobile,
-                          'sticky-nav__collaborator': editAccess
-                        })}
-                      >
-                        <ContactInfo modelID={modelID} />
-                      </Grid>
-                    )}
+                    {subinfo !== 'documents' &&
+                      subinfo !== 'crs-and-tdl' &&
+                      subinfo !== 'it-tools' && (
+                        <Grid
+                          desktop={{ col: 4 }}
+                          className={classnames({
+                            'sticky-nav': !isMobile,
+                            'sticky-nav__collaborator': editAccess
+                          })}
+                        >
+                          <ContactInfo modelID={modelID} />
+                        </Grid>
+                      )}
                   </Grid>
                 </GridContainer>
               </div>

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -76,7 +76,7 @@ const listOfSubpageKey = [
   'beneficiaries',
   'operations-evaluation-and-learning',
   'payment',
-  'it-tools',
+  'it-solutions',
   'team',
   'discussions',
   'documents',
@@ -233,10 +233,10 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
       helpRoute: '/help-and-knowledge/sample-model-plan/payment',
       component: <ReadOnlyPayments modelID={modelID} />
     },
-    'it-tools': {
-      route: `/models/${modelID}/read-only/it-tools`,
+    'it-solutions': {
+      route: `/models/${modelID}/read-only/it-solutions`,
       component: <ReadOnlyOperationalNeeds modelID={modelID} />,
-      helpRoute: '/help-and-knowledge/sample-model-plan/it-tools'
+      helpRoute: '/help-and-knowledge/sample-model-plan/it-solutions'
     },
     team: {
       route: `/models/${modelID}/read-only/team`,
@@ -478,7 +478,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
                         col:
                           subinfo === 'documents' ||
                           subinfo === 'crs-and-tdl' ||
-                          subinfo === 'it-tools'
+                          subinfo === 'it-solutions'
                             ? 12
                             : 8
                       }}
@@ -488,7 +488,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
                     {/* Contact info sidebar */}
                     {subinfo !== 'documents' &&
                       subinfo !== 'crs-and-tdl' &&
-                      subinfo !== 'it-tools' && (
+                      subinfo !== 'it-solutions' && (
                         <Grid
                           desktop={{ col: 4 }}
                           className={classnames({

--- a/src/views/ModelPlan/TaskList/ITSolutions/Home/__snapshots__/operationalNeedsTable.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Home/__snapshots__/operationalNeedsTable.test.tsx.snap
@@ -181,39 +181,6 @@ exports[`IT Solutions Home matches snapshot 1`] = `
                 </svg>
               </button>
             </th>
-            <th
-              aria-sort="none"
-              class="table-header"
-              colspan="1"
-              role="columnheader"
-              scope="col"
-              style="min-width: 138px; padding-bottom: .5rem; position: relative; padding-left: 0px;"
-            >
-              <button
-                class="usa-button usa-button--unstyled"
-                type="button"
-              >
-                Actions
-                <svg
-                  class="usa-icon margin-left-05 position-absolute"
-                  data-testid="caret--sort"
-                  focusable="false"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 24 24"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
-                  />
-                </svg>
-              </button>
-            </th>
           </tr>
         </thead>
         <tbody
@@ -247,11 +214,6 @@ exports[`IT Solutions Home matches snapshot 1`] = `
                 Not answered
               </span>
             </td>
-            <td
-              class=""
-              role="cell"
-              style="padding-left: 0px;"
-            />
           </tr>
         </tbody>
       </table>

--- a/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.test.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.test.tsx
@@ -38,6 +38,7 @@ const returnNeeds = (needed: boolean | null) => {
                 key: OperationalNeedKey.ADVERTISE_MODEL,
                 nameOther: null,
                 needed,
+                modifiedDts: '2022-05-12T15:01:39.190679Z',
                 solutions: [
                   {
                     __typename: 'OperationalSolution',

--- a/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
@@ -127,6 +127,9 @@ const OperationalNeedsTable = ({
           OperationalNeedsSolutionsStatus
         >): JSX.Element | string => {
           if (value === t('itSolutionsTable.selectSolution')) {
+            if (!hasEditAccess) {
+              return <span>{t('itSolutionsTable.noSolutionSelected')}</span>;
+            }
             return (
               <UswdsReactLink
                 to={`/models/${modelID}/task-list/it-solutions/${row.original.id}/select-solutions`}

--- a/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
@@ -254,7 +254,8 @@ const OperationalNeedsTable = ({
       autoResetPage: false,
       initialState: {
         sortBy: useMemo(() => [{ id: 'name', asc: true }], []),
-        pageIndex: 0
+        pageIndex: 0,
+        hiddenColumns: hasEditAccess ? [] : ['Actions']
       }
     },
     useFilters,

--- a/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
@@ -67,7 +67,7 @@ type OperationalNeedsTableProps = {
   hiddenColumns?: string[];
   modelID: string;
   type: 'needs' | 'possibleNeeds';
-  readOnly?: boolean; // TODO: used to render when readonly component is developed
+  readOnly?: boolean;
 };
 
 const OperationalNeedsTable = ({

--- a/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
@@ -254,8 +254,7 @@ const OperationalNeedsTable = ({
       autoResetPage: false,
       initialState: {
         sortBy: useMemo(() => [{ id: 'name', asc: true }], []),
-        pageIndex: 0,
-        hiddenColumns: hasEditAccess ? ['subTasks'] : ['subTasks', 'id']
+        pageIndex: 0
       }
     },
     useFilters,
@@ -317,7 +316,7 @@ const OperationalNeedsTable = ({
                     className="table-header"
                     scope="col"
                     style={{
-                      minWidth: readOnly ? '160px' : '138px',
+                      minWidth: '138px',
                       paddingBottom: '.5rem',
                       position: 'relative',
                       paddingLeft: index === 0 ? '.5em' : '0px'

--- a/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
@@ -176,11 +176,16 @@ const OperationalNeedsTable = ({
         Cell: ({
           row
         }: CellProps<GetOperationalNeedsTableType>): JSX.Element => {
-          return returnActionLinks(row.original.status, row.original, modelID);
+          return returnActionLinks(
+            row.original.status,
+            row.original,
+            modelID,
+            readOnly
+          );
         }
       }
     ];
-  }, [t, modelID]);
+  }, [t, modelID, readOnly]);
 
   const possibleNeedsColumns = useMemo<Column<any>[]>(() => {
     return [
@@ -250,7 +255,7 @@ const OperationalNeedsTable = ({
       initialState: {
         sortBy: useMemo(() => [{ id: 'name', asc: true }], []),
         pageIndex: 0,
-        hiddenColumns: hasEditAccess ? [] : ['id']
+        hiddenColumns: hasEditAccess ? ['subTasks'] : ['subTasks', 'id']
       }
     },
     useFilters,
@@ -312,7 +317,7 @@ const OperationalNeedsTable = ({
                     className="table-header"
                     scope="col"
                     style={{
-                      minWidth: '138px',
+                      minWidth: readOnly ? '160px' : '138px',
                       paddingBottom: '.5rem',
                       position: 'relative',
                       paddingLeft: index === 0 ? '.5em' : '0px'

--- a/src/views/ModelPlan/TaskList/ITSolutions/util.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/util.tsx
@@ -130,7 +130,7 @@ export const returnActionLinks = (
         <>
           <UswdsReactLink
             to="/"
-            className={`margin-right-2 ${readOnly ? 'display-block' : ''} `}
+            className={`margin-right-2${readOnly ? ' display-block' : ''}`}
           >
             {i18next.t('itSolutions:itSolutionsTable.updateStatus')}
           </UswdsReactLink>

--- a/src/views/ModelPlan/TaskList/ITSolutions/util.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/util.tsx
@@ -109,7 +109,8 @@ interface SolutionAsNeed extends GetOperationalNeedsOperationalNeedsType {
 export const returnActionLinks = (
   status: OperationalNeedStatus | OpSolutionStatus,
   operationalNeed: SolutionAsNeed,
-  modelID: string
+  modelID: string,
+  readOnly?: boolean
 ): JSX.Element => {
   /* eslint no-underscore-dangle: 0 */
   const operationalNeedKey =
@@ -127,7 +128,10 @@ export const returnActionLinks = (
     case OpSolutionStatus.ONBOARDING:
       return (
         <>
-          <UswdsReactLink to="/" className="margin-right-2">
+          <UswdsReactLink
+            to="/"
+            className={`margin-right-2 ${readOnly ? 'display-block' : ''} `}
+          >
             {i18next.t('itSolutions:itSolutionsTable.updateStatus')}
           </UswdsReactLink>
           <UswdsReactLink to="/">


### PR DESCRIPTION
# EASI-2213

## Changes and Description

- Add `modifiedDts` to `GetOperationalNeeds` query and types, so that `getITSolutionsStatus` works in OperationalNeeds Read Only component
- Add `ReadOnlyOperationalNeeds` component to ReadOnly subcomponent object
- add a few more conditionals to render a full width subcomponent section for `it-tools`
- add a `readOnly` parameter to `returnActionsLinks` in `operationalNeedsTable` file

<!-- Put a description here! -->

## How to test this change

1. Seed data
2. Navigate to Read Only
3. Navigate to IT tools
4. Ensure Operational Needs table is displaying
5. Editor Access and Collaborator should see the "Actions" column. Otherwise, "Actions" column is hidden.

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
