### PR TITLE
[EASI-2491] - Change Job Codes Depending on Environment

### DIFF
--- a/pkg/okta/authentication_middleware.go
+++ b/pkg/okta/authentication_middleware.go
@@ -26,7 +26,7 @@ const (
 	JobCodeTestMACUser    = "MINT MAC Users"
 	JobCodeProdUser       = "MINT_USER"
 	JobCodeProdAssessment = "MINT_ASSESSMENT"
-	JobCodeProdMACUser    = "MINT_MAC_USER"
+	JobCodeProdMACUser    = "MINT MAC Users"
 )
 
 // EnhancedJwt is the JWT and the auth token

--- a/pkg/okta/authentication_middleware_test.go
+++ b/pkg/okta/authentication_middleware_test.go
@@ -74,6 +74,7 @@ func (s *AuthenticationMiddlewareTestSuite) buildMiddleware(verify func(jwt stri
 		handlers.NewHandlerBase(s.logger),
 		verifier,
 		s.store,
+		true,
 	)
 	return factory.NewAuthenticationMiddleware
 }

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -90,10 +90,13 @@ func (s *Server) routes(
 	oktaConfig := s.NewOktaClientConfig()
 	jwtVerifier := okta.NewJwtVerifier(oktaConfig.OktaClientID, oktaConfig.OktaIssuer)
 
+	isLocalOrTestEnvironment := s.environment.Local() || s.environment.Test()
+
 	oktaMiddlewareFactory := okta.NewMiddlewareFactory(
 		handlers.NewHandlerBase(s.logger),
 		jwtVerifier,
 		store,
+		isLocalOrTestEnvironment,
 	)
 
 	s.router.Use(
@@ -122,7 +125,7 @@ func (s *Server) routes(
 		s.Config.GetString(appconfig.CEDARAPIURL),
 		s.Config.GetString(appconfig.CEDARAPIKey),
 	)
-	if s.environment.Local() || s.environment.Test() {
+	if isLocalOrTestEnvironment {
 		cedarLDAPClient = local.NewCedarLdapClient(s.logger)
 	}
 

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -90,13 +90,11 @@ func (s *Server) routes(
 	oktaConfig := s.NewOktaClientConfig()
 	jwtVerifier := okta.NewJwtVerifier(oktaConfig.OktaClientID, oktaConfig.OktaIssuer)
 
-	isLocalOrTestEnvironment := s.environment.Local() || s.environment.Test()
-
 	oktaMiddlewareFactory := okta.NewMiddlewareFactory(
 		handlers.NewHandlerBase(s.logger),
 		jwtVerifier,
 		store,
-		isLocalOrTestEnvironment,
+		!s.environment.Prod(),
 	)
 
 	s.router.Use(
@@ -125,7 +123,7 @@ func (s *Server) routes(
 		s.Config.GetString(appconfig.CEDARAPIURL),
 		s.Config.GetString(appconfig.CEDARAPIKey),
 	)
-	if isLocalOrTestEnvironment {
+	if s.environment.Local() || s.environment.Test() {
 		cedarLDAPClient = local.NewCedarLdapClient(s.logger)
 	}
 


### PR DESCRIPTION
# EASI-2491

## Changes and Description

- Okta middleware switches job codes depending on if the user is in a production environment or pre-production environment

<!-- Put a description here! -->

## How to test this change

TBD


## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
