### PR TITLE
[EASI-2207] Use WSS when connecting over HTTPs

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -73,10 +73,11 @@ const authLink = setContext((request, { headers }) => {
   };
 });
 
-const gqlAddressWithoutProtocol = (process.env
-  .REACT_APP_GRAPHQL_ADDRESS as string).split('://')[1];
+const [protocol, gqlAddressWithoutProtocol] = (process.env
+  .REACT_APP_GRAPHQL_ADDRESS as string).split('://');
+const wsProtocol = protocol === 'https' ? 'wss' : 'ws'; // Use WSS when connecting over HTTPs
 const wsLink = new WebSocketLink(
-  new SubscriptionClient(`ws://${gqlAddressWithoutProtocol}`, {
+  new SubscriptionClient(`${wsProtocol}://${gqlAddressWithoutProtocol}`, {
     connectionParams: {
       authToken: getAuthHeader(process.env.REACT_APP_GRAPHQL_ADDRESS as string)
     }


### PR DESCRIPTION
# EASI-2207

## Changes and Description

- Use `wss://` protocol when the API address is using `https://`

## How to test this change

- Same as #311 

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
