### PR TITLE
[NOREF] - Access control update

### DIFF
--- a/src/views/ModelAccessWrapper/index.tsx
+++ b/src/views/ModelAccessWrapper/index.tsx
@@ -33,9 +33,11 @@ const ModelAccessWrapper = ({ children }: ModelAccessWrapperProps) => {
   // If so, has full access to both task-list and read-only
   const { groups } = useSelector((state: RootStateOrAny) => state.auth);
 
-  // Checking if user's location is task-list
-  // Everything with a modelID and under the parent 'task-list' route is considered editable
-  const taskList: boolean = pathname.split('/')[3] === 'task-list';
+  // Checking if user's location is task-list or collaborators
+  // Everything with a modelID and under the parent 'task-list' or 'collaborators' route is considered editable
+  const editable: boolean =
+    pathname.split('/')[3] === 'task-list' ||
+    pathname.split('/')[3] === 'collaborators';
 
   const { data, loading } = useQuery<
     GetIsCollaboratorType,
@@ -44,7 +46,7 @@ const ModelAccessWrapper = ({ children }: ModelAccessWrapperProps) => {
     variables: {
       id: modelID
     },
-    skip: !taskList
+    skip: !editable
   });
 
   const isCollaborator: boolean = data?.modelPlan?.isCollaborator || false;
@@ -56,7 +58,7 @@ const ModelAccessWrapper = ({ children }: ModelAccessWrapperProps) => {
       !loading &&
       modelID &&
       validModelID &&
-      taskList &&
+      editable &&
       !isAssessment(groups)
     ) {
       history.replace(`/models/${modelID}/read-only/model-basics`);
@@ -68,7 +70,7 @@ const ModelAccessWrapper = ({ children }: ModelAccessWrapperProps) => {
     loading,
     modelID,
     validModelID,
-    taskList,
+    editable,
     groups
   ]);
 

--- a/src/views/ModelAccessWrapper/index.tsx
+++ b/src/views/ModelAccessWrapper/index.tsx
@@ -33,9 +33,9 @@ const ModelAccessWrapper = ({ children }: ModelAccessWrapperProps) => {
   // If so, has full access to both task-list and read-only
   const { groups } = useSelector((state: RootStateOrAny) => state.auth);
 
-  // Checking if user's location is readonly
-  // Everything with a modelID and not under the parent 'read-only' route is considered editable
-  const readOnly: boolean = pathname.split('/')[3] === 'read-only';
+  // Checking if user's location is task-list
+  // Everything with a modelID and under the parent 'task-list' route is considered editable
+  const taskList: boolean = pathname.split('/')[3] === 'task-list';
 
   const { data, loading } = useQuery<
     GetIsCollaboratorType,
@@ -43,7 +43,8 @@ const ModelAccessWrapper = ({ children }: ModelAccessWrapperProps) => {
   >(GetIsCollaborator, {
     variables: {
       id: modelID
-    }
+    },
+    skip: !taskList
   });
 
   const isCollaborator: boolean = data?.modelPlan?.isCollaborator || false;
@@ -55,7 +56,7 @@ const ModelAccessWrapper = ({ children }: ModelAccessWrapperProps) => {
       !loading &&
       modelID &&
       validModelID &&
-      !readOnly &&
+      taskList &&
       !isAssessment(groups)
     ) {
       history.replace(`/models/${modelID}/read-only/model-basics`);
@@ -67,7 +68,7 @@ const ModelAccessWrapper = ({ children }: ModelAccessWrapperProps) => {
     loading,
     modelID,
     validModelID,
-    readOnly,
+    taskList,
     groups
   ]);
 


### PR DESCRIPTION
NOREF

## Changes and Description

- Added a skip conditional to gql query for collaborators on routes that do need access control
- Changed the route definitions for access control from `!read-only` to `editable`

The access control wrapper was making unnecessary calls to BE for collaborator info on routes that had no need for access control
The access control routes are more clearly defined by the presence of the task list/collaborators rather than the absence of read only.  The task list/collaborators are the only editable sections in MINT

## How to test this change

- Attempt to access any route under `/task-list` or `/collaborators` if not a model team or assessment member
- Verify user is taken to read-only view


## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
