### PR TITLE
Added missing isMAC useMemo dependency

### DIFF
--- a/src/views/ModelPlan/Table/index.tsx
+++ b/src/views/ModelPlan/Table/index.tsx
@@ -191,7 +191,7 @@ const DraftModelPlansTable = ({
         }
       }
     ];
-  }, [t]);
+  }, [t, isMAC]);
 
   const macColumns = useMemo(() => {
     return [


### PR DESCRIPTION
NOREF

## Changes and Description

- Added missing isMAC useMemo dependency in model plan table

Not sure why linting checks didn't catch this missing useMemo dependency, but it caused the deployment ([EASI-2492] - Launch Darkly Flags to Hide IT Lead experience
) to fail.  Can probably cancel that deployment as this should fix the deployment error

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
