### PR TITLE
[NOREF] Disable docker caching in GH Actions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -50,8 +50,6 @@ jobs:
         uses: HatsuneMiku3939/direnv-action@v1
       - name: Get docker images
         run: docker-compose pull
-      - name: Docker Layer Caching
-        uses: satackey/action-docker-layer-caching@v0.0.11
         # Why does this step need to be done, you ask?
         # docker-compose, by default, allows referenceing other containers in the same network by name, i.e. "minio:9005".
         # Since the tests are being run outside docker, we need to ensure that the host "minio" is reachable, just like it is in the container.


### PR DESCRIPTION
# NOREF

## Changes and Description

- Remove use of [satackey/docker-layer-caching](https://github.com/satackey/action-docker-layer-caching) GitHub action in `run_tests.yml` as it seemed to be causing issues with the amount of storage space on the GH runners.

Some examples of failed jobs:
1. @patrickseguraoddball's https://github.com/CMSgov/mint-app/actions/runs/3686509199
2. @rileyanderson's https://github.com/CMSgov/mint-app/actions/runs/3689636858/jobs/6245825319

https://github.com/satackey/action-docker-layer-caching/issues/305#issuecomment-1231144309 This is a possible reason that this only started happening recently.

## How to test this change

Ensure that `run_tests` still passes - this is just a caching change, so as long as it still works, we should be good!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
