### PR TITLE
[NOREF] Create "testing" environment instead of using "test"

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           REACT_APP_API_ADDRESS: http://easi:8080/api/v1
           REACT_APP_GRAPHQL_ADDRESS: http://easi:8080/api/graph/query
-          REACT_APP_APP_ENV: test
+          REACT_APP_APP_ENV: testing
           REACT_APP_OKTA_CLIENT_ID: 0oad9awvebnsMwWNa297
           REACT_APP_OKTA_DOMAIN: https://test.idp.idm.cms.gov
           REACT_APP_OKTA_SERVER_ID: ausd980kt2CBBzStG297
@@ -169,7 +169,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be
       - name: Run e2e cypress tests
         env:
-          APP_ENV: test
+          APP_ENV: testing
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           OKTA_TEST_PASSWORD: ${{ secrets.OKTA_TEST_PASSWORD }}
           OKTA_TEST_SECRET: ${{ secrets.OKTA_TEST_SECRET }}

--- a/cmd/mint/test.go
+++ b/cmd/mint/test.go
@@ -14,7 +14,7 @@ var testCmd = &cobra.Command{
 	Short: "Test the MINT application",
 	Long:  `Test the MINT application`,
 	Run: func(cmd *cobra.Command, args []string) {
-		err := os.Setenv("APP_ENV", "test")
+		err := os.Setenv("APP_ENV", "testing")
 		if err != nil {
 			fmt.Printf("Failed to set APP_ENV: %v", err)
 		}

--- a/docker-compose.cypress_ci.yml
+++ b/docker-compose.cypress_ci.yml
@@ -18,7 +18,7 @@ services:
   mint:
     image: '${ECR_REGISTRY}/mint-backend:${IMAGE_TAG}'
     environment:
-      - APP_ENV=test
+      - APP_ENV=testing
       - EMAIL_TEMPLATE_DIR=/mint/templates
       - SERVER_CERT
       - SERVER_KEY

--- a/docker-compose.cypress_local.yml
+++ b/docker-compose.cypress_local.yml
@@ -28,7 +28,7 @@ services:
       dockerfile: Dockerfile
     image: mint-backend:latest
     environment:
-      - APP_ENV=test
+      - APP_ENV=testing
       - EMAIL_TEMPLATE_DIR=/mint/templates
       - FLAG_SOURCE=LOCAL
       - FLAGDATA_FILE=/cypress/fixtures/flagdata.json
@@ -40,7 +40,7 @@ services:
       context: .
       dockerfile: Dockerfile.client
       args:
-        - REACT_APP_APP_ENV=test
+        - REACT_APP_APP_ENV=testing
         - REACT_APP_API_ADDRESS=http://mint:8080/api/v1
         - REACT_APP_GRAPHQL_ADDRESS=http://mint:8080/api/graph/query
         - REACT_APP_OKTA_CLIENT_ID

--- a/docs/local_testing.md
+++ b/docs/local_testing.md
@@ -22,9 +22,9 @@ There are multiple ways to run the Cypress tests:
     - Option 1: Use the preview features available in Windows Insiders build. See [Microsoft docs](https://docs.microsoft.com/en-us/windows/wsl/tutorials/gui-apps).
     - Option 2: Set up an X server on Windows and configure WSL to use it. See [this article](https://wilcovanes.ch/articles/setting-up-the-cypress-gui-in-wsl2-ubuntu-for-windows-10/) for details.
   - Note: the database, frontend, and backend must be running prior to starting the Cypress tests. Use `scripts/dev up` to start them.
-  - The `APP_ENV` environment variable should be set to `test` in `.envrc.local`. After creating `.envrc.local` if necessary and adding `APP_ENV=test` to it, run `direnv allow` to enable it. (See [instructions above](#direnv) on `direnv` usage)
+  - The `APP_ENV` environment variable should be set to `testing` in `.envrc.local`. After creating `.envrc.local` if necessary and adding `APP_ENV=testing` to it, run `direnv allow` to enable it. (See [instructions above](#direnv) on `direnv` usage)
   - Running `login.spec.js` requires the environment variables `OKTA_TEST_USERNAME`, `OKTA_TEST_PASSWORD`, and `OKTA_TEST_SECRET` to be set in `.envrc.local`. The values can be found in 1Password, as mentioned in the [Authentication section](#authentication).
-- `APP_ENV=test ./scripts/run-cypress-test-docker` : Run the Cypress tests,
+- `APP_ENV=testing ./scripts/run-cypress-test-docker` : Run the Cypress tests,
   database, migrations, backend, and frontend locally in Docker, similar to how
   they run in CI. Running the tests in this way takes time, but is useful
   for troubleshooting integration test failures in CI.

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -29,13 +29,15 @@ type Environment string
 const (
 	// localEnv is the local environment
 	localEnv Environment = "local"
-	// testEnv is the environment for running tests
+	// testingEnv is the environment for running tests
+	testingEnv Environment = "testing"
+	// testEnv is the environment for the test deployed env
 	testEnv Environment = "test"
 	// devEnv is the environment for the dev deployed env
 	devEnv Environment = "dev"
 	// implEnv is the environment for the impl deployed env
 	implEnv Environment = "impl"
-	// prodEnv is the environment for the impl deployed env
+	// prodEnv is the environment for the prod deployed env
 	prodEnv Environment = "prod"
 )
 
@@ -44,6 +46,8 @@ func (e Environment) String() string {
 	switch e {
 	case localEnv:
 		return "local"
+	case testingEnv:
+		return "testing"
 	case testEnv:
 		return "test"
 	case devEnv:
@@ -60,6 +64,11 @@ func (e Environment) String() string {
 // Local returns true if the environment is local
 func (e Environment) Local() bool {
 	return e == localEnv
+}
+
+// Testing returns true if the environment is testing
+func (e Environment) Testing() bool {
+	return e == testingEnv
 }
 
 // Test returns true if the environment is local
@@ -86,6 +95,8 @@ func (e Environment) Prod() bool {
 func (e Environment) Deployed() bool {
 	switch e {
 	case devEnv:
+		return true
+	case testEnv:
 		return true
 	case implEnv:
 		return true

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -7,6 +7,8 @@ func NewEnvironment(config string) (Environment, error) {
 	switch config {
 	case localEnv.String():
 		return localEnv, nil
+	case testingEnv.String():
+		return testingEnv, nil
 	case testEnv.String():
 		return testEnv, nil
 	case devEnv.String():

--- a/pkg/appconfig/config_test.go
+++ b/pkg/appconfig/config_test.go
@@ -51,6 +51,12 @@ func (s *ConfigTestSuite) TestLocal() {
 	s.True(env.Local())
 }
 
+func (s *ConfigTestSuite) TestTesting() {
+	env, _ := NewEnvironment("testing")
+
+	s.True(env.Testing())
+}
+
 func (s *ConfigTestSuite) TestTest() {
 	env, _ := NewEnvironment("test")
 
@@ -79,8 +85,11 @@ func (s *ConfigTestSuite) TestDeployed() {
 	s.Run("local isn't deployed environment", func() {
 		s.False(localEnv.Deployed())
 	})
-	s.Run("test isn't deployed environment", func() {
-		s.False(testEnv.Deployed())
+	s.Run("testing isn't deployed environment", func() {
+		s.False(testingEnv.Deployed())
+	})
+	s.Run("test is deployed environment", func() {
+		s.True(testEnv.Deployed())
 	})
 	s.Run("dev is deployed environment", func() {
 		s.True(devEnv.Deployed())

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -122,7 +122,7 @@ func (s *Server) routes(
 		s.Config.GetString(appconfig.CEDARAPIURL),
 		s.Config.GetString(appconfig.CEDARAPIKey),
 	)
-	if s.environment.Local() || s.environment.Test() {
+	if s.environment.Local() || s.environment.Testing() {
 		cedarLDAPClient = local.NewCedarLdapClient(s.logger)
 	}
 
@@ -148,7 +148,7 @@ func (s *Server) routes(
 
 	// set up S3 client
 	s3Config := s.NewS3Config()
-	if s.environment.Local() || s.environment.Test() {
+	if s.environment.Local() || s.environment.Testing() {
 		s3Config.IsLocal = true
 	}
 
@@ -161,7 +161,7 @@ func (s *Server) routes(
 	princeConfig := s.NewPrinceLambdaConfig()
 	princeLambdaName = princeConfig.FunctionName
 
-	if s.environment.Local() || s.environment.Test() {
+	if s.environment.Local() || s.environment.Testing() {
 		endpoint := princeConfig.Endpoint
 		lambdaClient = lambda.New(lambdaSession, &aws.Config{Endpoint: &endpoint, Region: aws.String("us-west-2")})
 	} else {

--- a/scripts/check_deployed_image_findings
+++ b/scripts/check_deployed_image_findings
@@ -9,6 +9,9 @@ case "$APP_ENV" in
   "dev")
     MINT_URL="https://dev.mint.cms.gov"
     ;;
+  "test")
+    MINT_URL="https://test.mint.cms.gov"
+    ;;
   "impl")
     MINT_URL="https://impl.mint.cms.gov"
     ;;
@@ -17,7 +20,7 @@ case "$APP_ENV" in
     ;;
   *)
     echo "APP_ENV value not recognized: ${APP_ENV:-unset}"
-    echo "Allowed values: 'dev', 'impl', 'prod'"
+    echo "Allowed values: 'dev', 'impl', 'test', 'prod'"
     exit 1
     ;;
 esac

--- a/scripts/release_static
+++ b/scripts/release_static
@@ -8,6 +8,10 @@ case "$APP_ENV" in
     MINT_URL="https://dev.mint.cms.gov"
     export REACT_APP_OKTA_DOMAIN="https://test.idp.idm.cms.gov"
     ;;
+  "test")
+    MINT_URL="https://test.mint.cms.gov"
+    export REACT_APP_OKTA_DOMAIN="https://test.idp.idm.cms.gov"
+    ;;
   "impl")
     MINT_URL="https://impl.mint.cms.gov"
     export REACT_APP_OKTA_DOMAIN="https://impl.idp.idm.cms.gov"


### PR DESCRIPTION
# NOREF

## Changes and Description

- Changed references that used `test` as an environment to use `testing` instead
- Created new `testing` environment in `appconfig` package to facilitate identifying when we're running tests (what used to be `test`)

We needed to have some modifications to our environment configuration because EASi historically (and currently) only had `dev`, `impl`, and `prod` environments. Therefore, an environment was created in the appconfig called `test` which was used to identify when the application was being run for local test (i.e. `go test` or `cypress`)

However, MINT has an environment literally named `test`, so the "unit testing" environment was renamed `testing`, and all instances of `test` now refer to the _deployed_ test env, rather than the "unit testing" environment.

## How to test this change

- Ensure that when `APP_ENV` is set to `test`, a real connection to CEDAR LDAP is used.
- Ensure that when `APP_ENV` is set to `testing`, the CEDAR LDAP mock is used.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
