### PR TITLE
[NOREF] - Only submit dirty fields when sending mutations on forms

### DIFF
--- a/src/utils/formDiff.ts
+++ b/src/utils/formDiff.ts
@@ -1,0 +1,24 @@
+/* 
+Util used to return only dirty formik fields
+Formik has no dirty value per input, only on whole form
+This returns a payload with only values that have changes
+*/
+
+type DirtyInputType = {
+  [key: string]: any;
+};
+
+export const dirtyInput = (initialValues: any, values: any) => {
+  if (!initialValues || !values) return {};
+
+  const onlyDirtyInput: DirtyInputType = {};
+
+  Object.keys(initialValues).forEach(field => {
+    if (initialValues[field] !== values[field]) {
+      onlyDirtyInput[field] = values[field];
+    }
+  });
+  return onlyDirtyInput;
+};
+
+export default dirtyInput;

--- a/src/views/ModelPlan/TaskList/Beneficiaries/BeneficiaryIdentification/index.tsx
+++ b/src/views/ModelPlan/TaskList/Beneficiaries/BeneficiaryIdentification/index.tsx
@@ -38,6 +38,7 @@ import { UpdateModelPlanBeneficiariesVariables } from 'queries/Beneficiaries/typ
 import UpdateModelPlanBeneficiaries from 'queries/Beneficiaries/UpdateModelPlanBeneficiaries';
 import { BeneficiariesType, TriStateAnswer } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import { sortOtherEnum, translateBeneficiariesType } from 'utils/modelPlan';
 import { NotFoundPartial } from 'views/NotFound';
 
@@ -80,15 +81,14 @@ const BeneficiaryIdentification = () => {
     UpdateModelPlanBeneficiaries
   );
 
-  const handleFormSubmit = (
-    formikValues: BeneficiaryIdentificationFormType,
-    redirect?: 'next' | 'back'
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
+  const handleFormSubmit = (redirect?: 'next' | 'back') => {
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -168,8 +168,8 @@ const BeneficiaryIdentification = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -489,7 +489,7 @@ const BeneficiaryIdentification = () => {
                       <Button
                         type="button"
                         className="usa-button usa-button--unstyled"
-                        onClick={() => handleFormSubmit(values, 'back')}
+                        onClick={() => handleFormSubmit('back')}
                       >
                         <IconArrowBack className="margin-right-1" aria-hidden />
                         {h('saveAndReturn')}
@@ -502,7 +502,7 @@ const BeneficiaryIdentification = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/Beneficiaries/PeopleImpact/index.tsx
+++ b/src/views/ModelPlan/TaskList/Beneficiaries/PeopleImpact/index.tsx
@@ -41,6 +41,7 @@ import {
   SelectionMethodType
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   sortOtherEnum,
   translateConfidenceType,
@@ -81,15 +82,14 @@ const PeopleImpact = () => {
     UpdateModelPlanBeneficiaries
   );
 
-  const handleFormSubmit = (
-    formikValues: PeopleImpactedFormType,
-    redirect?: 'next' | 'back' | 'task-list'
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
+  const handleFormSubmit = (redirect?: 'next' | 'back' | 'task-list') => {
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -167,8 +167,8 @@ const PeopleImpact = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -363,7 +363,7 @@ const PeopleImpact = () => {
                           type="button"
                           className="usa-button usa-button--outline margin-bottom-1"
                           onClick={() => {
-                            handleFormSubmit(values, 'back');
+                            handleFormSubmit('back');
                           }}
                         >
                           {h('back')}
@@ -375,7 +375,7 @@ const PeopleImpact = () => {
                       <Button
                         type="button"
                         className="usa-button usa-button--unstyled"
-                        onClick={() => handleFormSubmit(values, 'task-list')}
+                        onClick={() => handleFormSubmit('task-list')}
                       >
                         <IconArrowBack className="margin-right-1" aria-hidden />
                         {h('saveAndReturn')}
@@ -388,7 +388,7 @@ const PeopleImpact = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/Authority/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/Authority/index.tsx
@@ -36,6 +36,7 @@ import { UpdatePlanGeneralCharacteristicsVariables } from 'queries/GeneralCharac
 import UpdatePlanGeneralCharacteristics from 'queries/GeneralCharacteristics/UpdatePlanGeneralCharacteristics';
 import { AuthorityAllowance, WaiverType } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   sortOtherEnum,
   translateAuthorityAllowance,
@@ -89,20 +90,20 @@ const Authority = () => {
     UpdatePlanGeneralCharacteristics
   );
 
-  const handleFormSubmit = (
-    formikValues: InitialValueType,
-    redirect?: 'back' | 'task-list'
-  ) => {
-    const {
-      id: updateId,
-      __typename,
-      status: inputStatus,
-      ...changeValues
-    } = formikValues;
+  const handleFormSubmit = (redirect?: 'back' | 'task-list') => {
+    const dirtyInputs = dirtyInput(
+      formikRef?.current?.initialValues,
+      formikRef?.current?.values
+    );
+
+    if (dirtyInputs.status) {
+      dirtyInputs.status = sanitizeStatus(dirtyInputs.status);
+    }
+
     update({
       variables: {
         id,
-        changes: { ...changeValues, status: sanitizeStatus(inputStatus) }
+        changes: dirtyInputs
       }
     })
       .then(response => {
@@ -174,7 +175,7 @@ const Authority = () => {
       <Formik
         initialValues={initialValues}
         onSubmit={values => {
-          handleFormSubmit(values, 'task-list');
+          handleFormSubmit('task-list');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -458,7 +459,7 @@ const Authority = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -470,7 +471,7 @@ const Authority = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -480,7 +481,7 @@ const Authority = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/Involvements/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/Involvements/index.tsx
@@ -32,6 +32,7 @@ import {
 import { UpdatePlanGeneralCharacteristicsVariables } from 'queries/GeneralCharacteristics/types/UpdatePlanGeneralCharacteristics';
 import UpdatePlanGeneralCharacteristics from 'queries/GeneralCharacteristics/UpdatePlanGeneralCharacteristics';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import { NotFoundPartial } from 'views/NotFound';
 
 const Involvements = () => {
@@ -70,15 +71,14 @@ const Involvements = () => {
     UpdatePlanGeneralCharacteristics
   );
 
-  const handleFormSubmit = (
-    formikValues: InvolvementsFormType,
-    redirect?: 'next' | 'back' | 'task-list'
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
+  const handleFormSubmit = (redirect?: 'next' | 'back' | 'task-list') => {
     update({
       variables: {
         id,
-        changes: changeValues
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -156,7 +156,7 @@ const Involvements = () => {
       <Formik
         initialValues={initialValues}
         onSubmit={values => {
-          handleFormSubmit(values, 'next');
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -430,7 +430,7 @@ const Involvements = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -442,7 +442,7 @@ const Involvements = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -452,7 +452,7 @@ const Involvements = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/KeyCharacteristics/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/KeyCharacteristics/index.tsx
@@ -41,6 +41,7 @@ import {
   KeyCharacteristic
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   mapMultiSelectOptions,
   translateAlternativePaymentTypes,
@@ -97,14 +98,15 @@ const KeyCharacteristics = () => {
   );
 
   const handleFormSubmit = (
-    formikValues: KeyCharacteristicsFormType,
     redirect?: 'next' | 'back' | 'task-list' | string
   ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
     update({
       variables: {
         id,
-        changes: changeValues
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -181,8 +183,8 @@ const KeyCharacteristics = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -411,7 +413,6 @@ const KeyCharacteristics = () => {
                           id="plan-characteristics-collect-bids-warning"
                           onClick={() =>
                             handleFormSubmit(
-                              values,
                               `/models/${modelID}/task-list/it-solutions`
                             )
                           }
@@ -468,7 +469,6 @@ const KeyCharacteristics = () => {
                           id="plan-characteristics-manage-enrollment-warning"
                           onClick={() =>
                             handleFormSubmit(
-                              values,
                               `/models/${modelID}/task-list/it-solutions`
                             )
                           }
@@ -525,7 +525,6 @@ const KeyCharacteristics = () => {
                           id="plan-characteristics-contact-updated-warning"
                           onClick={() =>
                             handleFormSubmit(
-                              values,
                               `/models/${modelID}/task-list/it-solutions`
                             )
                           }
@@ -572,7 +571,7 @@ const KeyCharacteristics = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -584,7 +583,7 @@ const KeyCharacteristics = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -594,7 +593,7 @@ const KeyCharacteristics = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/TargetsAndOptions/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/TargetsAndOptions/index.tsx
@@ -38,6 +38,7 @@ import {
   GeographyType
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   sortOtherEnum,
   translateAgreementTypes,
@@ -87,15 +88,14 @@ const TargetsAndOptions = () => {
     UpdatePlanGeneralCharacteristics
   );
 
-  const handleFormSubmit = (
-    formikValues: TargetsAndOptionsFormType,
-    redirect?: 'next' | 'back' | 'task-list'
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
+  const handleFormSubmit = (redirect?: 'next' | 'back' | 'task-list') => {
     update({
       variables: {
         id,
-        changes: changeValues
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -174,8 +174,8 @@ const TargetsAndOptions = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -596,7 +596,7 @@ const TargetsAndOptions = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -608,7 +608,7 @@ const TargetsAndOptions = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -618,7 +618,7 @@ const TargetsAndOptions = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/index.tsx
@@ -42,6 +42,7 @@ import GetDraftModelPlans from 'queries/GetModelPlans';
 import { GetExistingModelPlans as ExistingModelPlanType } from 'queries/types/GetExistingModelPlans';
 import { GetModelPlans as GetDraftModelPlansType } from 'queries/types/GetModelPlans';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import { NotFoundPartial } from 'views/NotFound';
 
 import Authority from './Authority';
@@ -113,15 +114,14 @@ export const CharacteristicsContent = () => {
     UpdatePlanGeneralCharacteristics
   );
 
-  const handleFormSubmit = (
-    formikValues: GetGeneralCharacteristicsFormType,
-    redirect?: 'next' | 'back'
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
+  const handleFormSubmit = (redirect?: 'next' | 'back') => {
     update({
       variables: {
         id,
-        changes: changeValues
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -191,8 +191,8 @@ export const CharacteristicsContent = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -488,7 +488,7 @@ export const CharacteristicsContent = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'back')}
+                  onClick={() => handleFormSubmit('back')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -498,7 +498,7 @@ export const CharacteristicsContent = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/CCWAndQuality/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/CCWAndQuality/index.tsx
@@ -32,6 +32,7 @@ import {
 import { UpdatePlanOpsEvalAndLearningVariables } from 'queries/OpsEvalAndLearning/types/UpdatePlanOpsEvalAndLearning';
 import UpdatePlanOpsEvalAndLearning from 'queries/OpsEvalAndLearning/UpdatePlanOpsEvalAndLearning';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import { NotFoundPartial } from 'views/NotFound';
 
 import { isCCWInvolvement, renderCurrentPage, renderTotalPages } from '..';
@@ -76,15 +77,14 @@ const CCWAndQuality = () => {
     UpdatePlanOpsEvalAndLearning
   );
 
-  const handleFormSubmit = (
-    formikValues: GetCCWAndQualityFormType,
-    redirect?: 'next' | 'back' | 'task-list'
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
+  const handleFormSubmit = (redirect?: 'next' | 'back' | 'task-list') => {
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -165,8 +165,8 @@ const CCWAndQuality = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -431,7 +431,7 @@ const CCWAndQuality = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -443,7 +443,7 @@ const CCWAndQuality = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -454,7 +454,7 @@ const CCWAndQuality = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/DataSharing/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/DataSharing/index.tsx
@@ -33,6 +33,7 @@ import { UpdatePlanOpsEvalAndLearningVariables } from 'queries/OpsEvalAndLearnin
 import UpdatePlanOpsEvalAndLearning from 'queries/OpsEvalAndLearning/UpdatePlanOpsEvalAndLearning';
 import { DataFrequencyType, DataStartsType } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   mapMultiSelectOptions,
   sortOtherEnum,
@@ -85,15 +86,14 @@ const DataSharing = () => {
     UpdatePlanOpsEvalAndLearning
   );
 
-  const handleFormSubmit = (
-    formikValues: GetDataSharingFormType,
-    redirect?: 'next' | 'back' | 'task-list'
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
+  const handleFormSubmit = (redirect?: 'next' | 'back' | 'task-list') => {
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -103,7 +103,9 @@ const DataSharing = () => {
               `/models/${modelID}/task-list/ops-eval-and-learning/learning`
             );
           } else if (redirect === 'back') {
-            if (isCCWInvolvement(formikValues.ccmInvolvment)) {
+            if (
+              isCCWInvolvement(formikRef?.current?.values.ccmInvolvment || [])
+            ) {
               history.push(
                 `/models/${modelID}/task-list/ops-eval-and-learning/ccw-and-quality`
               );
@@ -179,8 +181,8 @@ const DataSharing = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -526,7 +528,7 @@ const DataSharing = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -538,7 +540,7 @@ const DataSharing = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -549,7 +551,7 @@ const DataSharing = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Evaluation/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Evaluation/index.tsx
@@ -42,6 +42,7 @@ import {
   EvaluationApproachType
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   mapMultiSelectOptions,
   sortOtherEnum,
@@ -104,20 +105,23 @@ const Evaluation = () => {
   );
 
   const handleFormSubmit = (
-    formikValues: EvaluationFormType,
     redirect?: 'next' | 'back' | 'task-list' | string
   ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
         if (!response?.errors) {
           if (redirect === 'next') {
-            if (isCCWInvolvement(formikValues.ccmInvolvment)) {
+            if (
+              isCCWInvolvement(formikRef?.current?.values.ccmInvolvment || [])
+            ) {
               history.push(
                 `/models/${modelID}/task-list/ops-eval-and-learning/ccw-and-quality`
               );
@@ -199,8 +203,8 @@ const Evaluation = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -255,7 +259,6 @@ const Evaluation = () => {
                           id="ops-eval-and-learning-evaluation-approach-warning"
                           onClick={() =>
                             handleFormSubmit(
-                              values,
                               `/models/${modelID}/task-list/it-solutions`
                             )
                           }
@@ -409,7 +412,6 @@ const Evaluation = () => {
                       id="ops-eval-and-learning-data-needed-warning"
                       onClick={() =>
                         handleFormSubmit(
-                          values,
                           `/models/${modelID}/task-list/it-solutions`
                         )
                       }
@@ -480,7 +482,6 @@ const Evaluation = () => {
                       id="ops-eval-and-learning-data-to-send-warning"
                       onClick={() =>
                         handleFormSubmit(
-                          values,
                           `/models/${modelID}/task-list/it-solutions`
                         )
                       }
@@ -575,7 +576,7 @@ const Evaluation = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -587,7 +588,7 @@ const Evaluation = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -598,7 +599,7 @@ const Evaluation = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOC/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOC/index.tsx
@@ -33,6 +33,7 @@ import {
 import { UpdatePlanOpsEvalAndLearningVariables } from 'queries/OpsEvalAndLearning/types/UpdatePlanOpsEvalAndLearning';
 import UpdatePlanOpsEvalAndLearning from 'queries/OpsEvalAndLearning/UpdatePlanOpsEvalAndLearning';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import { NotFoundPartial } from 'views/NotFound';
 
 import { isCCWInvolvement, renderCurrentPage, renderTotalPages } from '..';
@@ -74,15 +75,14 @@ const IDDOC = () => {
     UpdatePlanOpsEvalAndLearning
   );
 
-  const handleFormSubmit = (
-    formikValues: IDDOCFormType,
-    redirect?: 'next' | 'back' | 'task-list'
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
+  const handleFormSubmit = (redirect?: 'next' | 'back' | 'task-list') => {
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -155,8 +155,8 @@ const IDDOC = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -368,7 +368,7 @@ const IDDOC = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -380,7 +380,7 @@ const IDDOC = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -391,7 +391,7 @@ const IDDOC = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCMonitoring/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCMonitoring/index.tsx
@@ -33,6 +33,7 @@ import { UpdatePlanOpsEvalAndLearningVariables } from 'queries/OpsEvalAndLearnin
 import UpdatePlanOpsEvalAndLearning from 'queries/OpsEvalAndLearning/UpdatePlanOpsEvalAndLearning';
 import { DataFullTimeOrIncrementalType } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import { translateDataFullTimeOrIncrementalType } from 'utils/modelPlan';
 import { NotFoundPartial } from 'views/NotFound';
 
@@ -74,15 +75,14 @@ const IDDOCMonitoring = () => {
     UpdatePlanOpsEvalAndLearning
   );
 
-  const handleFormSubmit = (
-    formikValues: IDDOCMonitoringFormType,
-    redirect?: 'next' | 'back' | 'task-list'
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
+  const handleFormSubmit = (redirect?: 'next' | 'back' | 'task-list') => {
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -156,8 +156,8 @@ const IDDOCMonitoring = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -377,7 +377,7 @@ const IDDOCMonitoring = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -389,7 +389,7 @@ const IDDOCMonitoring = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -400,7 +400,7 @@ const IDDOCMonitoring = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCTesting/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCTesting/index.tsx
@@ -34,6 +34,7 @@ import { UpdatePlanOpsEvalAndLearningVariables } from 'queries/OpsEvalAndLearnin
 import UpdatePlanOpsEvalAndLearning from 'queries/OpsEvalAndLearning/UpdatePlanOpsEvalAndLearning';
 import { MonitoringFileType } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import { sortOtherEnum, translateMonitoringFileType } from 'utils/modelPlan';
 import { NotFoundPartial } from 'views/NotFound';
 
@@ -76,15 +77,14 @@ const IDDOCTesting = () => {
     UpdatePlanOpsEvalAndLearning
   );
 
-  const handleFormSubmit = (
-    formikValues: IDDOCTestingFormType,
-    redirect?: 'next' | 'back' | 'task-list'
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
+  const handleFormSubmit = (redirect?: 'next' | 'back' | 'task-list') => {
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -159,8 +159,8 @@ const IDDOCTesting = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -382,7 +382,7 @@ const IDDOCTesting = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -394,7 +394,7 @@ const IDDOCTesting = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -405,7 +405,7 @@ const IDDOCTesting = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Performance/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Performance/index.tsx
@@ -34,6 +34,7 @@ import { UpdatePlanOpsEvalAndLearningVariables } from 'queries/OpsEvalAndLearnin
 import UpdatePlanOpsEvalAndLearning from 'queries/OpsEvalAndLearning/UpdatePlanOpsEvalAndLearning';
 import { BenchmarkForPerformanceType } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   sortOtherEnum,
   translateBenchmarkForPerformanceType
@@ -93,14 +94,15 @@ const Performance = () => {
   );
 
   const handleFormSubmit = (
-    formikValues: PerformanceFormType,
     redirect?: 'next' | 'back' | 'task-list' | string
   ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -189,8 +191,8 @@ const Performance = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -244,7 +246,6 @@ const Performance = () => {
                       id="ops-eval-and-learning-benchmark-performance-warning"
                       onClick={() =>
                         handleFormSubmit(
-                          values,
                           `/models/${modelID}/task-list/it-solutions`
                         )
                       }
@@ -440,7 +441,6 @@ const Performance = () => {
                       id="ops-eval-and-learning-appeal-performance-warning"
                       onClick={() =>
                         handleFormSubmit(
-                          values,
                           `/models/${modelID}/task-list/it-solutions`
                         )
                       }
@@ -553,7 +553,7 @@ const Performance = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -565,7 +565,7 @@ const Performance = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -576,7 +576,7 @@ const Performance = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/index.tsx
@@ -46,6 +46,7 @@ import {
   StakeholdersType
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   mapMultiSelectOptions,
   sortOtherEnum,
@@ -144,21 +145,20 @@ export const OpsEvalAndLearningContent = () => {
     UpdatePlanOpsEvalAndLearning
   );
 
-  const handleFormSubmit = (
-    formikValues: OpsEvalAndLearningFormType,
-    redirect?: 'next' | 'back' | string
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
+  const handleFormSubmit = (redirect?: 'next' | 'back' | string) => {
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
         if (!response?.errors) {
           if (redirect === 'next') {
-            if (formikValues.iddocSupport) {
+            if (formikRef?.current?.values.iddocSupport) {
               history.push(
                 `/models/${modelID}/task-list/ops-eval-and-learning/iddoc`
               );
@@ -236,8 +236,8 @@ export const OpsEvalAndLearningContent = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -414,7 +414,6 @@ export const OpsEvalAndLearningContent = () => {
                       id="ops-eval-and-learning-help-desk-use-warning"
                       onClick={() =>
                         handleFormSubmit(
-                          values,
                           `/models/${modelID}/task-list/it-solutions`
                         )
                       }
@@ -556,7 +555,6 @@ export const OpsEvalAndLearningContent = () => {
                       id="ops-eval-and-learning-iddoc-support-warning"
                       onClick={() =>
                         handleFormSubmit(
-                          values,
                           `/models/${modelID}/task-list/it-solutions`
                         )
                       }
@@ -608,7 +606,7 @@ export const OpsEvalAndLearningContent = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'back')}
+                  onClick={() => handleFormSubmit('back')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -619,7 +617,7 @@ export const OpsEvalAndLearningContent = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/Communication/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/Communication/index.tsx
@@ -39,6 +39,7 @@ import {
   ParticipantRiskType
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   sortOtherEnum,
   translateCommunicationType,
@@ -91,14 +92,15 @@ export const Communication = () => {
   );
 
   const handleFormSubmit = (
-    formikValues: CommunicationFormType,
     redirect?: 'next' | 'back' | 'task-list' | string
   ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
     update({
       variables: {
         id,
-        changes: changeValues
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -174,8 +176,8 @@ export const Communication = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -227,7 +229,6 @@ export const Communication = () => {
                           id="participants-and-providers-communication-method-warning"
                           onClick={() =>
                             handleFormSubmit(
-                              values,
                               `/models/${modelID}/task-list/it-solutions`
                             )
                           }
@@ -436,7 +437,7 @@ export const Communication = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -448,7 +449,7 @@ export const Communication = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -458,7 +459,7 @@ export const Communication = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/Coordination/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/Coordination/index.tsx
@@ -34,6 +34,7 @@ import { UpdatePlanParticipantsAndProvidersVariables } from 'queries/Participant
 import UpdatePlanParticipantsAndProviders from 'queries/ParticipantsAndProviders/UpdatePlanParticipantsAndProviders';
 import { ParticipantsIDType } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import { sortOtherEnum, translateParticipantIDType } from 'utils/modelPlan';
 import { NotFoundPartial } from 'views/NotFound';
 
@@ -72,15 +73,14 @@ export const Coordination = () => {
     UpdatePlanParticipantsAndProviders
   );
 
-  const handleFormSubmit = (
-    formikValues: CoordinationFormType,
-    redirect?: 'next' | 'back' | 'task-list'
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
+  const handleFormSubmit = (redirect?: 'next' | 'back' | 'task-list') => {
     update({
       variables: {
         id,
-        changes: changeValues
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -153,8 +153,8 @@ export const Coordination = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -390,7 +390,7 @@ export const Coordination = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -402,7 +402,7 @@ export const Coordination = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -412,7 +412,7 @@ export const Coordination = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ParticipantOptions/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ParticipantOptions/index.tsx
@@ -42,6 +42,7 @@ import {
   RecruitmentType
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   mapMultiSelectOptions,
   sortOtherEnum,
@@ -97,14 +98,15 @@ export const ParticipantOptions = () => {
   );
 
   const handleFormSubmit = (
-    formikValues: ParticipantOptionsFormType,
     redirect?: 'next' | 'back' | 'task-list' | string
   ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
     update({
       variables: {
         id,
-        changes: changeValues
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -180,8 +182,8 @@ export const ParticipantOptions = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -195,6 +197,7 @@ export const ParticipantOptions = () => {
             values
           } = formikProps;
           const flatErrors = flattenErrors(errors);
+
           return (
             <>
               {Object.keys(errors).length > 0 && (
@@ -323,7 +326,6 @@ export const ParticipantOptions = () => {
                       id="participants-and-providers-recruitment-method-warning"
                       onClick={() =>
                         handleFormSubmit(
-                          values,
                           `/models/${modelID}/task-list/it-solutions`
                         )
                       }
@@ -393,7 +395,6 @@ export const ParticipantOptions = () => {
                       id="participants-and-providers-selection-method-warning"
                       onClick={() =>
                         handleFormSubmit(
-                          values,
                           `/models/${modelID}/task-list/it-solutions`
                         )
                       }
@@ -449,7 +450,7 @@ export const ParticipantOptions = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -461,7 +462,7 @@ export const ParticipantOptions = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -471,7 +472,7 @@ export const ParticipantOptions = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ProviderOptions/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ProviderOptions/index.tsx
@@ -42,6 +42,7 @@ import {
   ProviderLeaveType
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   mapMultiSelectOptions,
   sortOtherEnum,
@@ -103,20 +104,20 @@ export const ProviderOptions = () => {
     UpdatePlanParticipantsAndProviders
   );
 
-  const handleFormSubmit = (
-    formikValues: InitialValueType,
-    redirect?: 'back' | 'task-list'
-  ) => {
-    const {
-      id: updateId,
-      __typename,
-      status: inputStatus,
-      ...changeValues
-    } = formikValues;
+  const handleFormSubmit = (redirect?: 'back' | 'task-list') => {
+    const dirtyInputs = dirtyInput(
+      formikRef?.current?.initialValues,
+      formikRef?.current?.values
+    );
+
+    if (dirtyInputs.status) {
+      dirtyInputs.status = sanitizeStatus(dirtyInputs.status);
+    }
+
     update({
       variables: {
         id,
-        changes: { ...changeValues, status: sanitizeStatus(inputStatus) }
+        changes: dirtyInputs
       }
     })
       .then(response => {
@@ -190,8 +191,8 @@ export const ProviderOptions = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'task-list');
+        onSubmit={() => {
+          handleFormSubmit('task-list');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -507,7 +508,7 @@ export const ProviderOptions = () => {
                     type="button"
                     className="usa-button usa-button--outline margin-bottom-1"
                     onClick={() => {
-                      handleFormSubmit(values, 'back');
+                      handleFormSubmit('back');
                     }}
                   >
                     {h('back')}
@@ -519,7 +520,7 @@ export const ProviderOptions = () => {
                 <Button
                   type="button"
                   className="usa-button usa-button--unstyled"
-                  onClick={() => handleFormSubmit(values, 'task-list')}
+                  onClick={() => handleFormSubmit('task-list')}
                 >
                   <IconArrowBack className="margin-right-1" aria-hidden />
                   {h('saveAndReturn')}
@@ -529,7 +530,7 @@ export const ProviderOptions = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/index.tsx
@@ -38,6 +38,7 @@ import { UpdatePlanParticipantsAndProvidersVariables } from 'queries/Participant
 import UpdatePlanParticipantsAndProviders from 'queries/ParticipantsAndProviders/UpdatePlanParticipantsAndProviders';
 import { ParticipantsType } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   mapMultiSelectOptions,
   translateParticipantsType
@@ -88,15 +89,14 @@ export const ParticipantsAndProvidersContent = () => {
     UpdatePlanParticipantsAndProviders
   );
 
-  const handleFormSubmit = (
-    formikValues: ParticipantsAndProvidersFormType,
-    redirect?: 'next' | 'back'
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
+  const handleFormSubmit = (redirect?: 'next' | 'back') => {
     update({
       variables: {
         id,
-        changes: changeValues
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -165,8 +165,8 @@ export const ParticipantsAndProvidersContent = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -419,7 +419,7 @@ export const ParticipantsAndProvidersContent = () => {
                       <Button
                         type="button"
                         className="usa-button usa-button--unstyled"
-                        onClick={() => handleFormSubmit(values, 'back')}
+                        onClick={() => handleFormSubmit('back')}
                       >
                         <IconArrowBack className="margin-right-1" aria-hidden />
                         {h('saveAndReturn')}
@@ -447,7 +447,7 @@ export const ParticipantsAndProvidersContent = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/Payment/ClaimsBasedPayment/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/ClaimsBasedPayment/index.tsx
@@ -39,6 +39,7 @@ import { UpdatePaymentsVariables } from 'queries/Payments/types/UpdatePayments';
 import UpdatePayments from 'queries/Payments/UpdatePayments';
 import { ClaimsBasedPayType, PayType } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   mapMultiSelectOptions,
   translateClaimsBasedPayType
@@ -92,14 +93,15 @@ const ClaimsBasedPayment = () => {
   const [update] = useMutation<UpdatePaymentsVariables>(UpdatePayments);
 
   const handleFormSubmit = (
-    formikValues: ClaimsBasedPaymentFormType,
     redirect?: 'next' | 'back' | 'task-list' | string
   ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -185,8 +187,8 @@ const ClaimsBasedPayment = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -312,7 +314,6 @@ const ClaimsBasedPayment = () => {
                             className="margin-top-neg-5"
                             onClick={() =>
                               handleFormSubmit(
-                                values,
                                 `/models/${modelID}/task-list/it-solutions`
                               )
                             }
@@ -512,7 +513,7 @@ const ClaimsBasedPayment = () => {
                           type="button"
                           className="usa-button usa-button--outline margin-bottom-1"
                           onClick={() => {
-                            handleFormSubmit(values, 'back');
+                            handleFormSubmit('back');
                           }}
                         >
                           {h('back')}
@@ -524,7 +525,7 @@ const ClaimsBasedPayment = () => {
                       <Button
                         type="button"
                         className="usa-button usa-button--unstyled"
-                        onClick={() => handleFormSubmit(values, 'task-list')}
+                        onClick={() => handleFormSubmit('task-list')}
                       >
                         <IconArrowBack className="margin-right-1" aria-hidden />
                         {h('saveAndReturn')}
@@ -537,7 +538,7 @@ const ClaimsBasedPayment = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/Payment/Complexity/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/Complexity/index.tsx
@@ -41,6 +41,7 @@ import {
   PayType
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   mapMultiSelectOptions,
   translateAnticipatedPaymentFrequencyType,
@@ -85,24 +86,23 @@ const Complexity = () => {
 
   const [update] = useMutation<UpdatePaymentsVariables>(UpdatePayments);
 
-  const handleFormSubmit = (
-    formikValues: ComplexityFormType,
-    redirect?: 'next' | 'back' | 'task-list'
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
-    const hasClaimsBasedPayment = formikValues.payType.includes(
+  const handleFormSubmit = (redirect?: 'next' | 'back' | 'task-list') => {
+    const hasClaimsBasedPayment = formikRef?.current?.values.payType.includes(
       PayType.CLAIMS_BASED_PAYMENTS
     );
-    const hasReductionToCostSharing = formikValues.payClaims.includes(
+    const hasReductionToCostSharing = formikRef?.current?.values.payClaims.includes(
       ClaimsBasedPayType.REDUCTIONS_TO_BENEFICIARY_COST_SHARING
     );
-    const hasNonClaimBasedPayment = formikValues.payType.includes(
+    const hasNonClaimBasedPayment = formikRef?.current?.values.payType.includes(
       PayType.NON_CLAIMS_BASED_PAYMENTS
     );
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -198,8 +198,8 @@ const Complexity = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -452,7 +452,7 @@ const Complexity = () => {
                           type="button"
                           className="usa-button usa-button--outline margin-bottom-1"
                           onClick={() => {
-                            handleFormSubmit(values, 'back');
+                            handleFormSubmit('back');
                           }}
                         >
                           {h('back')}
@@ -464,7 +464,7 @@ const Complexity = () => {
                       <Button
                         type="button"
                         className="usa-button usa-button--unstyled"
-                        onClick={() => handleFormSubmit(values, 'task-list')}
+                        onClick={() => handleFormSubmit('task-list')}
                       >
                         <IconArrowBack className="margin-right-1" aria-hidden />
                         {h('saveAndReturn')}
@@ -477,7 +477,7 @@ const Complexity = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/Payment/FundingSource/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/FundingSource/index.tsx
@@ -42,6 +42,7 @@ import {
   PayType
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   sortOtherEnum,
   sortPayTypeEnums,
@@ -99,21 +100,20 @@ const FundingSource = () => {
 
   const [update] = useMutation<UpdatePaymentsVariables>(UpdatePayments);
 
-  const handleFormSubmit = (
-    formikValues: FundingFormType,
-    redirect?: 'next' | 'back' | string
-  ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
-    const hasClaimsBasedPayment = formikValues.payType.includes(
+  const handleFormSubmit = (redirect?: 'next' | 'back' | string) => {
+    const hasClaimsBasedPayment = formikRef?.current?.values.payType.includes(
       PayType.CLAIMS_BASED_PAYMENTS
     );
-    const hasNonClaimBasedPayment = formikValues.payType.includes(
+    const hasNonClaimBasedPayment = formikRef?.current?.values.payType.includes(
       PayType.NON_CLAIMS_BASED_PAYMENTS
     );
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -200,8 +200,8 @@ const FundingSource = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -499,7 +499,6 @@ const FundingSource = () => {
                             id="payment-pay-recipients-warning"
                             onClick={() =>
                               handleFormSubmit(
-                                values,
                                 `/models/${modelID}/task-list/it-solutions`
                               )
                             }
@@ -542,7 +541,7 @@ const FundingSource = () => {
                       <Button
                         type="button"
                         className="usa-button usa-button--unstyled"
-                        onClick={() => handleFormSubmit(values, 'back')}
+                        onClick={() => handleFormSubmit('back')}
                       >
                         <IconArrowBack className="margin-right-1" aria-hidden />
                         {h('saveAndReturn')}
@@ -555,7 +554,7 @@ const FundingSource = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />

--- a/src/views/ModelPlan/TaskList/Payment/NonClaimsBasedPayment/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/NonClaimsBasedPayment/index.tsx
@@ -43,6 +43,7 @@ import {
   PayType
 } from 'types/graphql-global-types';
 import flattenErrors from 'utils/flattenErrors';
+import { dirtyInput } from 'utils/formDiff';
 import {
   mapMultiSelectOptions,
   translateNonClaimsBasedPayType
@@ -96,20 +97,21 @@ const NonClaimsBasedPayment = () => {
   const [update] = useMutation<UpdatePaymentsVariables>(UpdatePayments);
 
   const handleFormSubmit = (
-    formikValues: NonClaimsBasedPaymentFormType,
     redirect?: 'next' | 'back' | 'task-list' | string
   ) => {
-    const { id: updateId, __typename, ...changeValues } = formikValues;
-    const hasClaimsBasedPayment = formikValues.payType.includes(
+    const hasClaimsBasedPayment = formikRef?.current?.values.payType.includes(
       PayType.CLAIMS_BASED_PAYMENTS
     );
-    const hasReductionToCostSharing = formikValues.payClaims.includes(
+    const hasReductionToCostSharing = formikRef?.current?.values.payClaims.includes(
       ClaimsBasedPayType.REDUCTIONS_TO_BENEFICIARY_COST_SHARING
     );
     update({
       variables: {
-        id: updateId,
-        changes: changeValues
+        id,
+        changes: dirtyInput(
+          formikRef?.current?.initialValues,
+          formikRef?.current?.values
+        )
       }
     })
       .then(response => {
@@ -202,8 +204,8 @@ const NonClaimsBasedPayment = () => {
 
       <Formik
         initialValues={initialValues}
-        onSubmit={values => {
-          handleFormSubmit(values, 'next');
+        onSubmit={() => {
+          handleFormSubmit('next');
         }}
         enableReinitialize
         innerRef={formikRef}
@@ -266,7 +268,6 @@ const NonClaimsBasedPayment = () => {
                             id="payment-nonclaims-payments-warning"
                             onClick={() =>
                               handleFormSubmit(
-                                values,
                                 `/models/${modelID}/task-list/it-solutions`
                               )
                             }
@@ -490,7 +491,7 @@ const NonClaimsBasedPayment = () => {
                           type="button"
                           className="usa-button usa-button--outline margin-bottom-1"
                           onClick={() => {
-                            handleFormSubmit(values, 'back');
+                            handleFormSubmit('back');
                           }}
                         >
                           {h('back')}
@@ -502,7 +503,7 @@ const NonClaimsBasedPayment = () => {
                       <Button
                         type="button"
                         className="usa-button usa-button--unstyled"
-                        onClick={() => handleFormSubmit(values, 'task-list')}
+                        onClick={() => handleFormSubmit('task-list')}
                       >
                         <IconArrowBack className="margin-right-1" aria-hidden />
                         {h('saveAndReturn')}
@@ -515,7 +516,7 @@ const NonClaimsBasedPayment = () => {
                 <AutoSave
                   values={values}
                   onSave={() => {
-                    handleFormSubmit(formikRef.current!.values);
+                    handleFormSubmit();
                   }}
                   debounceDelay={3000}
                 />


### PR DESCRIPTION
NOREF

## Changes and Description

- Updated all forms to only pass dirty fields to update mutations

Currently, for IT Solutions, needs questions were being marked as 'Answered' because each form was sending the entire payload even if a field hadn't been touched.  Not we can have certainty over fields that have truly been answered.

## Notes

Formik does indeed have  a `dirty` value, but not per input - only per form.  This PR created a util function to return only dirty fields/values to mutation

## How to test this change

- Submit forms for question pertaining to IT Solutions without actually answering the question
- Verify on IT Solutions, that the relevant need still says `Not Answered`

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
