### PR TITLE
[NOREF] Re-enable IMPL deployments. Make dev/test deploy concurrently

### DIFF
--- a/.github/workflows/deploy_pipeline.yml
+++ b/.github/workflows/deploy_pipeline.yml
@@ -42,7 +42,7 @@ jobs:
       ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
 
   deploy_test:
-    needs: deploy_dev
+    needs: run_tests
     uses: ./.github/workflows/deploy_to_environment.yml
     with:
       env: test
@@ -56,7 +56,7 @@ jobs:
       ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
 
   deploy_impl:
-    needs: deploy_test
+    needs: [deploy_dev, deploy_test]
     uses: ./.github/workflows/deploy_to_environment.yml
     with:
       env: impl
@@ -70,8 +70,7 @@ jobs:
       ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
 
   deploy_prod:
-    # needs: deploy_impl
-    needs: deploy_test # TODO Reset to needing `deploy_impl` after pen-testing is complete! Right now, we'll base it off `deploy_test`
+    needs: deploy_impl
     uses: ./.github/workflows/deploy_to_environment.yml
     with:
       env: prod


### PR DESCRIPTION
# NOREF

## Changes and Description

- Re-enable IMPL deploys, now that pen-testing is complete in the IMPL environment
- Make `dev` and `test` environments deploy concurrently after `run_tests`. 
  - In the case of pushing a bug to `main`, this _does_ mean we will push it to both `dev` and `test`, but since `dev` is really meant to be an internal dev-only environment, and `test` is where most feature validation will happen, it feels like a good way to save some time on the deploy process.

## How to test this change

- There's not a great way to test GitHub actions locally (except for something like [act](https://github.com/nektos/act)), so it's recommended to just review the changes made to this file and ensure they're doing what we expect!
- Also, if folks disagree or have questions about making dev/test deploy at the same time, I'm happy to change this! It's not set in stone 😄 

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
