### PR TITLE
[NOREF] Fix an issue with multiple tabs triggering an infinite loop of messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-autosuggest": "^10.1.0",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.5.0",
-    "react-idle-timer": "^4.5.5",
+    "react-idle-timer": "^5.4.2",
     "react-media": "^1.10.0",
     "react-modal": "^3.11.2",
     "react-redux": "^7.1.1",

--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -15,22 +15,10 @@ type TimeOutWrapperProps = {
 };
 
 const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
-  const [lastActiveAt, setLastActiveAt] = useState(DateTime.local().toMillis());
-  const [expirationTime, setExpirationTime] = useState(0);
-
-  const LAST_ACTIVE_AT_KEY = 'mintLastActiveAt';
   const isLocalAuth =
     isLocalAuthEnabled() &&
     window.localStorage[localAuthStorageKey] &&
     JSON.parse(window.localStorage[localAuthStorageKey]).favorLocalAuth;
-
-  useIdleTimer({
-    onAction: () => {
-      setLastActiveAt(DateTime.local().toMillis());
-    },
-    events: ['mousedown', 'keydown'],
-    debounce: 500
-  });
 
   const { authState, oktaAuth } = useOktaAuth();
   const { t } = useTranslation();
@@ -38,7 +26,29 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [timeRemainingArr, setTimeRemainingArr] = useState([0, 'second']);
 
-  const tenMinutes = Duration.fromObject({ minutes: 10 }).as('milliseconds');
+  const fiveMinutes = Duration.fromObject({ minutes: 5 }).as('milliseconds');
+
+  // Since 5 minutes is used for the `promptTimeout` AND the `timeout`, you effectively have 10 minutes before you're logged out due to inactivity.
+  // 5 of those minutes will be uninterrupted, the other 5 will be when the prompt is up.
+  const idleTimer = useIdleTimer({
+    events: ['mousedown', 'keydown'],
+    onIdle: () => {
+      if (!isLocalAuth && authState?.isAuthenticated) {
+        oktaAuth.signOut();
+      }
+    },
+    onPrompt: () => {
+      if (authState?.isAuthenticated) {
+        setTimeRemainingArr(formatSessionTimeRemaining(fiveMinutes));
+        setIsModalOpen(true);
+      }
+    },
+    promptTimeout: fiveMinutes,
+    crossTab: true,
+    syncTimers: 1000,
+    debounce: 500,
+    timeout: fiveMinutes
+  });
 
   const forceRenew = async () => {
     const tokenManager = await oktaAuth.tokenManager;
@@ -47,31 +57,32 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
   };
 
   /**
-   * @param timeRemaining seconds
+   * @param timeRemainingMs milliseconds
    * @returns [minutes, seconds]
    */
   const formatSessionTimeRemaining = (
-    timeRemaining: number
+    timeRemainingMs: number
   ): [number, string] => {
-    const minutes = timeRemaining / 60;
+    const timeRemainingSeconds = timeRemainingMs / 1000;
+    const minutes = timeRemainingSeconds / 60;
     // Using Math.ceil() for greater than one minute
     // 299 seconds = 4.983 minutes, but should still display 5 minutes
     // Using Math.floor() for less than one minute
     // 59 seconds = .983 minutes, Using floor so minutes is 0 to display 59 secounds
     const wholeMinutes = minutes > 1 ? Math.ceil(minutes) : Math.floor(minutes);
 
-    if (timeRemaining > 0) {
+    if (timeRemainingSeconds > 0) {
       if (wholeMinutes > 0) {
         return [wholeMinutes, 'minute'];
       }
-      return [Math.floor(timeRemaining), 'second'];
+      return [Math.floor(timeRemainingSeconds), 'second'];
     }
     return [0, 'second'];
   };
 
   const handleModalExit = async () => {
     setIsModalOpen(false);
-    setLastActiveAt(DateTime.local().toMillis());
+    idleTimer.reset();
     forceRenew();
   };
 
@@ -79,46 +90,30 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
   // Updates the minutes/seconds in the message
   useInterval(
     () => {
-      const now = DateTime.local().toSeconds();
-      const isSessionExpired = now - expirationTime > 0;
-      setTimeRemainingArr(formatSessionTimeRemaining(expirationTime - now));
-      if (isSessionExpired) {
-        oktaAuth.signOut();
-      }
+      setTimeRemainingArr(
+        formatSessionTimeRemaining(idleTimer.getRemainingTime())
+      );
     },
     authState?.isAuthenticated && isModalOpen ? 1000 : null
-  );
-
-  // useInterval starts when a user is logged in AND the modal is not open
-  // useInterval stops/pauses, when a use is logged out or the modal is open
-  // Calculates the user's inactivity to display the modal
-  useInterval(
-    () => {
-      if (lastActiveAt + tenMinutes < DateTime.local().toMillis()) {
-        const now = DateTime.local();
-        const expiration = Math.floor(now.plus({ minutes: 5 }).toSeconds());
-        setExpirationTime(expiration);
-        setTimeRemainingArr(
-          formatSessionTimeRemaining(expiration - now.toSeconds())
-        );
-        setIsModalOpen(true);
-      }
-    },
-    authState?.isAuthenticated && !isModalOpen && !isLocalAuth ? 1000 : null
   );
 
   // If user is authenticated and has a token, renew it forever one
   // minute before expiration.
   // The user's inactivity will log the user out.
   useEffect(() => {
-    const twoMinutes = Duration.fromObject({ minutes: 1 }).as('seconds');
+    const oneMinute = Duration.fromObject({ minutes: 1 }).as('seconds');
 
     if (authState?.isAuthenticated && authState.accessToken) {
       // expiresAt is in seconds
       const timeUntilTokenExpiration =
         authState?.accessToken?.expiresAt -
         DateTime.local().toSeconds() -
-        twoMinutes;
+        oneMinute;
+
+      // If token is expired already, sign out!
+      if (timeUntilTokenExpiration <= 0) {
+        oktaAuth.signOut();
+      }
 
       const timeout = setTimeout(() => {
         forceRenew();
@@ -129,29 +124,6 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
     return undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authState?.isAuthenticated, authState?.accessToken]);
-
-  // Set lastActiveAt between tabs
-  useEffect(() => {
-    localStorage.setItem(LAST_ACTIVE_AT_KEY, lastActiveAt.toString());
-  }, [lastActiveAt]);
-
-  // Listen to lastActiveAt between tabs
-  useEffect(() => {
-    const handler = (event: StorageEvent) => {
-      if (
-        event.storageArea === localStorage &&
-        event.key === LAST_ACTIVE_AT_KEY
-      ) {
-        setLastActiveAt(parseInt(event.newValue || '0', 10));
-        setIsModalOpen(false);
-      }
-    };
-
-    window.addEventListener('storage', handler);
-    return () => {
-      window.removeEventListener('storage', handler);
-    };
-  }, []);
 
   return (
     <>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15244,10 +15244,10 @@ react-i18next@^11.5.0:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"
 
-react-idle-timer@^4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/react-idle-timer/-/react-idle-timer-4.5.5.tgz#73eeb816984d89fea1dda1225bd893bc4c2726be"
-  integrity sha512-hQpwbEmZq9NZyR3hsq9savk8SwKAyzBqqCpp3sjJQzMrYoQHMIxKrYy0dpCM0JbyHNmSDqD4vLTJAcA+BH47Dw==
+react-idle-timer@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/react-idle-timer/-/react-idle-timer-5.4.2.tgz#69e20044cf2ecc421aef99cd82298c526d8acf37"
+  integrity sha512-ofCS/qpFjm6ZguEyePvtf9YMDnLj7zZfeLXRWGRpsC6Ga47H4dm7EvoUW8MsozGEGy8zCvPK0Sk6YuAnwLEzRQ==
 
 react-inspector@^5.1.0:
   version "5.1.1"


### PR DESCRIPTION
# NOREF

## Changes and Description

- Fixed an issue with the TimeoutWrapper sending infinite messages to other tabs when multiple are open, causing the frontend/browser to crash.

## How to test this change

- Start up the service locally with `scripts/dev up`
- Log in (Okta auth is all that will work)
- Open multiple home page tabs (usually 3-5 would replicate the issue previously)
- Switch between those tabs as rapidly as you can (`cmd+shift+arrow` on Mac can help do this quickly)
- Ensure there's no performance issues / crashes.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
