### PR TITLE
[EASI-2499] GitHub actions to deploy to prod

### DIFF
--- a/.github/workflows/deploy_pipeline.yml
+++ b/.github/workflows/deploy_pipeline.yml
@@ -74,8 +74,8 @@ jobs:
       ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
 
   deploy_prod:
-    if: ${{ false }} # Disabled until we're ready to deploy
-    needs: deploy_impl
+    # needs: deploy_impl
+    needs: deploy_test # TODO Reset to needing `deploy_impl` after pen-testing is complete! Right now, we'll base it off `deploy_test`
     uses: ./.github/workflows/deploy_to_environment.yml
     with:
       env: prod


### PR DESCRIPTION
# EASI-2499

## Changes and Description

- Enabled GitHub action to deploy to the production environment
- Temporarily set the dependency on deploying to `prod` to require a deploy to `test` rather than `impl`, due to current pen-testing.

## How to test this change

- Overview the GitHub actions code to see if it aligns with other environment deploy code
- Ensure the environment in GitHub is properly configured (secrets)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
