### PR TITLE
[NOREF] Use 'mint-groups' instead of 'groups' when parsing job codes on Frontend

### DIFF
--- a/src/views/UserInfoWrapper/index.tsx
+++ b/src/views/UserInfoWrapper/index.tsx
@@ -15,7 +15,7 @@ type UserInfoWrapperProps = {
 type oktaUserProps = {
   name?: string;
   euaId?: string;
-  groups?: string[];
+  'mint-groups'?: string[];
 };
 
 const UserInfoWrapper = ({ children }: UserInfoWrapperProps) => {
@@ -34,7 +34,7 @@ const UserInfoWrapper = ({ children }: UserInfoWrapperProps) => {
       const user = {
         name: oktaUser.name,
         euaId: oktaUser.euaId || '',
-        groups: oktaUser.groups || [],
+        groups: oktaUser['mint-groups'] || [],
         acceptedNDA: data?.ndaInfo
       };
       dispatch(setUser(user));
@@ -43,7 +43,7 @@ const UserInfoWrapper = ({ children }: UserInfoWrapperProps) => {
         name: authState?.idToken?.claims.name,
         euaId: authState?.idToken?.claims.preferred_username,
         // @ts-ignore
-        groups: authState?.accessToken?.claims.groups || [],
+        groups: authState?.accessToken?.claims['mint-groups'] || [],
         acceptedNDA: data?.ndaInfo
       };
       dispatch(setUser(user));

--- a/src/views/UserInfoWrapper/index.tsx
+++ b/src/views/UserInfoWrapper/index.tsx
@@ -15,7 +15,7 @@ type UserInfoWrapperProps = {
 type oktaUserProps = {
   name?: string;
   euaId?: string;
-  'mint-groups'?: string[];
+  groups?: string[];
 };
 
 const UserInfoWrapper = ({ children }: UserInfoWrapperProps) => {
@@ -34,7 +34,7 @@ const UserInfoWrapper = ({ children }: UserInfoWrapperProps) => {
       const user = {
         name: oktaUser.name,
         euaId: oktaUser.euaId || '',
-        groups: oktaUser['mint-groups'] || [],
+        groups: oktaUser.groups || [],
         acceptedNDA: data?.ndaInfo
       };
       dispatch(setUser(user));


### PR DESCRIPTION
# NOREF

## Changes and Description

- Modify the key checked in the JWT from `groups` to `mint-groups` to reflect what actually gets returned from Okta

The backend change was made in this PR (https://github.com/CMSgov/mint-app/pull/300), and the corresponding frontend change was just missed until now!

## How to test this change

- Log in with Okta
- Navigate to http://localhost:3005/user-diagnostics
- Ensure that the right job codes are parsed!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
