### PR TITLE
Easi 2550/add user account collaborator

### DIFF
--- a/cmd/dbseed/resolver_wrappers.go
+++ b/cmd/dbseed/resolver_wrappers.go
@@ -28,7 +28,7 @@ import (
 func createModelPlan(store *storage.Store, logger *zap.Logger, modelName string, euaID string) *models.ModelPlan {
 
 	princ := getTestPrincipal(store, euaID)
-	plan, err := resolvers.ModelPlanCreate(context.Background(), logger, modelName, store, princ, stubFetchUserInfo)
+	plan, err := resolvers.ModelPlanCreate(context.Background(), logger, modelName, store, princ, userhelpers.GetUserInfoAccountInformationWrapperFunction(stubFetchUserInfo))
 	if err != nil {
 		panic(err)
 	}
@@ -97,7 +97,7 @@ func addPlanCollaborator(
 		princ,
 		store,
 		true,
-		stubFetchUserInfo,
+		userhelpers.GetUserInfoAccountInformationWrapperFunction(stubFetchUserInfo),
 	)
 	if err != nil {
 		panic(err)

--- a/cmd/dbseed/resolver_wrappers.go
+++ b/cmd/dbseed/resolver_wrappers.go
@@ -28,7 +28,7 @@ import (
 func createModelPlan(store *storage.Store, logger *zap.Logger, modelName string, euaID string) *models.ModelPlan {
 
 	princ := getTestPrincipal(store, euaID)
-	plan, err := resolvers.ModelPlanCreate(context.Background(), logger, modelName, store, princ, userhelpers.GetUserInfoAccountInformationWrapperFunction(stubFetchUserInfo))
+	plan, err := resolvers.ModelPlanCreate(context.Background(), logger, modelName, store, princ, userhelpers.GetUserInfoAccountInfoWrapperFunc(stubFetchUserInfo))
 	if err != nil {
 		panic(err)
 	}
@@ -97,7 +97,7 @@ func addPlanCollaborator(
 		princ,
 		store,
 		true,
-		userhelpers.GetUserInfoAccountInformationWrapperFunction(stubFetchUserInfo),
+		userhelpers.GetUserInfoAccountInfoWrapperFunc(stubFetchUserInfo),
 	)
 	if err != nil {
 		panic(err)

--- a/cmd/dbseed/resolver_wrappers.go
+++ b/cmd/dbseed/resolver_wrappers.go
@@ -234,7 +234,7 @@ func addPlanDocumentSolutionLinks(
 
 func getTestPrincipal(store *storage.Store, userName string) *authentication.ApplicationPrincipal {
 
-	userAccount, _ := userhelpers.GetOrCreateUserAccount(store, userName, true, "", "", false)
+	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false)
 
 	princ := &authentication.ApplicationPrincipal{
 		Username:          userName,

--- a/cmd/dbseed/resolver_wrappers.go
+++ b/cmd/dbseed/resolver_wrappers.go
@@ -234,7 +234,7 @@ func addPlanDocumentSolutionLinks(
 
 func getTestPrincipal(store *storage.Store, userName string) *authentication.ApplicationPrincipal {
 
-	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false, userhelpers.GetUserInfoFromOktaLocal)
+	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false, userhelpers.GetOktaAccountInfoWrapperFunction(userhelpers.GetUserInfoFromOktaLocal))
 
 	princ := &authentication.ApplicationPrincipal{
 		Username:          userName,

--- a/cmd/dbseed/resolver_wrappers.go
+++ b/cmd/dbseed/resolver_wrappers.go
@@ -234,7 +234,7 @@ func addPlanDocumentSolutionLinks(
 
 func getTestPrincipal(store *storage.Store, userName string) *authentication.ApplicationPrincipal {
 
-	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false)
+	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false, userhelpers.GetUserInfoFromOktaLocal)
 
 	princ := &authentication.ApplicationPrincipal{
 		Username:          userName,

--- a/cmd/dbseed/resolver_wrappers.go
+++ b/cmd/dbseed/resolver_wrappers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -27,7 +28,7 @@ import (
 func createModelPlan(store *storage.Store, logger *zap.Logger, modelName string, euaID string) *models.ModelPlan {
 
 	princ := getTestPrincipal(store, euaID)
-	plan, err := resolvers.ModelPlanCreate(logger, modelName, store, princ)
+	plan, err := resolvers.ModelPlanCreate(context.Background(), logger, modelName, store, princ, stubFetchUserInfo)
 	if err != nil {
 		panic(err)
 	}
@@ -64,6 +65,16 @@ func updatePlanBasics(store *storage.Store, logger *zap.Logger, mp *models.Model
 	return updated
 }
 
+func stubFetchUserInfo(ctx context.Context, username string) (*models.UserInfo, error) {
+	return &models.UserInfo{
+		EuaUserID:  username,
+		FirstName:  username,
+		LastName:   "Doe",
+		CommonName: username + " Doe",
+		Email:      models.NewEmailAddress(username + ".doe@local.fake"),
+	}, nil
+}
+
 // addPlanCollaborator is a wrapper for resolvers.CreatePlanCollaborator
 // It will panic if an error occurs, rather than bubbling the error up
 // It will always add the collaborator object with the principal value of the Model Plan's "createdBy"
@@ -78,6 +89,7 @@ func addPlanCollaborator(
 	princ := getTestPrincipal(store, mp.CreatedBy)
 
 	collaborator, _, err := resolvers.CreatePlanCollaborator(
+		context.Background(),
 		logger,
 		emailService,
 		emailTemplateService,
@@ -85,6 +97,7 @@ func addPlanCollaborator(
 		princ,
 		store,
 		true,
+		stubFetchUserInfo,
 	)
 	if err != nil {
 		panic(err)

--- a/migrations/V2.5__Add_Users_table.sql
+++ b/migrations/V2.5__Add_Users_table.sql
@@ -7,7 +7,8 @@ CREATE TABLE user_account (
     email ZERO_STRING NOT NULL,
     given_name ZERO_STRING NOT NULL,
     family_name ZERO_STRING NOT NULL,
-    zone_info ZERO_STRING NOT NULL
+    zone_info ZERO_STRING NOT NULL,
+    has_logged_in BOOLEAN NOT NULL
 );
 
 ALTER TABLE user_account

--- a/migrations/V2.5__Add_Users_table.sql
+++ b/migrations/V2.5__Add_Users_table.sql
@@ -7,8 +7,7 @@ CREATE TABLE user_account (
     email ZERO_STRING NOT NULL,
     given_name ZERO_STRING NOT NULL,
     family_name ZERO_STRING NOT NULL,
-    zone_info ZERO_STRING NOT NULL,
-    has_logged_in BOOLEAN NOT NULL
+    zone_info ZERO_STRING NOT NULL
 );
 
 ALTER TABLE user_account

--- a/migrations/V41__Add_Has_Logged_In_To_User_Account.sql
+++ b/migrations/V41__Add_Has_Logged_In_To_User_Account.sql
@@ -1,10 +1,2 @@
 ALTER TABLE user_account
-ADD COLUMN has_logged_in BOOLEAN DEFAULT FALSE; --ADD Column
-
-
-UPDATE user_account --Update missing information
-SET has_logged_in = FALSE
-WHERE has_logged_in IS NULL;
-
-ALTER TABLE user_account
-ALTER COLUMN has_logged_in SET NOT NULL; -- Add not null constraint
+ADD COLUMN has_logged_in BOOLEAN NOT NULL DEFAULT FALSE;

--- a/migrations/V41__Add_Has_Logged_In_To_User_Account.sql
+++ b/migrations/V41__Add_Has_Logged_In_To_User_Account.sql
@@ -1,0 +1,10 @@
+ALTER TABLE user_account
+ADD COLUMN has_logged_in BOOLEAN DEFAULT FALSE; --ADD Column
+
+
+UPDATE user_account --Update missing information
+SET has_logged_in = FALSE
+WHERE has_logged_in IS NULL;
+
+ALTER TABLE user_account
+ALTER COLUMN has_logged_in SET NOT NULL; -- Add not null constraint

--- a/pkg/appcontext/context.go
+++ b/pkg/appcontext/context.go
@@ -17,6 +17,8 @@ const (
 	loggerKey contextKey = iota
 	traceKey
 	principalKey
+	jwtKey
+	authTokenKey
 )
 
 // WithLogger returns a context with the given logger
@@ -66,4 +68,30 @@ func Principal(c context.Context) authentication.Principal {
 		return p
 	}
 	return authentication.ANON
+}
+
+// WithAuthToken decorates the context with the given authToken
+func WithAuthToken(c context.Context, token string) context.Context {
+	return context.WithValue(c, authTokenKey, token)
+}
+
+// AuthToken returns the auth token defaulting to nil if not provided
+func AuthToken(c context.Context) *string {
+	if token, ok := c.Value(authTokenKey).(string); ok {
+		return &token
+	}
+	return nil
+}
+
+// WithJWT returns the context decorated with the jwt
+func WithJWT(c context.Context, jwt authentication.EnhancedJwt) context.Context {
+	return context.WithValue(c, jwtKey, jwt)
+}
+
+// JWT returns the enhanced JWT defaulting to nil if not present.
+func JWT(c context.Context) *authentication.EnhancedJwt {
+	if jwt, ok := c.Value(authTokenKey).(authentication.EnhancedJwt); ok {
+		return &jwt
+	}
+	return nil
 }

--- a/pkg/appcontext/context.go
+++ b/pkg/appcontext/context.go
@@ -90,7 +90,7 @@ func WithJWT(c context.Context, jwt authentication.EnhancedJwt) context.Context 
 
 // JWT returns the enhanced JWT defaulting to nil if not present.
 func JWT(c context.Context) *authentication.EnhancedJwt {
-	if jwt, ok := c.Value(authTokenKey).(authentication.EnhancedJwt); ok {
+	if jwt, ok := c.Value(jwtKey).(authentication.EnhancedJwt); ok {
 		return &jwt
 	}
 	return nil

--- a/pkg/appcontext/context.go
+++ b/pkg/appcontext/context.go
@@ -18,7 +18,6 @@ const (
 	traceKey
 	principalKey
 	jwtKey
-	authTokenKey
 )
 
 // WithLogger returns a context with the given logger
@@ -70,26 +69,13 @@ func Principal(c context.Context) authentication.Principal {
 	return authentication.ANON
 }
 
-// WithAuthToken decorates the context with the given authToken
-func WithAuthToken(c context.Context, token string) context.Context {
-	return context.WithValue(c, authTokenKey, token)
-}
-
-// AuthToken returns the auth token defaulting to nil if not provided
-func AuthToken(c context.Context) *string {
-	if token, ok := c.Value(authTokenKey).(string); ok {
-		return &token
-	}
-	return nil
-}
-
-// WithJWT returns the context decorated with the jwt
-func WithJWT(c context.Context, jwt authentication.EnhancedJwt) context.Context {
+// WithEnhancedJWT returns the context decorated with the enhanced jwt
+func WithEnhancedJWT(c context.Context, jwt authentication.EnhancedJwt) context.Context {
 	return context.WithValue(c, jwtKey, jwt)
 }
 
-// JWT returns the enhanced JWT defaulting to nil if not present.
-func JWT(c context.Context) *authentication.EnhancedJwt {
+// EnhancedJWT returns the enhanced EnhancedJWT defaulting to nil if not present.
+func EnhancedJWT(c context.Context) *authentication.EnhancedJwt {
 	if jwt, ok := c.Value(jwtKey).(authentication.EnhancedJwt); ok {
 		return &jwt
 	}

--- a/pkg/authentication/enhanced_jwt.go
+++ b/pkg/authentication/enhanced_jwt.go
@@ -1,0 +1,9 @@
+package authentication
+
+import jwtverifier "github.com/okta/okta-jwt-verifier-golang"
+
+// EnhancedJwt is the JWT and the auth token
+type EnhancedJwt struct {
+	JWT       *jwtverifier.Jwt
+	AuthToken string
+}

--- a/pkg/authentication/enhanced_jwt.go
+++ b/pkg/authentication/enhanced_jwt.go
@@ -1,9 +1,21 @@
 package authentication
 
-import jwtverifier "github.com/okta/okta-jwt-verifier-golang"
+import (
+	"fmt"
+
+	jwtverifier "github.com/okta/okta-jwt-verifier-golang"
+)
 
 // EnhancedJwt is the JWT and the auth token
 type EnhancedJwt struct {
 	JWT       *jwtverifier.Jwt
 	AuthToken string
+}
+
+// GetOktaBaseURL returns the OktaBaseURL for the user in the context of the request and errors if the context doesn't have one
+func (ejwt *EnhancedJwt) GetOktaBaseURL() (*string, error) {
+	if url, ok := ejwt.JWT.Claims["iss"].(string); ok {
+		return &url, nil
+	}
+	return nil, fmt.Errorf("there is no base URL in the JWT claim")
 }

--- a/pkg/authentication/user_account.go
+++ b/pkg/authentication/user_account.go
@@ -4,13 +4,14 @@ import "github.com/google/uuid"
 
 // UserAccount represents a user from the database
 type UserAccount struct {
-	ID         uuid.UUID `json:"id" db:"id"`
-	Username   *string   `json:"username" db:"username"`
-	IsEUAID    bool      `json:"isEUAID" db:"is_euaid"`
-	CommonName string    `json:"commonName" db:"common_name"`
-	Locale     string    `json:"locale" db:"locale"`
-	Email      string    `json:"email" db:"email"`
-	GivenName  string    `json:"given_name" db:"given_name"`
-	FamilyName string    `json:"family_name" db:"family_name"`
-	ZoneInfo   string    `json:"zoneinfo" db:"zone_info"`
+	ID          uuid.UUID `json:"id" db:"id"`
+	Username    *string   `json:"username" db:"username"`
+	IsEUAID     bool      `json:"isEUAID" db:"is_euaid"`
+	CommonName  string    `json:"commonName" db:"common_name"`
+	Locale      string    `json:"locale" db:"locale"`
+	Email       string    `json:"email" db:"email"`
+	GivenName   string    `json:"given_name" db:"given_name"`
+	FamilyName  string    `json:"family_name" db:"family_name"`
+	ZoneInfo    string    `json:"zoneinfo" db:"zone_info"`
+	HasLoggedIn bool      `json:"hasLoggedIn" db:"has_logged_in"`
 }

--- a/pkg/cedar/cedarldap/translated_client.go
+++ b/pkg/cedar/cedarldap/translated_client.go
@@ -93,6 +93,8 @@ func (c TranslatedClient) FetchUserInfo(ctx context.Context, euaID string) (*mod
 		CommonName: person.CommonName,
 		Email:      models2.NewEmailAddress(person.Email),
 		EuaUserID:  person.UserName,
+		FirstName:  person.FirstName,
+		LastName:   person.LastName,
 	}, nil
 }
 
@@ -136,6 +138,8 @@ func (c TranslatedClient) SearchCommonNameContains(ctx context.Context, commonNa
 			CommonName: person.CommonName,
 			Email:      models2.NewEmailAddress(person.Email),
 			EuaUserID:  person.UserName,
+			FirstName:  person.FirstName,
+			LastName:   person.LastName,
 		}
 	}
 

--- a/pkg/graph/resolvers/added_as_collaborator_email_test.go
+++ b/pkg/graph/resolvers/added_as_collaborator_email_test.go
@@ -67,7 +67,7 @@ func (s *ResolverSuite) TestAddedAsCollaboratorEmail() {
 		s.testConfigs.Principal,
 		s.testConfigs.Store,
 		false,
-		userhelpers.GetUserInfoAccountInformationWrapperFunction(s.stubFetchUserInfo),
+		userhelpers.GetUserInfoAccountInfoWrapperFunc(s.stubFetchUserInfo),
 	)
 	s.NoError(err)
 	mockController.Finish()

--- a/pkg/graph/resolvers/added_as_collaborator_email_test.go
+++ b/pkg/graph/resolvers/added_as_collaborator_email_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cmsgov/mint-app/pkg/graph/model"
 	"github.com/cmsgov/mint-app/pkg/models"
 	"github.com/cmsgov/mint-app/pkg/shared/oddmail"
+	"github.com/cmsgov/mint-app/pkg/userhelpers"
 )
 
 func (s *ResolverSuite) TestAddedAsCollaboratorEmail() {
@@ -66,7 +67,7 @@ func (s *ResolverSuite) TestAddedAsCollaboratorEmail() {
 		s.testConfigs.Principal,
 		s.testConfigs.Store,
 		false,
-		s.stubFetchUserInfo,
+		userhelpers.GetUserInfoAccountInformationWrapperFunction(s.stubFetchUserInfo),
 	)
 	s.NoError(err)
 	mockController.Finish()

--- a/pkg/graph/resolvers/added_as_collaborator_email_test.go
+++ b/pkg/graph/resolvers/added_as_collaborator_email_test.go
@@ -1,6 +1,8 @@
 package resolvers
 
 import (
+	"context"
+
 	"github.com/golang/mock/gomock"
 
 	"github.com/cmsgov/mint-app/pkg/email"
@@ -56,6 +58,7 @@ func (s *ResolverSuite) TestAddedAsCollaboratorEmail() {
 		AnyTimes()
 
 	_, _, err := CreatePlanCollaborator(
+		context.Background(),
 		s.testConfigs.Logger,
 		mockEmailService,
 		mockEmailTemplateService,
@@ -63,6 +66,7 @@ func (s *ResolverSuite) TestAddedAsCollaboratorEmail() {
 		s.testConfigs.Principal,
 		s.testConfigs.Store,
 		false,
+		s.stubFetchUserInfo,
 	)
 	s.NoError(err)
 	mockController.Finish()

--- a/pkg/graph/resolvers/model_plan.go
+++ b/pkg/graph/resolvers/model_plan.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/cmsgov/mint-app/pkg/graph/model"
+	"github.com/cmsgov/mint-app/pkg/userhelpers"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -18,7 +19,7 @@ import (
 // ModelPlanCreate implements resolver logic to create a model plan
 // TODO Revist this function, as we probably want to add all of these DB entries inthe scope of a single SQL transaction
 // so that we can roll back if there is an error with any of these calls.
-func ModelPlanCreate(ctx context.Context, logger *zap.Logger, modelName string, store *storage.Store, principal authentication.Principal, getAccountInformation func(context.Context, string) (*models.UserInfo, error)) (*models.ModelPlan, error) {
+func ModelPlanCreate(ctx context.Context, logger *zap.Logger, modelName string, store *storage.Store, principal authentication.Principal, getAccountInformation userhelpers.GetAccountInfoFunc) (*models.ModelPlan, error) {
 	plan := models.NewModelPlan(principal.ID(), modelName)
 
 	err := BaseStructPreCreate(logger, plan, principal, store, false) //We don't check access here, because the user can't yet be a collaborator. Collaborators are created after ModelPlan initiation.

--- a/pkg/graph/resolvers/model_plan.go
+++ b/pkg/graph/resolvers/model_plan.go
@@ -1,6 +1,7 @@
 package resolvers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cmsgov/mint-app/pkg/graph/model"
@@ -17,8 +18,7 @@ import (
 // ModelPlanCreate implements resolver logic to create a model plan
 // TODO Revist this function, as we probably want to add all of these DB entries inthe scope of a single SQL transaction
 // so that we can roll back if there is an error with any of these calls.
-func ModelPlanCreate(logger *zap.Logger, modelName string, store *storage.Store, principal authentication.Principal) (*models.ModelPlan, error) {
-
+func ModelPlanCreate(ctx context.Context, logger *zap.Logger, modelName string, store *storage.Store, principal authentication.Principal, getAccountInformation func(context.Context, string) (*models.UserInfo, error)) (*models.ModelPlan, error) {
 	plan := models.NewModelPlan(principal.ID(), modelName)
 
 	err := BaseStructPreCreate(logger, plan, principal, store, false) //We don't check access here, because the user can't yet be a collaborator. Collaborators are created after ModelPlan initiation.
@@ -35,6 +35,7 @@ func ModelPlanCreate(logger *zap.Logger, modelName string, store *storage.Store,
 
 	// Create an initial collaborator for the plan
 	_, _, err = CreatePlanCollaborator(
+		ctx,
 		logger,
 		nil,
 		nil,
@@ -48,6 +49,7 @@ func ModelPlanCreate(logger *zap.Logger, modelName string, store *storage.Store,
 		principal,
 		store,
 		false,
+		getAccountInformation,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/graph/resolvers/model_plan_test.go
+++ b/pkg/graph/resolvers/model_plan_test.go
@@ -12,7 +12,7 @@ import (
 
 func (suite *ResolverSuite) TestModelPlanCreate() {
 	planName := "Test Plan"
-	result, err := ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, userhelpers.GetUserInfoAccountInformationWrapperFunction(suite.stubFetchUserInfo))
+	result, err := ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, userhelpers.GetUserInfoAccountInfoWrapperFunc(suite.stubFetchUserInfo))
 
 	suite.NoError(err)
 	suite.NotNil(result.ID)

--- a/pkg/graph/resolvers/model_plan_test.go
+++ b/pkg/graph/resolvers/model_plan_test.go
@@ -1,6 +1,7 @@
 package resolvers
 
 import (
+	"context"
 	"time"
 
 	"github.com/cmsgov/mint-app/pkg/authentication"
@@ -10,7 +11,7 @@ import (
 
 func (suite *ResolverSuite) TestModelPlanCreate() {
 	planName := "Test Plan"
-	result, err := ModelPlanCreate(suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal)
+	result, err := ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, suite.stubFetchUserInfo)
 
 	suite.NoError(err)
 	suite.NotNil(result.ID)

--- a/pkg/graph/resolvers/model_plan_test.go
+++ b/pkg/graph/resolvers/model_plan_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/cmsgov/mint-app/pkg/authentication"
 	"github.com/cmsgov/mint-app/pkg/graph/model"
 	"github.com/cmsgov/mint-app/pkg/models"
+	"github.com/cmsgov/mint-app/pkg/userhelpers"
 )
 
 func (suite *ResolverSuite) TestModelPlanCreate() {
 	planName := "Test Plan"
-	result, err := ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, suite.stubFetchUserInfo)
+	result, err := ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, userhelpers.GetUserInfoAccountInformationWrapperFunction(suite.stubFetchUserInfo))
 
 	suite.NoError(err)
 	suite.NotNil(result.ID)

--- a/pkg/graph/resolvers/plan_collaborator.go
+++ b/pkg/graph/resolvers/plan_collaborator.go
@@ -48,7 +48,8 @@ func CreatePlanCollaborator(
 		return nil, nil, err
 	}
 
-	_, err = userhelpers.GetOrCreateUserAccountDelegate(ctx, store, retCollaborator.EUAUserID, getAccountInformation)
+	isMacUser := false
+	_, err = userhelpers.GetOrCreateUserAccount(ctx, store, retCollaborator.EUAUserID, false, isMacUser, userhelpers.GetAccountInformationWrapperFunction(getAccountInformation))
 	if err != nil {
 		return retCollaborator, nil, err
 	}

--- a/pkg/graph/resolvers/plan_collaborator.go
+++ b/pkg/graph/resolvers/plan_collaborator.go
@@ -31,7 +31,7 @@ func CreatePlanCollaborator(
 	principal authentication.Principal,
 	store *storage.Store,
 	checkAccess bool,
-	getAccountInformation func(context.Context, string) (*models.UserInfo, error)) (*models.PlanCollaborator, *models.PlanFavorite, error) {
+	getAccountInformation userhelpers.GetAccountInfoFunc) (*models.PlanCollaborator, *models.PlanFavorite, error) {
 	collaborator := models.NewPlanCollaborator(principal.ID(), input.ModelPlanID, input.EuaUserID, input.FullName, input.TeamRole, input.Email)
 	err := BaseStructPreCreate(logger, collaborator, principal, store, checkAccess)
 	if err != nil {
@@ -49,7 +49,7 @@ func CreatePlanCollaborator(
 	}
 
 	isMacUser := false
-	_, err = userhelpers.GetOrCreateUserAccount(ctx, store, retCollaborator.EUAUserID, false, isMacUser, userhelpers.GetUserInfoAccountInformationWrapperFunction(getAccountInformation))
+	_, err = userhelpers.GetOrCreateUserAccount(ctx, store, retCollaborator.EUAUserID, false, isMacUser, getAccountInformation)
 	if err != nil {
 		return retCollaborator, nil, err
 	}

--- a/pkg/graph/resolvers/plan_collaborator.go
+++ b/pkg/graph/resolvers/plan_collaborator.go
@@ -49,7 +49,7 @@ func CreatePlanCollaborator(
 	}
 
 	isMacUser := false
-	_, err = userhelpers.GetOrCreateUserAccount(ctx, store, retCollaborator.EUAUserID, false, isMacUser, userhelpers.GetAccountInformationWrapperFunction(getAccountInformation))
+	_, err = userhelpers.GetOrCreateUserAccount(ctx, store, retCollaborator.EUAUserID, false, isMacUser, userhelpers.GetUserInfoAccountInformationWrapperFunction(getAccountInformation))
 	if err != nil {
 		return retCollaborator, nil, err
 	}

--- a/pkg/graph/resolvers/plan_collaborator.go
+++ b/pkg/graph/resolvers/plan_collaborator.go
@@ -47,7 +47,7 @@ func CreatePlanCollaborator(
 	if err != nil {
 		return nil, nil, err
 	}
-	// ctx := context.TODO() //TODO pass the actual context
+
 	_, err = userhelpers.GetOrCreateUserAccountDelegate(ctx, store, retCollaborator.EUAUserID, getAccountInformation)
 	if err != nil {
 		return retCollaborator, nil, err

--- a/pkg/graph/resolvers/plan_collaborator_test.go
+++ b/pkg/graph/resolvers/plan_collaborator_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/golang/mock/gomock"
 
 	"github.com/cmsgov/mint-app/pkg/shared/oddmail"
+	"github.com/cmsgov/mint-app/pkg/userhelpers"
 
 	"github.com/cmsgov/mint-app/pkg/authentication"
 	"github.com/cmsgov/mint-app/pkg/email"
@@ -69,7 +70,7 @@ func (suite *ResolverSuite) TestCreatePlanCollaborator() {
 		suite.testConfigs.Principal,
 		suite.testConfigs.Store,
 		false,
-		suite.stubFetchUserInfo,
+		userhelpers.GetUserInfoAccountInformationWrapperFunction(suite.stubFetchUserInfo),
 	)
 	account, uAccountErr := suite.testConfigs.Store.UserAccountGetByUsername(collaboratorInput.EuaUserID)
 	suite.NoError(uAccountErr)

--- a/pkg/graph/resolvers/plan_collaborator_test.go
+++ b/pkg/graph/resolvers/plan_collaborator_test.go
@@ -71,6 +71,9 @@ func (suite *ResolverSuite) TestCreatePlanCollaborator() {
 		false,
 		suite.stubFetchUserInfo,
 	)
+	account, uAccountErr := suite.testConfigs.Store.UserAccountGetByUsername(collaboratorInput.EuaUserID)
+	suite.NoError(uAccountErr)
+	suite.NotNil(account)
 
 	suite.NoError(err)
 	suite.EqualValues(plan.ID, collaborator.ModelPlanID)

--- a/pkg/graph/resolvers/plan_collaborator_test.go
+++ b/pkg/graph/resolvers/plan_collaborator_test.go
@@ -1,6 +1,8 @@
 package resolvers
 
 import (
+	"context"
+
 	"github.com/golang/mock/gomock"
 
 	"github.com/cmsgov/mint-app/pkg/shared/oddmail"
@@ -59,6 +61,7 @@ func (suite *ResolverSuite) TestCreatePlanCollaborator() {
 		AnyTimes()
 
 	collaborator, _, err := CreatePlanCollaborator(
+		context.Background(),
 		suite.testConfigs.Logger,
 		mockEmailService,
 		mockEmailTemplateService,
@@ -66,6 +69,7 @@ func (suite *ResolverSuite) TestCreatePlanCollaborator() {
 		suite.testConfigs.Principal,
 		suite.testConfigs.Store,
 		false,
+		suite.stubFetchUserInfo,
 	)
 
 	suite.NoError(err)

--- a/pkg/graph/resolvers/plan_collaborator_test.go
+++ b/pkg/graph/resolvers/plan_collaborator_test.go
@@ -70,7 +70,7 @@ func (suite *ResolverSuite) TestCreatePlanCollaborator() {
 		suite.testConfigs.Principal,
 		suite.testConfigs.Store,
 		false,
-		userhelpers.GetUserInfoAccountInformationWrapperFunction(suite.stubFetchUserInfo),
+		userhelpers.GetUserInfoAccountInfoWrapperFunc(suite.stubFetchUserInfo),
 	)
 	account, uAccountErr := suite.testConfigs.Store.UserAccountGetByUsername(collaboratorInput.EuaUserID)
 	suite.NoError(uAccountErr)

--- a/pkg/graph/resolvers/resolver_test.go
+++ b/pkg/graph/resolvers/resolver_test.go
@@ -1,6 +1,7 @@
 package resolvers
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -27,8 +28,18 @@ func (suite *ResolverSuite) SetupTest() {
 	assert.NoError(suite.T(), err)
 }
 
+func (suite *ResolverSuite) stubFetchUserInfo(ctx context.Context, username string) (*models.UserInfo, error) {
+	return &models.UserInfo{
+		EuaUserID:  username,
+		FirstName:  username,
+		LastName:   "Doe",
+		CommonName: username + " Doe",
+		Email:      models.NewEmailAddress(username + ".doe@local.fake"),
+	}, nil
+}
+
 func (suite *ResolverSuite) createModelPlan(planName string) *models.ModelPlan {
-	mp, err := ModelPlanCreate(suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal)
+	mp, err := ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, suite.stubFetchUserInfo)
 	suite.NoError(err)
 	return mp
 }
@@ -98,6 +109,7 @@ func (suite *ResolverSuite) createPlanCollaborator(mp *models.ModelPlan, EUAUser
 		AnyTimes()
 
 	collaborator, _, err := CreatePlanCollaborator(
+		context.Background(),
 		suite.testConfigs.Logger,
 		mockEmailService,
 		mockEmailTemplateService,
@@ -105,6 +117,7 @@ func (suite *ResolverSuite) createPlanCollaborator(mp *models.ModelPlan, EUAUser
 		suite.testConfigs.Principal,
 		suite.testConfigs.Store,
 		false,
+		suite.stubFetchUserInfo,
 	)
 	suite.NoError(err)
 	return collaborator

--- a/pkg/graph/resolvers/resolver_test.go
+++ b/pkg/graph/resolvers/resolver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cmsgov/mint-app/pkg/email"
+	"github.com/cmsgov/mint-app/pkg/userhelpers"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -39,7 +40,7 @@ func (suite *ResolverSuite) stubFetchUserInfo(ctx context.Context, username stri
 }
 
 func (suite *ResolverSuite) createModelPlan(planName string) *models.ModelPlan {
-	mp, err := ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, suite.stubFetchUserInfo)
+	mp, err := ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, userhelpers.GetUserInfoAccountInformationWrapperFunction(suite.stubFetchUserInfo))
 	suite.NoError(err)
 	return mp
 }
@@ -117,7 +118,7 @@ func (suite *ResolverSuite) createPlanCollaborator(mp *models.ModelPlan, EUAUser
 		suite.testConfigs.Principal,
 		suite.testConfigs.Store,
 		false,
-		suite.stubFetchUserInfo,
+		userhelpers.GetUserInfoAccountInformationWrapperFunction(suite.stubFetchUserInfo),
 	)
 	suite.NoError(err)
 	return collaborator

--- a/pkg/graph/resolvers/resolver_test.go
+++ b/pkg/graph/resolvers/resolver_test.go
@@ -40,7 +40,7 @@ func (suite *ResolverSuite) stubFetchUserInfo(ctx context.Context, username stri
 }
 
 func (suite *ResolverSuite) createModelPlan(planName string) *models.ModelPlan {
-	mp, err := ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, userhelpers.GetUserInfoAccountInformationWrapperFunction(suite.stubFetchUserInfo))
+	mp, err := ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, userhelpers.GetUserInfoAccountInfoWrapperFunc(suite.stubFetchUserInfo))
 	suite.NoError(err)
 	return mp
 }
@@ -118,7 +118,7 @@ func (suite *ResolverSuite) createPlanCollaborator(mp *models.ModelPlan, EUAUser
 		suite.testConfigs.Principal,
 		suite.testConfigs.Store,
 		false,
-		userhelpers.GetUserInfoAccountInformationWrapperFunction(suite.stubFetchUserInfo),
+		userhelpers.GetUserInfoAccountInfoWrapperFunc(suite.stubFetchUserInfo),
 	)
 	suite.NoError(err)
 	return collaborator

--- a/pkg/graph/resolvers/resolver_test_utilities.go
+++ b/pkg/graph/resolvers/resolver_test_utilities.go
@@ -100,7 +100,7 @@ func getTestDependencies() (storage.DBConfig, *ld.LDClient, *zap.Logger, *models
 
 func getTestPrincipal(store *storage.Store, userName string) *authentication.ApplicationPrincipal {
 
-	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false, userhelpers.GetUserInfoFromOktaLocal)
+	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false, userhelpers.GetOktaAccountInfoWrapperFunction(userhelpers.GetUserInfoFromOktaLocal))
 
 	princ := &authentication.ApplicationPrincipal{
 		Username:          userName,

--- a/pkg/graph/resolvers/resolver_test_utilities.go
+++ b/pkg/graph/resolvers/resolver_test_utilities.go
@@ -1,6 +1,7 @@
 package resolvers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cmsgov/mint-app/pkg/shared/emailTemplates"
@@ -99,7 +100,7 @@ func getTestDependencies() (storage.DBConfig, *ld.LDClient, *zap.Logger, *models
 
 func getTestPrincipal(store *storage.Store, userName string) *authentication.ApplicationPrincipal {
 
-	userAccount, _ := userhelpers.GetOrCreateUserAccount(store, userName, true, "", "", false)
+	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false)
 
 	princ := &authentication.ApplicationPrincipal{
 		Username:          userName,

--- a/pkg/graph/resolvers/resolver_test_utilities.go
+++ b/pkg/graph/resolvers/resolver_test_utilities.go
@@ -100,7 +100,7 @@ func getTestDependencies() (storage.DBConfig, *ld.LDClient, *zap.Logger, *models
 
 func getTestPrincipal(store *storage.Store, userName string) *authentication.ApplicationPrincipal {
 
-	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false)
+	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false, userhelpers.GetUserInfoFromOktaLocal)
 
 	princ := &authentication.ApplicationPrincipal{
 		Username:          userName,

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -142,7 +142,7 @@ func (r *mutationResolver) CreateModelPlan(ctx context.Context, modelName string
 	logger := appcontext.ZLogger(ctx)
 	principal := appcontext.Principal(ctx)
 
-	return resolvers.ModelPlanCreate(logger, modelName, r.store, principal)
+	return resolvers.ModelPlanCreate(ctx, logger, modelName, r.store, principal, r.service.FetchUserInfo)
 }
 
 // UpdateModelPlan is the resolver for the updateModelPlan field.
@@ -157,18 +157,9 @@ func (r *mutationResolver) UpdateModelPlan(ctx context.Context, id uuid.UUID, ch
 func (r *mutationResolver) CreatePlanCollaborator(ctx context.Context, input model.PlanCollaboratorCreateInput) (*models.PlanCollaborator, error) {
 	principal := appcontext.Principal(ctx)
 	logger := appcontext.ZLogger(ctx)
-	// response, err := r.service.FetchUserInfo(ctx,input.EuaUserID)
-
-	// userAccount, err := userhelpers.GetOrCreateUserAccount( //TODO how to handle this generically for cedar vs OKTA?
-	// 	r.store,
-	// 	input.EuaUserID,
-	// 	false,
-	// 	oktaBaseURL,
-	// 	enchanced.AuthToken,
-	// 	false, //we can't add MACs as collaboratores
-	// )
 
 	planCollaborator, _, err := resolvers.CreatePlanCollaborator(
+		ctx,
 		logger,
 		r.emailService,
 		r.emailTemplateService,
@@ -176,6 +167,7 @@ func (r *mutationResolver) CreatePlanCollaborator(ctx context.Context, input mod
 		principal,
 		r.store,
 		true,
+		r.service.FetchUserInfo,
 	)
 	return planCollaborator, err
 }

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cmsgov/mint-app/pkg/graph/model"
 	"github.com/cmsgov/mint-app/pkg/graph/resolvers"
 	"github.com/cmsgov/mint-app/pkg/models"
+	"github.com/cmsgov/mint-app/pkg/userhelpers"
 )
 
 // Fields is the resolver for the fields field.
@@ -142,7 +143,7 @@ func (r *mutationResolver) CreateModelPlan(ctx context.Context, modelName string
 	logger := appcontext.ZLogger(ctx)
 	principal := appcontext.Principal(ctx)
 
-	return resolvers.ModelPlanCreate(ctx, logger, modelName, r.store, principal, r.service.FetchUserInfo)
+	return resolvers.ModelPlanCreate(ctx, logger, modelName, r.store, principal, userhelpers.GetUserInfoAccountInformationWrapperFunction(r.service.FetchUserInfo))
 }
 
 // UpdateModelPlan is the resolver for the updateModelPlan field.
@@ -167,7 +168,7 @@ func (r *mutationResolver) CreatePlanCollaborator(ctx context.Context, input mod
 		principal,
 		r.store,
 		true,
-		r.service.FetchUserInfo,
+		userhelpers.GetUserInfoAccountInformationWrapperFunction(r.service.FetchUserInfo),
 	)
 	return planCollaborator, err
 }

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -143,7 +143,7 @@ func (r *mutationResolver) CreateModelPlan(ctx context.Context, modelName string
 	logger := appcontext.ZLogger(ctx)
 	principal := appcontext.Principal(ctx)
 
-	return resolvers.ModelPlanCreate(ctx, logger, modelName, r.store, principal, userhelpers.GetUserInfoAccountInformationWrapperFunction(r.service.FetchUserInfo))
+	return resolvers.ModelPlanCreate(ctx, logger, modelName, r.store, principal, userhelpers.GetUserInfoAccountInfoWrapperFunc(r.service.FetchUserInfo))
 }
 
 // UpdateModelPlan is the resolver for the updateModelPlan field.
@@ -168,7 +168,7 @@ func (r *mutationResolver) CreatePlanCollaborator(ctx context.Context, input mod
 		principal,
 		r.store,
 		true,
-		userhelpers.GetUserInfoAccountInformationWrapperFunction(r.service.FetchUserInfo),
+		userhelpers.GetUserInfoAccountInfoWrapperFunc(r.service.FetchUserInfo),
 	)
 	return planCollaborator, err
 }

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -157,6 +157,16 @@ func (r *mutationResolver) UpdateModelPlan(ctx context.Context, id uuid.UUID, ch
 func (r *mutationResolver) CreatePlanCollaborator(ctx context.Context, input model.PlanCollaboratorCreateInput) (*models.PlanCollaborator, error) {
 	principal := appcontext.Principal(ctx)
 	logger := appcontext.ZLogger(ctx)
+	// response, err := r.service.FetchUserInfo(ctx,input.EuaUserID)
+
+	// userAccount, err := userhelpers.GetOrCreateUserAccount( //TODO how to handle this generically for cedar vs OKTA?
+	// 	r.store,
+	// 	input.EuaUserID,
+	// 	false,
+	// 	oktaBaseURL,
+	// 	enchanced.AuthToken,
+	// 	false, //we can't add MACs as collaboratores
+	// )
 
 	planCollaborator, _, err := resolvers.CreatePlanCollaborator(
 		logger,

--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -81,7 +81,7 @@ func devUserContext(ctx context.Context, authHeader string, store *storage.Store
 		JobCodeMAC:        swag.ContainsStrings(config.JobCodes, "MINT MAC Users"),
 	}
 
-	userAccount, err := userhelpers.GetOrCreateUserAccount(ctx, store, princ.ID(), true, princ.JobCodeMAC, userhelpers.GetUserInfoFromOktaLocal)
+	userAccount, err := userhelpers.GetOrCreateUserAccount(ctx, store, princ.ID(), true, princ.JobCodeMAC, userhelpers.GetOktaAccountInfoWrapperFunction(userhelpers.GetUserInfoFromOktaLocal))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -81,7 +81,7 @@ func devUserContext(ctx context.Context, authHeader string, store *storage.Store
 		JobCodeMAC:        swag.ContainsStrings(config.JobCodes, "MINT MAC Users"),
 	}
 
-	userAccount, err := userhelpers.GetOrCreateUserAccount(ctx, store, princ.ID(), true, princ.JobCodeMAC)
+	userAccount, err := userhelpers.GetOrCreateUserAccount(ctx, store, princ.ID(), true, princ.JobCodeMAC, userhelpers.GetUserInfoFromOktaLocal)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -81,7 +81,7 @@ func devUserContext(ctx context.Context, authHeader string, store *storage.Store
 		JobCodeMAC:        swag.ContainsStrings(config.JobCodes, "MINT MAC Users"),
 	}
 
-	userAccount, err := userhelpers.GetOrCreateUserAccount(store, princ.ID(), true, "", "", princ.JobCodeMAC)
+	userAccount, err := userhelpers.GetOrCreateUserAccount(ctx, store, princ.ID(), true, princ.JobCodeMAC)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/local/cedar_ldap.go
+++ b/pkg/local/cedar_ldap.go
@@ -34,6 +34,8 @@ func (c CedarLdapClient) FetchUserInfo(_ context.Context, euaID string) (*models
 	c.logger.Info("Mock FetchUserInfo from LDAP", zap.String("euaID", euaID))
 	return &models.UserInfo{
 		CommonName: fmt.Sprintf("%s Doe", strings.ToLower(euaID)),
+		FirstName:  euaID,
+		LastName:   "Doe",
 		Email:      models.NewEmailAddress(fmt.Sprintf("%s@local.fake", euaID)),
 		EuaUserID:  euaID,
 	}, nil

--- a/pkg/models/user_info.go
+++ b/pkg/models/user_info.go
@@ -5,4 +5,6 @@ type UserInfo struct {
 	CommonName string
 	Email      EmailAddress
 	EuaUserID  string
+	FirstName  string
+	LastName   string
 }

--- a/pkg/okta/authentication_middleware.go
+++ b/pkg/okta/authentication_middleware.go
@@ -163,7 +163,7 @@ func (f MiddlewareFactory) newPrincipal(ctx context.Context) (*authentication.Ap
 		euaID,
 		true,
 		jcMAC,
-		userhelpers.GetUserInfoFromOkta,
+		userhelpers.GetOktaAccountInfoWrapperFunction(userhelpers.GetOktaAccountInfo),
 	) //TODO, do we need to do anything with the user? Should we pass the id around?
 	if err != nil {
 		return nil, err

--- a/pkg/okta/authentication_middleware_test.go
+++ b/pkg/okta/authentication_middleware_test.go
@@ -94,7 +94,7 @@ func (s *AuthenticationMiddlewareTestSuite) buildMiddleware(verify func(jwt stri
 
 func (s *AuthenticationMiddlewareTestSuite) TestAuthorizeMiddleware() {
 
-	_, err := userhelpers.GetOrCreateUserAccount(context.Background(), s.store, "EASI", true, false, userhelpers.GetUserInfoFromOktaLocal)
+	_, err := userhelpers.GetOrCreateUserAccount(context.Background(), s.store, "EASI", true, false, userhelpers.GetOktaAccountInfoWrapperFunction(userhelpers.GetUserInfoFromOktaLocal))
 
 	s.NoError(err)
 

--- a/pkg/okta/authentication_middleware_test.go
+++ b/pkg/okta/authentication_middleware_test.go
@@ -1,6 +1,7 @@
 package okta
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -93,7 +94,7 @@ func (s *AuthenticationMiddlewareTestSuite) buildMiddleware(verify func(jwt stri
 
 func (s *AuthenticationMiddlewareTestSuite) TestAuthorizeMiddleware() {
 
-	_, err := userhelpers.GetOrCreateUserAccount(s.store, "EASI", true, "", "", false)
+	_, err := userhelpers.GetOrCreateUserAccount(context.Background(), s.store, "EASI", true, false)
 
 	s.NoError(err)
 

--- a/pkg/okta/authentication_middleware_test.go
+++ b/pkg/okta/authentication_middleware_test.go
@@ -94,7 +94,7 @@ func (s *AuthenticationMiddlewareTestSuite) buildMiddleware(verify func(jwt stri
 
 func (s *AuthenticationMiddlewareTestSuite) TestAuthorizeMiddleware() {
 
-	_, err := userhelpers.GetOrCreateUserAccount(context.Background(), s.store, "EASI", true, false)
+	_, err := userhelpers.GetOrCreateUserAccount(context.Background(), s.store, "EASI", true, false, userhelpers.GetUserInfoFromOktaLocal)
 
 	s.NoError(err)
 

--- a/pkg/storage/SQL/user_account/get_by_username.sql
+++ b/pkg/storage/SQL/user_account/get_by_username.sql
@@ -7,6 +7,7 @@ SELECT
     email,
     given_name,
     family_name,
-    zone_info
+    zone_info,
+    has_logged_in
 
 FROM user_account WHERE username = :username

--- a/pkg/storage/SQL/user_account/insert_by_username.sql
+++ b/pkg/storage/SQL/user_account/insert_by_username.sql
@@ -8,7 +8,8 @@ INSERT INTO user_account
     email,
     given_name,
     family_name,
-    zone_info
+    zone_info,
+    has_logged_in
 )
 VALUES (
     :id,
@@ -19,7 +20,8 @@ VALUES (
     :email,
     :given_name,
     :family_name,
-    :zone_info
+    :zone_info,
+    :has_logged_in
 )
 RETURNING
 id,
@@ -30,4 +32,5 @@ locale,
 email,
 given_name,
 family_name,
-zone_info;
+zone_info,
+has_logged_in;

--- a/pkg/storage/SQL/user_account/update_by_username.sql
+++ b/pkg/storage/SQL/user_account/update_by_username.sql
@@ -1,6 +1,6 @@
 UPDATE user_account
 SET
-    commonName = :commonName,
+    common_name = :common_name,
     locale = :locale,
     email = :email,
     given_name = :given_name,
@@ -9,3 +9,14 @@ SET
     has_logged_in = :has_logged_in
 
 WHERE username = :username
+RETURNING
+id,
+username,
+is_euaid,
+common_name,
+locale,
+email,
+given_name,
+family_name,
+zone_info,
+has_logged_in;

--- a/pkg/storage/SQL/user_account/update_by_username.sql
+++ b/pkg/storage/SQL/user_account/update_by_username.sql
@@ -5,6 +5,7 @@ SET
     email = :email,
     given_name = :given_name,
     family_name = :family_name,
-    zone_info = :zone_info
+    zone_info = :zone_info,
+    has_logged_in = :has_logged_in
 
 WHERE username = :username

--- a/pkg/storage/user_accountStore.go
+++ b/pkg/storage/user_accountStore.go
@@ -14,6 +14,9 @@ var userAccountGetByUsername string
 //go:embed SQL/user_account/insert_by_username.sql
 var userAccountInsertByUsername string
 
+//go:embed SQL/user_account/update_by_username.sql
+var userAccountUpdateByUsername string
+
 // UserAccountGetByUsername reads information about a model plan's clearance
 func (s *Store) UserAccountGetByUsername(username string) (*authentication.UserAccount, error) {
 	user := &authentication.UserAccount{}
@@ -59,5 +62,26 @@ func (s *Store) UserAccountInsertByUsername(userAccount *authentication.UserAcco
 	}
 
 	return user, nil
-	// TODO work in progress
+}
+
+// UserAccountUpdateByUserName updates an existing user account for a given username
+func (s *Store) UserAccountUpdateByUserName(userAccount *authentication.UserAccount) (*authentication.UserAccount, error) {
+	user := &authentication.UserAccount{}
+
+	if userAccount.ID == uuid.Nil {
+		userAccount.ID = uuid.New()
+	}
+
+	statement, err := s.db.PrepareNamed(userAccountUpdateByUsername)
+	if err != nil {
+		return nil, err
+	}
+
+	err = statement.Get(user, userAccount)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
 }

--- a/pkg/userhelpers/user_account_utils.go
+++ b/pkg/userhelpers/user_account_utils.go
@@ -98,7 +98,7 @@ func GetAccountInformationWrapper(ctx context.Context, username string, getAccou
 }
 
 // GetUserInfoFromOkta uses the Okta endpoint to retun OktaAccountInfo
-func GetUserInfoFromOkta(ctx context.Context, username string) (*OktaAccountInfo, error) {
+func GetUserInfoFromOkta(ctx context.Context, _ string) (*OktaAccountInfo, error) {
 	userEndpoint := "/v1/userinfo" //TODO: it would be better to actually get the endpoint from the token, but not currently given to the front end
 	authPrefix := "Bearer "
 	enhancedJWT := appcontext.EnhancedJWT(ctx)

--- a/pkg/userhelpers/user_account_utils.go
+++ b/pkg/userhelpers/user_account_utils.go
@@ -32,9 +32,15 @@ type AccountInfo OktaAccountInfo
 // GetAccountInfoFunc represents a type of function which takes a context and username and returns AccountInfo
 type GetAccountInfoFunc func(ctx context.Context, username string) (*AccountInfo, error)
 
+// GetOktaAccountInfoFunc represents a type of function which takes a context and username and returns OktaAccountInfo
+type GetOktaAccountInfoFunc func(ctx context.Context, username string) (*OktaAccountInfo, error)
+
+// GetUserInfoFunc represents a type of function which takes a context and username and returns UserInfo
+type GetUserInfoFunc func(ctx context.Context, username string) (*models.UserInfo, error)
+
 // GetOrCreateUserAccount will return an account if it exists, or create and return a new one if not
 func GetOrCreateUserAccount(ctx context.Context, store *storage.Store, username string, hasLoggedIn bool,
-	isMacUser bool, getAccountInformation func(ctx context.Context, username string) (*AccountInfo, error)) (*authentication.UserAccount, error) {
+	isMacUser bool, getAccountInformation GetAccountInfoFunc) (*authentication.UserAccount, error) {
 	userAccount, accErr := store.UserAccountGetByUsername(username)
 	if accErr != nil {
 		return nil, errors.New("failed to get user information from the database")
@@ -76,7 +82,7 @@ func GetOrCreateUserAccount(ctx context.Context, store *storage.Store, username 
 }
 
 // GetUserInfoAccountInformationWrapperFunction returns a function that returns *AccountInfo with the input of a function that returns UserInfo
-func GetUserInfoAccountInformationWrapperFunction(getAccountInformation func(ctx context.Context, username string) (*models.UserInfo, error)) func(ctx context.Context, username string) (*AccountInfo, error) {
+func GetUserInfoAccountInformationWrapperFunction(getAccountInformation GetUserInfoFunc) GetAccountInfoFunc {
 
 	wrapperFunc := func(ctx context.Context, username string) (*AccountInfo, error) {
 		return GetUserInfoAccountInformationWrapper(ctx, username, getAccountInformation)
@@ -85,7 +91,7 @@ func GetUserInfoAccountInformationWrapperFunction(getAccountInformation func(ctx
 }
 
 // GetUserInfoAccountInformationWrapper this function appends models.UserInfo with needed account info fields as UNKNOWN
-func GetUserInfoAccountInformationWrapper(ctx context.Context, username string, getAccountInformation func(context.Context, string) (*models.UserInfo, error)) (*AccountInfo, error) {
+func GetUserInfoAccountInformationWrapper(ctx context.Context, username string, getAccountInformation GetUserInfoFunc) (*AccountInfo, error) {
 	userinfo, err := getAccountInformation(ctx, username)
 	if err != nil {
 		return nil, err
@@ -104,7 +110,7 @@ func GetUserInfoAccountInformationWrapper(ctx context.Context, username string, 
 }
 
 // GetOktaAccountInfoWrapperFunction returns a function that returns *AccountInfo with the input of a function that returns OktaAccountInfo
-func GetOktaAccountInfoWrapperFunction(getAccountInformation func(ctx context.Context, username string) (*OktaAccountInfo, error)) func(ctx context.Context, username string) (*AccountInfo, error) {
+func GetOktaAccountInfoWrapperFunction(getAccountInformation GetOktaAccountInfoFunc) GetAccountInfoFunc {
 	wrapperFunc := func(ctx context.Context, username string) (*AccountInfo, error) {
 		return GetOktaAccountInfoWrapper(ctx, username, getAccountInformation)
 	}
@@ -112,7 +118,7 @@ func GetOktaAccountInfoWrapperFunction(getAccountInformation func(ctx context.Co
 }
 
 // GetOktaAccountInfoWrapper converts a returns OktaAccountInformation converted to AccountInformation
-func GetOktaAccountInfoWrapper(ctx context.Context, username string, getAccountInformation func(context.Context, string) (*OktaAccountInfo, error)) (*AccountInfo, error) {
+func GetOktaAccountInfoWrapper(ctx context.Context, username string, getAccountInformation GetOktaAccountInfoFunc) (*AccountInfo, error) {
 	userinfo, err := getAccountInformation(ctx, username)
 	if err != nil {
 		return nil, err

--- a/pkg/userhelpers/user_account_utils.go
+++ b/pkg/userhelpers/user_account_utils.go
@@ -81,18 +81,18 @@ func GetOrCreateUserAccount(ctx context.Context, store *storage.Store, username 
 	return updatedAccount, nil
 }
 
-// GetUserInfoAccountInformationWrapperFunction returns a function that returns *AccountInfo with the input of a function that returns UserInfo
-func GetUserInfoAccountInformationWrapperFunction(getAccountInformation GetUserInfoFunc) GetAccountInfoFunc {
+// GetUserInfoAccountInfoWrapperFunc returns a function that returns *AccountInfo with the input of a function that returns UserInfo
+func GetUserInfoAccountInfoWrapperFunc(getUserInfo GetUserInfoFunc) GetAccountInfoFunc {
 
 	wrapperFunc := func(ctx context.Context, username string) (*AccountInfo, error) {
-		return GetUserInfoAccountInformationWrapper(ctx, username, getAccountInformation)
+		return GetUserInfoAccountInfoWrapper(ctx, username, getUserInfo)
 	}
 	return wrapperFunc
 }
 
-// GetUserInfoAccountInformationWrapper this function appends models.UserInfo with needed account info fields as UNKNOWN
-func GetUserInfoAccountInformationWrapper(ctx context.Context, username string, getAccountInformation GetUserInfoFunc) (*AccountInfo, error) {
-	userinfo, err := getAccountInformation(ctx, username)
+// GetUserInfoAccountInfoWrapper this function appends models.UserInfo with needed account info fields as UNKNOWN
+func GetUserInfoAccountInfoWrapper(ctx context.Context, username string, getUserInfo GetUserInfoFunc) (*AccountInfo, error) {
+	userinfo, err := getUserInfo(ctx, username)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -46,7 +46,7 @@ func (suite *WorkerSuite) SetupTest() {
 }
 
 func (suite *WorkerSuite) createModelPlan(planName string) *models.ModelPlan {
-	mp, err := resolvers.ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, userhelpers.GetUserInfoAccountInformationWrapperFunction(suite.stubFetchUserInfo))
+	mp, err := resolvers.ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, userhelpers.GetUserInfoAccountInfoWrapperFunc(suite.stubFetchUserInfo))
 	suite.NoError(err)
 	return mp
 }
@@ -79,7 +79,7 @@ func (suite *WorkerSuite) createPlanCollaborator(mp *models.ModelPlan, EUAUserID
 		suite.testConfigs.Principal,
 		suite.testConfigs.Store,
 		false,
-		userhelpers.GetUserInfoAccountInformationWrapperFunction(suite.stubFetchUserInfo),
+		userhelpers.GetUserInfoAccountInfoWrapperFunc(suite.stubFetchUserInfo),
 	)
 	suite.NoError(err)
 	return collaborator

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cmsgov/mint-app/pkg/graph/model"
 	"github.com/cmsgov/mint-app/pkg/graph/resolvers"
 	"github.com/cmsgov/mint-app/pkg/models"
+	"github.com/cmsgov/mint-app/pkg/userhelpers"
 )
 
 // WorkerSuite is the testify suite for the worker package
@@ -45,7 +46,7 @@ func (suite *WorkerSuite) SetupTest() {
 }
 
 func (suite *WorkerSuite) createModelPlan(planName string) *models.ModelPlan {
-	mp, err := resolvers.ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, suite.stubFetchUserInfo)
+	mp, err := resolvers.ModelPlanCreate(context.Background(), suite.testConfigs.Logger, planName, suite.testConfigs.Store, suite.testConfigs.Principal, userhelpers.GetUserInfoAccountInformationWrapperFunction(suite.stubFetchUserInfo))
 	suite.NoError(err)
 	return mp
 }
@@ -78,7 +79,7 @@ func (suite *WorkerSuite) createPlanCollaborator(mp *models.ModelPlan, EUAUserID
 		suite.testConfigs.Principal,
 		suite.testConfigs.Store,
 		false,
-		suite.stubFetchUserInfo,
+		userhelpers.GetUserInfoAccountInformationWrapperFunction(suite.stubFetchUserInfo),
 	)
 	suite.NoError(err)
 	return collaborator

--- a/pkg/worker/worker_test_utilities.go
+++ b/pkg/worker/worker_test_utilities.go
@@ -101,7 +101,7 @@ func getTestDependencies() (storage.DBConfig, *ld.LDClient, *zap.Logger, *models
 
 func getTestPrincipal(store *storage.Store, userName string) *authentication.ApplicationPrincipal {
 
-	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false, userhelpers.GetUserInfoFromOktaLocal)
+	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false, userhelpers.GetOktaAccountInfoWrapperFunction(userhelpers.GetUserInfoFromOktaLocal))
 
 	princ := &authentication.ApplicationPrincipal{
 		Username:          userName,

--- a/pkg/worker/worker_test_utilities.go
+++ b/pkg/worker/worker_test_utilities.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"context"
+
 	"github.com/cmsgov/mint-app/pkg/email"
 	"github.com/cmsgov/mint-app/pkg/userhelpers"
 
@@ -99,7 +101,7 @@ func getTestDependencies() (storage.DBConfig, *ld.LDClient, *zap.Logger, *models
 
 func getTestPrincipal(store *storage.Store, userName string) *authentication.ApplicationPrincipal {
 
-	userAccount, _ := userhelpers.GetOrCreateUserAccount(store, userName, true, "", "", false)
+	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false)
 
 	princ := &authentication.ApplicationPrincipal{
 		Username:          userName,

--- a/pkg/worker/worker_test_utilities.go
+++ b/pkg/worker/worker_test_utilities.go
@@ -101,7 +101,7 @@ func getTestDependencies() (storage.DBConfig, *ld.LDClient, *zap.Logger, *models
 
 func getTestPrincipal(store *storage.Store, userName string) *authentication.ApplicationPrincipal {
 
-	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false)
+	userAccount, _ := userhelpers.GetOrCreateUserAccount(context.Background(), store, userName, true, false, userhelpers.GetUserInfoFromOktaLocal)
 
 	princ := &authentication.ApplicationPrincipal{
 		Username:          userName,


### PR DESCRIPTION
# EASI-2550

## Changes and Description

- Add functionality to add a user account using CEDAR information when a collaborator is added
- Add hasLoggedIn bool to user account
   - If user hasn't logged in, update the information with OKTA instead at the time of login.
- Decorate the context with the JWT, so we we can use that for reaching OKTA endpoints 


## How to test this change
Note, this change should function for both local and CEDAR. It is worth while to check with both
To check Cedar locally, you need to comment out line 127-129 in routes and connect to the vpn
``` go
	if s.environment.Local() || s.environment.Testing() {
		cedarLDAPClient = local.NewCedarLdapClient(s.logger)
	}
```

1. Create model plan.
2. Add a collaborator to the MODEL PLAN
    a. Verify that a user account was added for this collaborator, and that hasLoggedIn == false
3. Log in as that user. (Or send any request in postman)
    a. Verify that the user account has been updated to hasLoggedIn == true, and any missing information is filled in. 
     
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [x] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
