### PR TITLE
[EASI-2484] Remove "More team members" link from the read-only Team sub-page

### DIFF
--- a/src/views/ModelPlan/ReadOnly/_components/ContactInfo/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/ContactInfo/index.tsx
@@ -11,7 +11,13 @@ import {
 } from 'queries/Collaborators/types/GetModelCollaborators';
 import { TeamRole } from 'types/graphql-global-types';
 
-const ContactInfo = ({ modelID }: { modelID: string }) => {
+const ContactInfo = ({
+  modelID,
+  isViewingTeamPage
+}: {
+  modelID: string;
+  isViewingTeamPage: boolean;
+}) => {
   const { t: h } = useTranslation('generalReadOnly');
 
   const { data } = useQuery<GetModelCollaborators>(GetModelPlanCollaborators, {
@@ -56,14 +62,16 @@ const ContactInfo = ({ modelID }: { modelID: string }) => {
           );
         })}
 
-      <UswdsReactLink
-        aria-label={h('contactInfo.moreTeamMembers')}
-        className="line-height-body-5 display-flex flex-align-center "
-        to={`/models/${modelID}/read-only/team`}
-      >
-        {h('contactInfo.moreTeamMembers')}
-        <IconArrowForward className="margin-left-1" />
-      </UswdsReactLink>
+      {!isViewingTeamPage && (
+        <UswdsReactLink
+          aria-label={h('contactInfo.moreTeamMembers')}
+          className="line-height-body-5 display-flex flex-align-center "
+          to={`/models/${modelID}/read-only/team`}
+        >
+          {h('contactInfo.moreTeamMembers')}
+          <IconArrowForward className="margin-left-1" />
+        </UswdsReactLink>
+      )}
     </div>
   );
 };

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -496,7 +496,10 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
                             'sticky-nav__collaborator': hasEditAccess
                           })}
                         >
-                          <ContactInfo modelID={modelID} />
+                          <ContactInfo
+                            modelID={modelID}
+                            isViewingTeamPage={subinfo === 'team'}
+                          />
                         </Grid>
                       )}
                   </Grid>


### PR DESCRIPTION
# [EASI-2484](https://jiraent.cms.gov/browse/EASI-2484)

## Changes and Description

- Add new prop to ContactInfo -- isViewingTeamPage to conditionally render the "More team members" link

<!-- Put a description here! -->

## How to test this change

1. seed
2. Navigate to any model plan read only page
3. Navigate to team sub-page and check to see that the link is now gone.
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
