### PR TITLE
[EASI-2003] Allow 'main' in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,10 @@ repos:
     hooks:
       - id: no-commit-to-branch
         args: [
-          '--pattern', '^(?!((feature\/EASI-\d{1,5})|((EASI-\d{1,5}|NOREF|dependabot)\/[a-zA-Z0-9\-\._/]+))$).*',
+          '--pattern', '^(?!((main)|(feature\/EASI-\d{1,5})|((EASI-\d{1,5}|NOREF|dependabot)\/[a-zA-Z0-9\-\._/]+))$).*',
+          '--branch', '' # Adding this to remove the default protection on `main` so that CI checks can pass
         ]
-        name: Enforce branch naming pattern
+        name: Enforce branch naming patterns
         description: Enforces branch naming policy. Allowed branch patterns are 'EASI-#', 'EASI-#/*', 'feature/EASI-#', 'NOREF/*', and 'dependabot/*'. A feature branch like feature/EASI-2020 would have branches like EASI-2020/frontend and EASI-2020/backend merge into it.
       - id: check-yaml
         name: Check YAML formatting


### PR DESCRIPTION
# EASI-2003

## Changes and Description

- Commits to `main` are allowed by pre-commit so that when `pre-commit` runs in CI it won't fail on `main`.
  - GitHub itself (due to repository config) will not allow pushing to `main` anyways, so this is just for CI/CD (still can't commit directly to `main`)

## How to test this change

Attempt to make a commit (with this pre-commit config) on `main`. It should let you commit, but not push!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
