### PR TITLE
[NOREF] Use default logout URI

### DIFF
--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -83,9 +83,7 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
       const isSessionExpired = now - expirationTime > 0;
       setTimeRemainingArr(formatSessionTimeRemaining(expirationTime - now));
       if (isSessionExpired) {
-        oktaAuth.signOut({
-          postLogoutRedirectUri: `${window.location.origin}/login`
-        });
+        oktaAuth.signOut();
       }
     },
     authState?.isAuthenticated && isModalOpen ? 1000 : null


### PR DESCRIPTION
# NOREF

## Changes and Description

- Use default `post_logout_redirect_uri` when logging users out via a session timeout

Not 100% sure why, but depending on _how_ a user logged out (session timeout vs. clicking "Sign Out") we'd send the user to a different URI. This was annoying because it wasn't consistent, and was problematic because the IDM team only has `/` as a valid redirect URI (rather than `/` and `/signin`)

## How to test this change

Sadly, only `dev.mint.cms.gov` and `test.mint.cms.gov` are valid redirect URIs, not `localhost:3005/`, so testing this locally isn't possible yet, but ensuring that when you get a session timeout the `post_logout_redirect_uri` is what you expect it to be in the network console is sufficient!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
