### PR TITLE
[EASI-2435] Upgrade flyway to v9

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Migrate Database
-        uses: joshuaavalon/flyway-action@v1
+        uses: joshuaavalon/flyway-action@v3.0.0 # flyway-action 3.0.0 uses flyway v9, which should (if we do our jobs) match what's in Dockerfile.db_clean and Dockerfile.db_migrations
         with:
           url: jdbc:postgresql://postgres:5432/${{ env.POSTGRES_DB }}
           user: ${{ env.POSTGRES_USER }}

--- a/Dockerfile.db_clean
+++ b/Dockerfile.db_clean
@@ -1,4 +1,4 @@
-FROM flyway/flyway:7.8.2-alpine
+FROM flyway/flyway:9.10.1-alpine
 
 ENV FLYWAY_CONNECT_RETRIES=10
 ENV FLYWAY_IGNORE_INVALID_MIGRATION_NAMES="false"

--- a/Dockerfile.db_clean
+++ b/Dockerfile.db_clean
@@ -1,4 +1,4 @@
-FROM flyway/flyway:9.10.1-alpine
+FROM flyway/flyway:9.10-alpine
 
 ENV FLYWAY_CONNECT_RETRIES=10
 ENV FLYWAY_IGNORE_INVALID_MIGRATION_NAMES="false"

--- a/Dockerfile.db_migrations
+++ b/Dockerfile.db_migrations
@@ -1,4 +1,4 @@
-FROM flyway/flyway:9.10.1-alpine
+FROM flyway/flyway:9.10-alpine
 
 COPY migrations/ /flyway/sql
 

--- a/Dockerfile.db_migrations
+++ b/Dockerfile.db_migrations
@@ -1,4 +1,4 @@
-FROM flyway/flyway:7.8.2-alpine
+FROM flyway/flyway:9.10.1-alpine
 
 COPY migrations/ /flyway/sql
 


### PR DESCRIPTION
# EASI-2435

## Changes and Description

- Upgrade flyway to V9 in Dockerfiles for DB Clean and DB Migrate
- Upgrade flyway to V9 by upgrading `joshuaavalon/flyway-action` to v3.0.0 (https://github.com/joshuaavalon/flyway-action/releases/tag/v3.0.0)

<!-- Put a description here! -->

## How to test this change

### Upgrade of the flyway-action

- Ensure that the CI/CD jobs pass, which use the flyway-action to run migrations!

### Upgrade in the `Dockerfile`s
- Start the service with `scripts/dev up`
  - This inherently runs the `Dockerfile.db_migrations` file due to [this entry](https://github.com/CMSgov/mint-app/blob/8401c8c2a62a26a15e236051ebb05755b3911851/docker-compose.yml#L9-L18) in our docker-compose.yml file.
- Ensure DB migrations ran as expected
- Use this nasty one-liner to build and run the DB Clean image:
```bash
FLYWAY_CLEAN_DISABLED=false FLYWAY_USER=postgres FLYWAY_PASSWORD=mysecretpassword FLYWAY_URL=jdbc:postgresql://host.docker.internal:5437/postgres docker run --env FLYWAY_CLEAN_DISABLED --env FLYWAY_USER --env FLYWAY_PASSWORD --env FLYWAY_URL $(docker build -q -f Dockerfile.db_clean .)
```
- Ensure DB Clean ran as expected

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
