### PR TITLE
[EASI-2207] Introduce WebSocket authentication for Okta.

### DIFF
--- a/pkg/okta/authentication_middleware.go
+++ b/pkg/okta/authentication_middleware.go
@@ -78,7 +78,7 @@ func (f oktaMiddlewareFactory) newPrincipal(jwt *jwtverifier.Jwt) (*authenticati
 	}, nil
 }
 
-func (f oktaMiddlewareFactory) newAuthenticationMiddleware(next http.Handler) http.Handler {
+func (f oktaMiddlewareFactory) NewAuthenticationMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger := appcontext.ZLogger(r.Context())
 		authHeader := r.Header.Get("Authorization")
@@ -174,13 +174,13 @@ func (f oktaMiddlewareFactory) NewOktaWebSocketAuthenticationMiddleware(logger *
 	}
 }
 
-// NewOktaAuthenticationMiddleware returns a wrapper for HandlerFunc to authorize with Okta
-func NewOktaAuthenticationMiddleware(base handlers.HandlerBase, jwtVerifier JwtVerifier) (func(http.Handler) http.Handler, *oktaMiddlewareFactory) {
-	middlewareFactory := oktaMiddlewareFactory{
+// NewOktaMiddlewareFactory returns a factory creating Okta middleware functions
+func NewOktaMiddlewareFactory(base handlers.HandlerBase, jwtVerifier JwtVerifier) *oktaMiddlewareFactory {
+	return &oktaMiddlewareFactory{
 		HandlerBase:       base,
 		verifier:          jwtVerifier,
 		jobCodeUser:       jobCodeUser,
 		jobCodeAssessment: jobCodeAssessment,
 	}
-	return middlewareFactory.newAuthenticationMiddleware, &middlewareFactory
+	// return middlewareFactory.NewAuthenticationMiddleware, &middlewareFactory
 }

--- a/pkg/okta/authentication_middleware_test.go
+++ b/pkg/okta/authentication_middleware_test.go
@@ -60,11 +60,11 @@ func (s *AuthenticationMiddlewareTestSuite) buildMiddleware(verify func(jwt stri
 		verify: verify,
 	}
 
-	return NewOktaAuthenticationMiddleware(
+	factory := NewOktaMiddlewareFactory(
 		handlers.NewHandlerBase(s.logger),
 		verifier,
 	)
-
+	return factory.NewAuthenticationMiddleware
 }
 
 func (s *AuthenticationMiddlewareTestSuite) TestAuthorizeMiddleware() {

--- a/pkg/okta/authentication_middleware_test.go
+++ b/pkg/okta/authentication_middleware_test.go
@@ -60,7 +60,7 @@ func (s *AuthenticationMiddlewareTestSuite) buildMiddleware(verify func(jwt stri
 		verify: verify,
 	}
 
-	factory := NewOktaMiddlewareFactory(
+	factory := NewMiddlewareFactory(
 		handlers.NewHandlerBase(s.logger),
 		verifier,
 	)

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -43,6 +43,29 @@ import (
 	"github.com/cmsgov/mint-app/pkg/upload"
 )
 
+// HandleLocalOrOktaWebSocketAuth is a function that effectively acts as a wrapper around 2 functions that can serve as a transport.WebSocket "InitFunc"
+// This function looks at the initial payload sent when authenticating a websocket connection, and chooses the appropriate authentication middleware
+// to use (in the case of Authorization headers beginning with "Local", it will use package "local"s local.NewLocalWebSocketAuthenticationMiddleware, and in any other case will
+// use package "okta"s NewOktaWebSocketAuthenticationMiddleware)
+//
+// This function requires the OktaMiddlewareFactory object because it, in some cases (as described above), needs to perform operations that decode JWTs, which is a responsibility of
+// some of the functions attached to that factory. A refactor to clean up this cross-package dependency was considered but determined to be too much effort. (Don't hurt me)
+func HandleLocalOrOktaWebSocketAuth(logger *zap.Logger, omf *okta.MiddlewareFactory) transport.WebsocketInitFunc {
+	return func(ctx context.Context, initPayload transport.InitPayload) (context.Context, error) {
+		authToken := initPayload["authToken"]
+		token, ok := authToken.(string)
+		if !ok || token == "" {
+			return nil, errors.New("authToken not found in transport payload")
+		}
+
+		localToken := strings.HasPrefix(token, "Local ")
+		if localToken {
+			return local.NewLocalWebSocketAuthenticationMiddleware(logger)(ctx, initPayload)
+		}
+		return omf.NewOktaWebSocketAuthenticationMiddleware(logger)(ctx, initPayload)
+	}
+}
+
 func (s *Server) routes(
 	corsMiddleware func(handler http.Handler) http.Handler,
 	traceMiddleware func(handler http.Handler) http.Handler,
@@ -51,7 +74,7 @@ func (s *Server) routes(
 	oktaConfig := s.NewOktaClientConfig()
 	jwtVerifier := okta.NewJwtVerifier(oktaConfig.OktaClientID, oktaConfig.OktaIssuer)
 
-	oktaMiddlewareFactory := okta.NewOktaMiddlewareFactory(
+	oktaMiddlewareFactory := okta.NewMiddlewareFactory(
 		handlers.NewHandlerBase(s.logger),
 		jwtVerifier,
 	)
@@ -175,11 +198,7 @@ func (s *Server) routes(
 		}}
 	gqlConfig := generated.Config{Resolvers: resolver, Directives: gqlDirectives}
 	graphqlServer := handler.New(generated.NewExecutableSchema(gqlConfig))
-	initFunc := oktaMiddlewareFactory.NewOktaWebSocketAuthenticationMiddleware(s.logger)
-	// if s.environment.Local() {
-	// 	initFunc = local.NewLocalWebSocketAuthenticationMiddleware(s.logger)
-	// } else {
-	// }
+
 	graphqlServer.AddTransport(transport.Websocket{
 		KeepAlivePingInterval: 10 * time.Second,
 		Upgrader: websocket.Upgrader{
@@ -188,7 +207,7 @@ func (s *Server) routes(
 			},
 			Subprotocols: []string{"graphql-transport-ws"},
 		},
-		InitFunc: initFunc,
+		InitFunc: HandleLocalOrOktaWebSocketAuth(s.logger, oktaMiddlewareFactory),
 	})
 	graphqlServer.AddTransport(transport.Options{})
 	graphqlServer.AddTransport(transport.GET{})

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -51,7 +51,7 @@ func (s *Server) routes(
 	oktaConfig := s.NewOktaClientConfig()
 	jwtVerifier := okta.NewJwtVerifier(oktaConfig.OktaClientID, oktaConfig.OktaIssuer)
 
-	oktaAuthenticationMiddleware := okta.NewOktaAuthenticationMiddleware(
+	oktaAuthenticationMiddleware, fact := okta.NewOktaAuthenticationMiddleware(
 		handlers.NewHandlerBase(s.logger),
 		jwtVerifier,
 	)
@@ -175,6 +175,12 @@ func (s *Server) routes(
 		}}
 	gqlConfig := generated.Config{Resolvers: resolver, Directives: gqlDirectives}
 	graphqlServer := handler.New(generated.NewExecutableSchema(gqlConfig))
+	var initFunc transport.WebsocketInitFunc
+	initFunc = fact.NewOktaWebSocketAuthenticationMiddleware(s.logger)
+	// if s.environment.Local() {
+	// 	initFunc = local.NewLocalWebSocketAuthenticationMiddleware(s.logger)
+	// } else {
+	// }
 	graphqlServer.AddTransport(transport.Websocket{
 		KeepAlivePingInterval: 10 * time.Second,
 		Upgrader: websocket.Upgrader{
@@ -183,7 +189,7 @@ func (s *Server) routes(
 			},
 			Subprotocols: []string{"graphql-transport-ws"},
 		},
-		InitFunc: local.NewLocalWebSocketAuthenticationMiddleware(s.logger),
+		InitFunc: initFunc,
 	})
 	graphqlServer.AddTransport(transport.Options{})
 	graphqlServer.AddTransport(transport.GET{})


### PR DESCRIPTION
# EASI-2207

## Changes and Description

- Introduces functionality to allow Okta users to authenticate WebSocket connections

## How to test this change

- Log in with Okta authentication on two browsers (same account)
- Create a model plan
- Test out task list locking between the two browsers.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
