### PR TITLE
[NOREF] - Connect CRTDL data to /models table

### DIFF
--- a/src/views/ModelPlan/ReadOnly/Table/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/Table/index.tsx
@@ -22,7 +22,10 @@ import Alert from 'components/shared/Alert';
 import GlobalClientFilter from 'components/TableFilter';
 import TablePagination from 'components/TablePagination';
 import TableResults from 'components/TableResults';
-import { GetAllModelPlans_modelPlanCollection as AllModelPlansType } from 'queries/ReadOnly/types/GetAllModelPlans';
+import {
+  GetAllModelPlans_modelPlanCollection as AllModelPlansType,
+  GetAllModelPlans_modelPlanCollection_crTdls as CRTDLType
+} from 'queries/ReadOnly/types/GetAllModelPlans';
 import globalTableFilter from 'utils/globalTableFilter';
 import {
   translateModelCategory,
@@ -140,12 +143,15 @@ const Table = ({ data, updateFavorite }: ModelPlansTableProps) => {
       },
       {
         Header: t('allModels.tableHeading.crsAndTdls'),
-        accessor: 'crsAndTdls',
-        Cell: ({ value }: any) => {
-          if (!value) {
+        accessor: 'crTdls',
+        Cell: ({ value }: { value: CRTDLType[] }) => {
+          if (!value || value.length === 0) {
             return <div>{h('noAnswer.tBD')}</div>;
           }
-          return value;
+          const crtdlIDs = value
+            .map((crtdl: CRTDLType) => crtdl.idNumber)
+            .join(', ');
+          return crtdlIDs;
         }
       }
     ];


### PR DESCRIPTION
NOREF

## Changes and Description

- Connected CRTDL data on the table on /models

When adding CRTDL dev work, data flow was not connected to the previously stubbed data on the table on /models.  This was previously added on the favorite card and should be reflected there as well

## How to test this change

Verify CRTDLs show up on the table on /models

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
