### PR TITLE
[NOREF] Fix timeout modal locally

### DIFF
--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -53,7 +53,7 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
   const forceRenew = async () => {
     // If not using local auth, and we've got an authenticated user with an access token, attempt to refresh it
     // Otherwise, do nothing
-    if (!isLocalAuth && authState?.isAuthenticated && authState.accessToken) {
+    if (authState?.idToken && authState?.accessToken) {
       const tokenManager = await oktaAuth.tokenManager;
       tokenManager.renew('idToken');
       tokenManager.renew('accessToken');

--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -14,6 +14,9 @@ type TimeOutWrapperProps = {
   children: React.ReactNode;
 };
 
+// TimeOutWrapper handles all of the logic for tracking user activity and conditionally rendering a timeout modal
+// if idle time reaches a certain threshold.
+// This component effectively doesn't do anything when using local auth.
 const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
   const isLocalAuth =
     isLocalAuthEnabled() &&
@@ -38,7 +41,7 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
       }
     },
     onPrompt: () => {
-      if (authState?.isAuthenticated) {
+      if (!isLocalAuth && authState?.isAuthenticated) {
         setTimeRemainingArr(formatSessionTimeRemaining(fiveMinutes));
         setIsModalOpen(true);
       }

--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -51,9 +51,13 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
   });
 
   const forceRenew = async () => {
-    const tokenManager = await oktaAuth.tokenManager;
-    tokenManager.renew('idToken');
-    tokenManager.renew('accessToken');
+    // If not using local auth, and we've got an authenticated user with an access token, attempt to refresh it
+    // Otherwise, do nothing
+    if (!isLocalAuth && authState?.isAuthenticated && authState.accessToken) {
+      const tokenManager = await oktaAuth.tokenManager;
+      tokenManager.renew('idToken');
+      tokenManager.renew('accessToken');
+    }
   };
 
   /**

--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -26,10 +26,9 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
   const { authState, oktaAuth } = useOktaAuth();
   const { t } = useTranslation();
 
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const [timeRemainingArr, setTimeRemainingArr] = useState([0, 'second']);
 
-  const fiveMinutes = Duration.fromObject({ minutes: 5 }).as('milliseconds');
+  const fiveMinutes = Duration.fromObject({ seconds: 15 }).as('milliseconds');
 
   // Since 5 minutes is used for the `promptTimeout` AND the `timeout`, you effectively have 10 minutes before you're logged out due to inactivity.
   // 5 of those minutes will be uninterrupted, the other 5 will be when the prompt is up.
@@ -43,7 +42,6 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
     onPrompt: () => {
       if (!isLocalAuth && authState?.isAuthenticated) {
         setTimeRemainingArr(formatSessionTimeRemaining(fiveMinutes));
-        setIsModalOpen(true);
       }
     },
     promptTimeout: fiveMinutes,
@@ -88,7 +86,6 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
   };
 
   const handleModalExit = async () => {
-    setIsModalOpen(false);
     idleTimer.reset();
     forceRenew();
   };
@@ -101,7 +98,7 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
         formatSessionTimeRemaining(idleTimer.getRemainingTime())
       );
     },
-    authState?.isAuthenticated && isModalOpen ? 1000 : null
+    authState?.isAuthenticated && idleTimer.isPrompted() ? 1000 : null
   );
 
   // If user is authenticated and has a token, renew it forever one
@@ -134,7 +131,7 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
 
   return (
     <>
-      <Modal isOpen={isModalOpen} closeModal={handleModalExit}>
+      <Modal isOpen={idleTimer.isPrompted()} closeModal={handleModalExit}>
         <h3
           className="margin-top-0"
           role="timer"

--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -28,7 +28,7 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
 
   const [timeRemainingArr, setTimeRemainingArr] = useState([0, 'second']);
 
-  const fiveMinutes = Duration.fromObject({ seconds: 15 }).as('milliseconds');
+  const fiveMinutes = Duration.fromObject({ minutes: 5 }).as('milliseconds');
 
   // Since 5 minutes is used for the `promptTimeout` AND the `timeout`, you effectively have 10 minutes before you're logged out due to inactivity.
   // 5 of those minutes will be uninterrupted, the other 5 will be when the prompt is up.


### PR DESCRIPTION
# NOREF

## Changes and Description

- Check if using Okta auth (if you have an `idToken` and an `accessToken`) before attempting to renew tokens

## How to test this change

- Start MINT locally
- Set the timeout in `src/views/TimeOutWrapper/index.tsx` to something manageable for local development
```javascript
// const fiveMinutes = Duration.fromObject({ minutes: 5 }).as('milliseconds');
const fiveMinutes = Duration.fromObject({ seconds: 15 }).as('milliseconds');
```
- Log in with local dev
- Let the timeout modal pop up
- Close the modal to continue using MINT
- Ensure no errors pop up

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
