### PR TITLE
[EASI-2401] Follow Model Plan When Added As Collaborator

### DIFF
--- a/pkg/graph/resolvers/model_plan.go
+++ b/pkg/graph/resolvers/model_plan.go
@@ -33,7 +33,7 @@ func ModelPlanCreate(logger *zap.Logger, modelName string, store *storage.Store,
 	// Create an initial collaborator for the plan
 	collab := models.NewPlanCollaborator(principal.ID(), createdPlan.ID, principalInfo.EuaUserID, principalInfo.CommonName, models.TeamRoleModelLead, principalInfo.Email.String())
 
-	_, err = store.PlanCollaboratorCreate(logger, collab)
+	_, _, err = AddPlanCollaboratorAndFollow(logger, store, collab, createdPlan)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/SQL/plan_favorite_create.sql
+++ b/pkg/storage/SQL/plan_favorite_create.sql
@@ -12,6 +12,7 @@ VALUES (
     :created_by,
     :modified_by
 )
+ON CONFLICT (model_plan_id, user_id) DO NOTHING
 RETURNING
 id,
 model_plan_id,


### PR DESCRIPTION
When a user is added as a collaborator to a model plan, we want that user to automatically follow said model plan.

# EASI-2401

## Changes and Description

- Wrap the calling logic for adding a collaborator to a model plan in a shared utility method which both adds a collaborator and follows a model plan
- Assign this logic in both places where a user is added as a collaborator, including the creation of the model plan and resolver to add a collaborator to a model plan
- Update SQL to not duplicate a collaborator on a model plan if it already exists

<!-- Put a description here! -->

## How to test this change

- Create a model plan and observe that the creating user is added as a collaborator and automatically follows the model plan
- Add a users as a collaborator to a model plan and observe that the user is added as a collaborator and automatically follows the model plan

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
