### PR TITLE
[EASI-2207] Add code to dynamically get ws:// protocol address

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -73,8 +73,10 @@ const authLink = setContext((request, { headers }) => {
   };
 });
 
+const gqlAddressWithoutProtocol = (process.env
+  .REACT_APP_GRAPHQL_ADDRESS as string).split('://')[1];
 const wsLink = new WebSocketLink(
-  new SubscriptionClient('ws://localhost:8085/api/graph/query', {
+  new SubscriptionClient(`ws://${gqlAddressWithoutProtocol}`, {
     connectionParams: {
       authToken: getAuthHeader(process.env.REACT_APP_GRAPHQL_ADDRESS as string)
     }


### PR DESCRIPTION
# EASI-2207

## Changes and Description

- Calculate the `ws://` address based on the `process.env.REACT_APP_GRAPHQL_ADDRESS` variable, rather than hard-coding `localhost`

<!-- Put a description here! -->

## How to test this change

- `scripts/dev up`
- Log in on two different browser instances (local dev or Okta)
- Create a model plan that both logged in accounts are collaborators on
- Browse the task list and ensure task list locking works as expected.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
