### PR TITLE
[EASI-2521] Discussion and Discussion Reply return user info full stack

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -82,15 +82,17 @@ type ComplexityRoot struct {
 	}
 
 	DiscussionReply struct {
-		Content      func(childComplexity int) int
-		CreatedBy    func(childComplexity int) int
-		CreatedDts   func(childComplexity int) int
-		DiscussionID func(childComplexity int) int
-		ID           func(childComplexity int) int
-		IsAssessment func(childComplexity int) int
-		ModifiedBy   func(childComplexity int) int
-		ModifiedDts  func(childComplexity int) int
-		Resolution   func(childComplexity int) int
+		Content            func(childComplexity int) int
+		CreatedBy          func(childComplexity int) int
+		CreatedByUserInfo  func(childComplexity int) int
+		CreatedDts         func(childComplexity int) int
+		DiscussionID       func(childComplexity int) int
+		ID                 func(childComplexity int) int
+		IsAssessment       func(childComplexity int) int
+		ModifiedBy         func(childComplexity int) int
+		ModifiedByUserInfo func(childComplexity int) int
+		ModifiedDts        func(childComplexity int) int
+		Resolution         func(childComplexity int) int
 	}
 
 	ExistingModel struct {
@@ -323,16 +325,18 @@ type ComplexityRoot struct {
 	}
 
 	PlanDiscussion struct {
-		Content      func(childComplexity int) int
-		CreatedBy    func(childComplexity int) int
-		CreatedDts   func(childComplexity int) int
-		ID           func(childComplexity int) int
-		IsAssessment func(childComplexity int) int
-		ModelPlanID  func(childComplexity int) int
-		ModifiedBy   func(childComplexity int) int
-		ModifiedDts  func(childComplexity int) int
-		Replies      func(childComplexity int) int
-		Status       func(childComplexity int) int
+		Content            func(childComplexity int) int
+		CreatedBy          func(childComplexity int) int
+		CreatedByUserInfo  func(childComplexity int) int
+		CreatedDts         func(childComplexity int) int
+		ID                 func(childComplexity int) int
+		IsAssessment       func(childComplexity int) int
+		ModelPlanID        func(childComplexity int) int
+		ModifiedBy         func(childComplexity int) int
+		ModifiedByUserInfo func(childComplexity int) int
+		ModifiedDts        func(childComplexity int) int
+		Replies            func(childComplexity int) int
+		Status             func(childComplexity int) int
 	}
 
 	PlanDocument struct {
@@ -1176,6 +1180,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.DiscussionReply.CreatedBy(childComplexity), true
 
+	case "DiscussionReply.createdByUserInfo":
+		if e.complexity.DiscussionReply.CreatedByUserInfo == nil {
+			break
+		}
+
+		return e.complexity.DiscussionReply.CreatedByUserInfo(childComplexity), true
+
 	case "DiscussionReply.createdDts":
 		if e.complexity.DiscussionReply.CreatedDts == nil {
 			break
@@ -1210,6 +1221,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.DiscussionReply.ModifiedBy(childComplexity), true
+
+	case "DiscussionReply.modifiedByUserInfo":
+		if e.complexity.DiscussionReply.ModifiedByUserInfo == nil {
+			break
+		}
+
+		return e.complexity.DiscussionReply.ModifiedByUserInfo(childComplexity), true
 
 	case "DiscussionReply.modifiedDts":
 		if e.complexity.DiscussionReply.ModifiedDts == nil {
@@ -2801,6 +2819,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PlanDiscussion.CreatedBy(childComplexity), true
 
+	case "PlanDiscussion.createdByUserInfo":
+		if e.complexity.PlanDiscussion.CreatedByUserInfo == nil {
+			break
+		}
+
+		return e.complexity.PlanDiscussion.CreatedByUserInfo(childComplexity), true
+
 	case "PlanDiscussion.createdDts":
 		if e.complexity.PlanDiscussion.CreatedDts == nil {
 			break
@@ -2835,6 +2860,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PlanDiscussion.ModifiedBy(childComplexity), true
+
+	case "PlanDiscussion.modifiedByUserInfo":
+		if e.complexity.PlanDiscussion.ModifiedByUserInfo == nil {
+			break
+		}
+
+		return e.complexity.PlanDiscussion.ModifiedByUserInfo(childComplexity), true
 
 	case "PlanDiscussion.modifiedDts":
 		if e.complexity.PlanDiscussion.ModifiedDts == nil {
@@ -6570,6 +6602,8 @@ type PlanDiscussion  {
 	status: DiscussionStatus!
   replies: [DiscussionReply!]!
   isAssessment: Boolean!
+  createdByUserInfo: UserInfo!
+  modifiedByUserInfo: UserInfo
 
   createdBy: String!
   createdDts: Time!
@@ -6604,6 +6638,8 @@ type DiscussionReply  {
 	content: String
 	resolution: Boolean
   isAssessment: Boolean!
+  createdByUserInfo: UserInfo!
+  modifiedByUserInfo: UserInfo
 
 	createdBy: String!
 	createdDts: Time!
@@ -10306,6 +10342,107 @@ func (ec *executionContext) fieldContext_DiscussionReply_isAssessment(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _DiscussionReply_createdByUserInfo(ctx context.Context, field graphql.CollectedField, obj *models.DiscussionReply) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DiscussionReply_createdByUserInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedByUserInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(models.UserInfo)
+	fc.Result = res
+	return ec.marshalNUserInfo2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DiscussionReply_createdByUserInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DiscussionReply",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "commonName":
+				return ec.fieldContext_UserInfo_commonName(ctx, field)
+			case "email":
+				return ec.fieldContext_UserInfo_email(ctx, field)
+			case "euaUserId":
+				return ec.fieldContext_UserInfo_euaUserId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UserInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DiscussionReply_modifiedByUserInfo(ctx context.Context, field graphql.CollectedField, obj *models.DiscussionReply) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DiscussionReply_modifiedByUserInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ModifiedByUserInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.UserInfo)
+	fc.Result = res
+	return ec.marshalOUserInfo2ᚖgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DiscussionReply_modifiedByUserInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DiscussionReply",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "commonName":
+				return ec.fieldContext_UserInfo_commonName(ctx, field)
+			case "email":
+				return ec.fieldContext_UserInfo_email(ctx, field)
+			case "euaUserId":
+				return ec.fieldContext_UserInfo_euaUserId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UserInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _DiscussionReply_createdBy(ctx context.Context, field graphql.CollectedField, obj *models.DiscussionReply) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_DiscussionReply_createdBy(ctx, field)
 	if err != nil {
@@ -12657,6 +12794,10 @@ func (ec *executionContext) fieldContext_ModelPlan_discussions(ctx context.Conte
 				return ec.fieldContext_PlanDiscussion_replies(ctx, field)
 			case "isAssessment":
 				return ec.fieldContext_PlanDiscussion_isAssessment(ctx, field)
+			case "createdByUserInfo":
+				return ec.fieldContext_PlanDiscussion_createdByUserInfo(ctx, field)
+			case "modifiedByUserInfo":
+				return ec.fieldContext_PlanDiscussion_modifiedByUserInfo(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_PlanDiscussion_createdBy(ctx, field)
 			case "createdDts":
@@ -15529,6 +15670,10 @@ func (ec *executionContext) fieldContext_Mutation_createPlanDiscussion(ctx conte
 				return ec.fieldContext_PlanDiscussion_replies(ctx, field)
 			case "isAssessment":
 				return ec.fieldContext_PlanDiscussion_isAssessment(ctx, field)
+			case "createdByUserInfo":
+				return ec.fieldContext_PlanDiscussion_createdByUserInfo(ctx, field)
+			case "modifiedByUserInfo":
+				return ec.fieldContext_PlanDiscussion_modifiedByUserInfo(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_PlanDiscussion_createdBy(ctx, field)
 			case "createdDts":
@@ -15630,6 +15775,10 @@ func (ec *executionContext) fieldContext_Mutation_updatePlanDiscussion(ctx conte
 				return ec.fieldContext_PlanDiscussion_replies(ctx, field)
 			case "isAssessment":
 				return ec.fieldContext_PlanDiscussion_isAssessment(ctx, field)
+			case "createdByUserInfo":
+				return ec.fieldContext_PlanDiscussion_createdByUserInfo(ctx, field)
+			case "modifiedByUserInfo":
+				return ec.fieldContext_PlanDiscussion_modifiedByUserInfo(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_PlanDiscussion_createdBy(ctx, field)
 			case "createdDts":
@@ -15731,6 +15880,10 @@ func (ec *executionContext) fieldContext_Mutation_deletePlanDiscussion(ctx conte
 				return ec.fieldContext_PlanDiscussion_replies(ctx, field)
 			case "isAssessment":
 				return ec.fieldContext_PlanDiscussion_isAssessment(ctx, field)
+			case "createdByUserInfo":
+				return ec.fieldContext_PlanDiscussion_createdByUserInfo(ctx, field)
+			case "modifiedByUserInfo":
+				return ec.fieldContext_PlanDiscussion_modifiedByUserInfo(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_PlanDiscussion_createdBy(ctx, field)
 			case "createdDts":
@@ -15830,6 +15983,10 @@ func (ec *executionContext) fieldContext_Mutation_createDiscussionReply(ctx cont
 				return ec.fieldContext_DiscussionReply_resolution(ctx, field)
 			case "isAssessment":
 				return ec.fieldContext_DiscussionReply_isAssessment(ctx, field)
+			case "createdByUserInfo":
+				return ec.fieldContext_DiscussionReply_createdByUserInfo(ctx, field)
+			case "modifiedByUserInfo":
+				return ec.fieldContext_DiscussionReply_modifiedByUserInfo(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_DiscussionReply_createdBy(ctx, field)
 			case "createdDts":
@@ -15929,6 +16086,10 @@ func (ec *executionContext) fieldContext_Mutation_updateDiscussionReply(ctx cont
 				return ec.fieldContext_DiscussionReply_resolution(ctx, field)
 			case "isAssessment":
 				return ec.fieldContext_DiscussionReply_isAssessment(ctx, field)
+			case "createdByUserInfo":
+				return ec.fieldContext_DiscussionReply_createdByUserInfo(ctx, field)
+			case "modifiedByUserInfo":
+				return ec.fieldContext_DiscussionReply_modifiedByUserInfo(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_DiscussionReply_createdBy(ctx, field)
 			case "createdDts":
@@ -16028,6 +16189,10 @@ func (ec *executionContext) fieldContext_Mutation_deleteDiscussionReply(ctx cont
 				return ec.fieldContext_DiscussionReply_resolution(ctx, field)
 			case "isAssessment":
 				return ec.fieldContext_DiscussionReply_isAssessment(ctx, field)
+			case "createdByUserInfo":
+				return ec.fieldContext_DiscussionReply_createdByUserInfo(ctx, field)
+			case "modifiedByUserInfo":
+				return ec.fieldContext_DiscussionReply_modifiedByUserInfo(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_DiscussionReply_createdBy(ctx, field)
 			case "createdDts":
@@ -22973,6 +23138,10 @@ func (ec *executionContext) fieldContext_PlanDiscussion_replies(ctx context.Cont
 				return ec.fieldContext_DiscussionReply_resolution(ctx, field)
 			case "isAssessment":
 				return ec.fieldContext_DiscussionReply_isAssessment(ctx, field)
+			case "createdByUserInfo":
+				return ec.fieldContext_DiscussionReply_createdByUserInfo(ctx, field)
+			case "modifiedByUserInfo":
+				return ec.fieldContext_DiscussionReply_modifiedByUserInfo(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_DiscussionReply_createdBy(ctx, field)
 			case "createdDts":
@@ -23027,6 +23196,107 @@ func (ec *executionContext) fieldContext_PlanDiscussion_isAssessment(ctx context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PlanDiscussion_createdByUserInfo(ctx context.Context, field graphql.CollectedField, obj *models.PlanDiscussion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PlanDiscussion_createdByUserInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedByUserInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(models.UserInfo)
+	fc.Result = res
+	return ec.marshalNUserInfo2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PlanDiscussion_createdByUserInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PlanDiscussion",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "commonName":
+				return ec.fieldContext_UserInfo_commonName(ctx, field)
+			case "email":
+				return ec.fieldContext_UserInfo_email(ctx, field)
+			case "euaUserId":
+				return ec.fieldContext_UserInfo_euaUserId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UserInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PlanDiscussion_modifiedByUserInfo(ctx context.Context, field graphql.CollectedField, obj *models.PlanDiscussion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PlanDiscussion_modifiedByUserInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ModifiedByUserInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.UserInfo)
+	fc.Result = res
+	return ec.marshalOUserInfo2ᚖgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PlanDiscussion_modifiedByUserInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PlanDiscussion",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "commonName":
+				return ec.fieldContext_UserInfo_commonName(ctx, field)
+			case "email":
+				return ec.fieldContext_UserInfo_email(ctx, field)
+			case "euaUserId":
+				return ec.fieldContext_UserInfo_euaUserId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UserInfo", field.Name)
 		},
 	}
 	return fc, nil
@@ -45736,6 +46006,17 @@ func (ec *executionContext) _DiscussionReply(ctx context.Context, sel ast.Select
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "createdByUserInfo":
+
+			out.Values[i] = ec._DiscussionReply_createdByUserInfo(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "modifiedByUserInfo":
+
+			out.Values[i] = ec._DiscussionReply_modifiedByUserInfo(ctx, field, obj)
+
 		case "createdBy":
 
 			out.Values[i] = ec._DiscussionReply_createdBy(ctx, field, obj)
@@ -47522,6 +47803,17 @@ func (ec *executionContext) _PlanDiscussion(ctx context.Context, sel ast.Selecti
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		case "createdByUserInfo":
+
+			out.Values[i] = ec._PlanDiscussion_createdByUserInfo(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "modifiedByUserInfo":
+
+			out.Values[i] = ec._PlanDiscussion_modifiedByUserInfo(ctx, field, obj)
+
 		case "createdBy":
 
 			out.Values[i] = ec._PlanDiscussion_createdBy(ctx, field, obj)
@@ -57307,6 +57599,10 @@ func (ec *executionContext) marshalNUpload2githubᚗcomᚋ99designsᚋgqlgenᚋg
 	return res
 }
 
+func (ec *executionContext) marshalNUserInfo2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserInfo(ctx context.Context, sel ast.SelectionSet, v models.UserInfo) graphql.Marshaler {
+	return ec._UserInfo(ctx, sel, &v)
+}
+
 func (ec *executionContext) marshalNUserInfo2ᚕᚖgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserInfoᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.UserInfo) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -62186,6 +62482,13 @@ func (ec *executionContext) unmarshalOUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(c
 func (ec *executionContext) marshalOUUID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx context.Context, sel ast.SelectionSet, v uuid.UUID) graphql.Marshaler {
 	res := models.MarshalUUID(v)
 	return res
+}
+
+func (ec *executionContext) marshalOUserInfo2ᚖgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserInfo(ctx context.Context, sel ast.SelectionSet, v *models.UserInfo) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._UserInfo(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOWaiverType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐWaiverTypeᚄ(ctx context.Context, v interface{}) ([]model.WaiverType, error) {

--- a/pkg/graph/resolver.go
+++ b/pkg/graph/resolver.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/cmsgov/mint-app/pkg/cedar/cedarldap"
+
 	"github.com/cmsgov/mint-app/pkg/email"
 	"github.com/cmsgov/mint-app/pkg/shared/oddmail"
 
@@ -33,6 +35,7 @@ type Resolver struct {
 	emailTemplateService email.TemplateService
 	ldClient             *ldclient.LDClient
 	pubsub               pubsub.PubSub
+	cedarClient          cedarldap.Client
 }
 
 // ResolverService holds service methods for use in resolvers
@@ -53,8 +56,9 @@ func NewResolver(
 	emailTemplateService email.TemplateService,
 	ldClient *ldclient.LDClient,
 	pubsub pubsub.PubSub,
+	cedarClient cedarldap.Client,
 ) *Resolver {
 	return &Resolver{store: store, service: service, s3Client: s3Client,
 		emailService: emailService, emailTemplateService: emailTemplateService,
-		ldClient: ldClient, pubsub: pubsub}
+		ldClient: ldClient, pubsub: pubsub, cedarClient: cedarClient}
 }

--- a/pkg/graph/resolvers/plan_discussion.go
+++ b/pkg/graph/resolvers/plan_discussion.go
@@ -112,8 +112,8 @@ func DeletePlanDiscussion(logger *zap.Logger, id uuid.UUID, principal authentica
 // CreateDiscussionReply implements resolver logic to create a Discussion reply object
 func CreateDiscussionReply(
 	ctx context.Context,
-	userInfoProvider providers.UserInfoProvider,
 	logger *zap.Logger,
+	userInfoProvider providers.UserInfoProvider,
 	input *model.DiscussionReplyCreateInput,
 	principal authentication.Principal,
 	store *storage.Store,

--- a/pkg/graph/resolvers/plan_discussion_test.go
+++ b/pkg/graph/resolvers/plan_discussion_test.go
@@ -1,6 +1,8 @@
 package resolvers
 
 import (
+	"context"
+
 	_ "github.com/lib/pq" // required for postgres driver in sql
 	"github.com/stretchr/testify/assert"
 
@@ -17,7 +19,14 @@ func (suite *ResolverSuite) TestCreatePlanDiscussion() {
 		Content:     "This is a test comment",
 	}
 
-	result, err := CreatePlanDiscussion(suite.testConfigs.Logger, input, suite.testConfigs.Principal, suite.testConfigs.Store)
+	result, err := CreatePlanDiscussion(
+		context.TODO(),
+		suite.testConfigs.Logger,
+		suite.testConfigs.CedarClient,
+		input,
+		suite.testConfigs.Principal,
+		suite.testConfigs.Store,
+	)
 	suite.NoError(err)
 	suite.NotNil(result.ID)
 	suite.EqualValues(plan.ID, result.ModelPlanID)
@@ -41,7 +50,14 @@ func (suite *ResolverSuite) TestCreatePlanDiscussionAsRegularUser() {
 		JobCodeUSER:       true,
 		JobCodeASSESSMENT: false,
 	}
-	result, err := CreatePlanDiscussion(suite.testConfigs.Logger, input, regularUserPrincipal, suite.testConfigs.Store)
+	result, err := CreatePlanDiscussion(
+		context.TODO(),
+		suite.testConfigs.Logger,
+		suite.testConfigs.CedarClient,
+		input,
+		regularUserPrincipal,
+		suite.testConfigs.Store,
+	)
 	suite.NoError(err)
 	suite.NotNil(result.ID)
 	suite.EqualValues(plan.ID, result.ModelPlanID)
@@ -60,7 +76,15 @@ func (suite *ResolverSuite) TestUpdatePlanDiscussion() {
 		"content": "This is now updated! Thanks for looking at my test",
 		"status":  models.DiscussionAnswered,
 	}
-	result, err := UpdatePlanDiscussion(suite.testConfigs.Logger, discussion.ID, changes, suite.testConfigs.Principal, suite.testConfigs.Store)
+	result, err := UpdatePlanDiscussion(
+		context.TODO(),
+		suite.testConfigs.Logger,
+		suite.testConfigs.CedarClient,
+		discussion.ID,
+		changes,
+		suite.testConfigs.Principal,
+		suite.testConfigs.Store,
+	)
 
 	suite.NoError(err)
 	suite.EqualValues(discussion.ID, result.ID)
@@ -104,7 +128,14 @@ func (suite *ResolverSuite) TestCreateDiscussionReply() {
 		Resolution:   true,
 	}
 
-	result, err := CreateDiscussionReply(suite.testConfigs.Logger, input, suite.testConfigs.Principal, suite.testConfigs.Store)
+	result, err := CreateDiscussionReply(
+		context.TODO(),
+		suite.testConfigs.CedarClient,
+		suite.testConfigs.Logger,
+		input,
+		suite.testConfigs.Principal,
+		suite.testConfigs.Store,
+	)
 	suite.NoError(err)
 	suite.NotNil(result.ID)
 	suite.EqualValues(discussion.ID, result.DiscussionID)
@@ -128,7 +159,14 @@ func (suite *ResolverSuite) TestCreateDiscussionReplyAsRegularUser() {
 		JobCodeUSER:       true,
 		JobCodeASSESSMENT: false,
 	}
-	result, err := CreateDiscussionReply(suite.testConfigs.Logger, input, regularUserPrincipal, suite.testConfigs.Store)
+	result, err := CreateDiscussionReply(
+		context.TODO(),
+		suite.testConfigs.CedarClient,
+		suite.testConfigs.Logger,
+		input,
+		regularUserPrincipal,
+		suite.testConfigs.Store,
+	)
 	suite.NoError(err)
 	suite.NotNil(result.ID)
 	suite.EqualValues(discussion.ID, result.DiscussionID)
@@ -149,7 +187,15 @@ func (suite *ResolverSuite) TestUpdateDiscussionReply() {
 		"resolution": true,
 	}
 
-	result, err := UpdateDiscussionReply(suite.testConfigs.Logger, reply.ID, changes, suite.testConfigs.Principal, suite.testConfigs.Store)
+	result, err := UpdateDiscussionReply(
+		context.TODO(),
+		suite.testConfigs.Logger,
+		suite.testConfigs.CedarClient,
+		reply.ID,
+		changes,
+		suite.testConfigs.Principal,
+		suite.testConfigs.Store,
+	)
 
 	suite.NoError(err)
 	suite.EqualValues(changes["content"], result.Content)

--- a/pkg/graph/resolvers/plan_discussion_test.go
+++ b/pkg/graph/resolvers/plan_discussion_test.go
@@ -130,8 +130,8 @@ func (suite *ResolverSuite) TestCreateDiscussionReply() {
 
 	result, err := CreateDiscussionReply(
 		context.TODO(),
-		suite.testConfigs.CedarClient,
 		suite.testConfigs.Logger,
+		suite.testConfigs.CedarClient,
 		input,
 		suite.testConfigs.Principal,
 		suite.testConfigs.Store,
@@ -161,8 +161,8 @@ func (suite *ResolverSuite) TestCreateDiscussionReplyAsRegularUser() {
 	}
 	result, err := CreateDiscussionReply(
 		context.TODO(),
-		suite.testConfigs.CedarClient,
 		suite.testConfigs.Logger,
+		suite.testConfigs.CedarClient,
 		input,
 		regularUserPrincipal,
 		suite.testConfigs.Store,

--- a/pkg/graph/resolvers/resolver_test.go
+++ b/pkg/graph/resolvers/resolver_test.go
@@ -1,6 +1,7 @@
 package resolvers
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -38,7 +39,14 @@ func (suite *ResolverSuite) createPlanDiscussion(mp *models.ModelPlan, content s
 		ModelPlanID: mp.ID,
 		Content:     content,
 	}
-	pd, err := CreatePlanDiscussion(suite.testConfigs.Logger, input, suite.testConfigs.Principal, suite.testConfigs.Store)
+	pd, err := CreatePlanDiscussion(
+		context.TODO(),
+		suite.testConfigs.Logger,
+		suite.testConfigs.CedarClient,
+		input,
+		suite.testConfigs.Principal,
+		suite.testConfigs.Store,
+	)
 	suite.NoError(err)
 	return pd
 }
@@ -49,7 +57,14 @@ func (suite *ResolverSuite) createDiscussionReply(pd *models.PlanDiscussion, con
 		Content:      content,
 		Resolution:   resolution,
 	}
-	dr, err := CreateDiscussionReply(suite.testConfigs.Logger, input, suite.testConfigs.Principal, suite.testConfigs.Store)
+	dr, err := CreateDiscussionReply(
+		context.TODO(),
+		suite.testConfigs.CedarClient,
+		suite.testConfigs.Logger,
+		input,
+		suite.testConfigs.Principal,
+		suite.testConfigs.Store,
+	)
 	suite.NoError(err)
 	return dr
 }

--- a/pkg/graph/resolvers/resolver_test.go
+++ b/pkg/graph/resolvers/resolver_test.go
@@ -59,8 +59,8 @@ func (suite *ResolverSuite) createDiscussionReply(pd *models.PlanDiscussion, con
 	}
 	dr, err := CreateDiscussionReply(
 		context.TODO(),
-		suite.testConfigs.CedarClient,
 		suite.testConfigs.Logger,
+		suite.testConfigs.CedarClient,
 		input,
 		suite.testConfigs.Principal,
 		suite.testConfigs.Store,

--- a/pkg/graph/resolvers/resolver_test_utilities.go
+++ b/pkg/graph/resolvers/resolver_test_utilities.go
@@ -3,6 +3,9 @@ package resolvers
 import (
 	"fmt"
 
+	"github.com/cmsgov/mint-app/pkg/cedar/cedarldap"
+	"github.com/cmsgov/mint-app/pkg/local"
+
 	"github.com/cmsgov/mint-app/pkg/shared/emailTemplates"
 	"github.com/cmsgov/mint-app/pkg/userhelpers"
 
@@ -21,14 +24,15 @@ import (
 
 // TestConfigs is a struct that contains all the dependencies needed to run a test
 type TestConfigs struct {
-	DBConfig  storage.DBConfig
-	LDClient  *ld.LDClient
-	Logger    *zap.Logger
-	UserInfo  *models.UserInfo
-	Store     *storage.Store
-	S3Client  *upload.S3Client
-	PubSub    *pubsub.ServicePubSub
-	Principal *authentication.ApplicationPrincipal
+	DBConfig    storage.DBConfig
+	LDClient    *ld.LDClient
+	Logger      *zap.Logger
+	UserInfo    *models.UserInfo
+	Store       *storage.Store
+	S3Client    *upload.S3Client
+	PubSub      *pubsub.ServicePubSub
+	Principal   *authentication.ApplicationPrincipal
+	CedarClient cedarldap.Client
 }
 
 // GetDefaultTestConfigs returns a TestConfigs struct with all the dependencies needed to run a test
@@ -56,6 +60,8 @@ func (tc *TestConfigs) GetDefaults() {
 	store, _ := storage.NewStore(logger, config, ldClient)
 	princ := getTestPrincipal(store, userInfo.EuaUserID)
 
+	cedarLDAPClient := local.NewCedarLdapClient(logger)
+
 	s3Client := createS3Client()
 	tc.DBConfig = config
 	tc.LDClient = ldClient
@@ -64,6 +70,7 @@ func (tc *TestConfigs) GetDefaults() {
 	tc.Store = store
 	tc.S3Client = &s3Client
 	tc.PubSub = ps
+	tc.CedarClient = cedarLDAPClient
 
 	tc.Principal = princ
 }

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -317,6 +317,8 @@ type PlanDiscussion  {
 	status: DiscussionStatus!
   replies: [DiscussionReply!]!
   isAssessment: Boolean!
+  createdByUserInfo: UserInfo!
+  modifiedByUserInfo: UserInfo
 
   createdBy: String!
   createdDts: Time!
@@ -351,6 +353,8 @@ type DiscussionReply  {
 	content: String
 	resolution: Boolean
   isAssessment: Boolean!
+  createdByUserInfo: UserInfo!
+  modifiedByUserInfo: UserInfo
 
 	createdBy: String!
 	createdDts: Time!

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -260,7 +260,7 @@ func (r *mutationResolver) CreatePlanDiscussion(ctx context.Context, input model
 	principal := appcontext.Principal(ctx)
 	logger := appcontext.ZLogger(ctx)
 
-	return resolvers.CreatePlanDiscussion(logger, &input, principal, r.store)
+	return resolvers.CreatePlanDiscussion(ctx, logger, r.cedarClient, &input, principal, r.store)
 }
 
 // UpdatePlanDiscussion is the resolver for the updatePlanDiscussion field.
@@ -268,7 +268,7 @@ func (r *mutationResolver) UpdatePlanDiscussion(ctx context.Context, id uuid.UUI
 	principal := appcontext.Principal(ctx)
 	logger := appcontext.ZLogger(ctx)
 
-	return resolvers.UpdatePlanDiscussion(logger, id, changes, principal, r.store)
+	return resolvers.UpdatePlanDiscussion(ctx, logger, r.cedarClient, id, changes, principal, r.store)
 }
 
 // DeletePlanDiscussion is the resolver for the deletePlanDiscussion field.
@@ -284,7 +284,7 @@ func (r *mutationResolver) CreateDiscussionReply(ctx context.Context, input mode
 	principal := appcontext.Principal(ctx)
 	logger := appcontext.ZLogger(ctx)
 
-	return resolvers.CreateDiscussionReply(logger, &input, principal, r.store)
+	return resolvers.CreateDiscussionReply(ctx, r.cedarClient, logger, &input, principal, r.store)
 }
 
 // UpdateDiscussionReply is the resolver for the updateDiscussionReply field.
@@ -292,7 +292,7 @@ func (r *mutationResolver) UpdateDiscussionReply(ctx context.Context, id uuid.UU
 	principal := appcontext.Principal(ctx)
 	logger := appcontext.ZLogger(ctx)
 
-	return resolvers.UpdateDiscussionReply(logger, id, changes, principal, r.store)
+	return resolvers.UpdateDiscussionReply(ctx, logger, r.cedarClient, id, changes, principal, r.store)
 }
 
 // DeleteDiscussionReply is the resolver for the deleteDiscussionReply field.

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -284,7 +284,7 @@ func (r *mutationResolver) CreateDiscussionReply(ctx context.Context, input mode
 	principal := appcontext.Principal(ctx)
 	logger := appcontext.ZLogger(ctx)
 
-	return resolvers.CreateDiscussionReply(ctx, r.cedarClient, logger, &input, principal, r.store)
+	return resolvers.CreateDiscussionReply(ctx, logger, r.cedarClient, &input, principal, r.store)
 }
 
 // UpdateDiscussionReply is the resolver for the updateDiscussionReply field.

--- a/pkg/graph/schema.resolvers_test.go
+++ b/pkg/graph/schema.resolvers_test.go
@@ -154,7 +154,7 @@ func TestGraphQLTestSuite(t *testing.T) {
 	resolverService.FetchUserInfo = cedarLdapClient.FetchUserInfo
 
 	ps := pubsub.NewServicePubSub()
-	resolver := NewResolver(store, resolverService, &s3Client, *emailService, emailTemplateService, ldClient, ps)
+	resolver := NewResolver(store, resolverService, &s3Client, *emailService, emailTemplateService, ldClient, ps, cedarLdapClient)
 	schema := generated.NewExecutableSchema(generated.Config{Resolvers: resolver, Directives: directives})
 	graphQLClient := client.New(handler.NewDefaultServer(schema))
 

--- a/pkg/models/plan_discussion.go
+++ b/pkg/models/plan_discussion.go
@@ -8,19 +8,30 @@ import (
 type PlanDiscussion struct {
 	baseStruct
 	modelPlanRelation
-	Content      string           `json:"content" db:"content"`
-	Status       DiscussionStatus `json:"status" db:"status"`
-	IsAssessment bool             `json:"isAssessment" db:"is_assessment"`
+	Content            string           `json:"content" db:"content"`
+	Status             DiscussionStatus `json:"status" db:"status"`
+	IsAssessment       bool             `json:"isAssessment" db:"is_assessment"`
+	CreatedByUserInfo  UserInfo         `json:"createdByUserInfo" db:"created_by_user_info"`
+	ModifiedByUserInfo *UserInfo        `json:"modifiedByUserInfo" db:"modified_by_user_info"`
 }
 
 // NewPlanDiscussion returns a New PlanDiscussion with a status of UNANSWERED
-func NewPlanDiscussion(principal string, isAssessment bool, modelPlanID uuid.UUID, content string) *PlanDiscussion {
+func NewPlanDiscussion(
+	principal string,
+	isAssessment bool,
+	modelPlanID uuid.UUID,
+	content string,
+	createdByUserInfo UserInfo,
+	modifiedByUserInfo *UserInfo,
+) *PlanDiscussion {
 	return &PlanDiscussion{
-		Content:           content,
-		Status:            DiscussionUnAnswered,
-		IsAssessment:      isAssessment,
-		modelPlanRelation: NewModelPlanRelation(modelPlanID),
-		baseStruct:        NewBaseStruct(principal),
+		Content:            content,
+		Status:             DiscussionUnAnswered,
+		IsAssessment:       isAssessment,
+		CreatedByUserInfo:  createdByUserInfo,
+		ModifiedByUserInfo: modifiedByUserInfo,
+		modelPlanRelation:  NewModelPlanRelation(modelPlanID),
+		baseStruct:         NewBaseStruct(principal),
 	}
 }
 
@@ -28,17 +39,29 @@ func NewPlanDiscussion(principal string, isAssessment bool, modelPlanID uuid.UUI
 type DiscussionReply struct {
 	baseStruct
 	discussionRelation
-	Content      string `json:"content" db:"content"`
-	Resolution   bool   `json:"resolution" db:"resolution"` //default to false
-	IsAssessment bool   `json:"isAssessment" db:"is_assessment"`
+	Content            string    `json:"content" db:"content"`
+	Resolution         bool      `json:"resolution" db:"resolution"` //default to false
+	IsAssessment       bool      `json:"isAssessment" db:"is_assessment"`
+	CreatedByUserInfo  UserInfo  `json:"createdByUserInfo" db:"created_by_user_info"`
+	ModifiedByUserInfo *UserInfo `json:"modifiedByUserInfo" db:"modified_by_user_info"`
 }
 
 // NewDiscussionReply returns a new Discussion Reply
-func NewDiscussionReply(principal string, isAssessment bool, discussionID uuid.UUID, content string, resolution bool) *DiscussionReply {
+func NewDiscussionReply(
+	principal string,
+	isAssessment bool,
+	discussionID uuid.UUID,
+	content string,
+	resolution bool,
+	createdByUserInfo UserInfo,
+	modifiedByUserInfo *UserInfo,
+) *DiscussionReply {
 	return &DiscussionReply{
 		Content:            content,
 		Resolution:         resolution,
 		IsAssessment:       isAssessment,
+		CreatedByUserInfo:  createdByUserInfo,
+		ModifiedByUserInfo: modifiedByUserInfo,
 		discussionRelation: NewDiscussionRelation(discussionID),
 		baseStruct:         NewBaseStruct(principal),
 	}

--- a/pkg/providers/user_info.go
+++ b/pkg/providers/user_info.go
@@ -1,0 +1,12 @@
+package providers
+
+import (
+	"context"
+
+	"github.com/cmsgov/mint-app/pkg/models"
+)
+
+// UserInfoProvider is an interface to allow injection of any service which will satisfy UserInfo requests
+type UserInfoProvider interface {
+	FetchUserInfo(context.Context, string) (*models.UserInfo, error)
+}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -188,6 +188,7 @@ func (s *Server) routes(
 		emailTemplateService,
 		ldClient,
 		s.pubsub,
+		cedarLDAPClient,
 	)
 	gqlDirectives := generated.DirectiveRoot{
 		HasRole: func(ctx context.Context, obj interface{}, next graphql.Resolver, role model.Role) (res interface{}, err error) {

--- a/pkg/storage/plan_discussionStore.go
+++ b/pkg/storage/plan_discussionStore.go
@@ -132,7 +132,10 @@ func (s *Store) PlanDiscussionCollectionByModelPlanID(logger *zap.Logger, modelP
 }
 
 // PlanDiscussionUpdate updates a plan discussion object
-func (s *Store) PlanDiscussionUpdate(logger *zap.Logger, discussion *models.PlanDiscussion) (*models.PlanDiscussion, error) {
+func (s *Store) PlanDiscussionUpdate(
+	logger *zap.Logger,
+	discussion *models.PlanDiscussion,
+) (*models.PlanDiscussion, error) {
 	statement, err := s.db.PrepareNamed(planDiscussionUpdateSQL)
 	if err != nil {
 		return nil, genericmodel.HandleModelUpdateError(logger, err, discussion)

--- a/pkg/worker/worker_test.go
+++ b/pkg/worker/worker_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -38,7 +39,14 @@ func (suite *WorkerSuite) createPlanDiscussion(mp *models.ModelPlan, content str
 		ModelPlanID: mp.ID,
 		Content:     content,
 	}
-	pd, err := resolvers.CreatePlanDiscussion(suite.testConfigs.Logger, input, suite.testConfigs.Principal, suite.testConfigs.Store)
+	pd, err := resolvers.CreatePlanDiscussion(
+		context.TODO(),
+		suite.testConfigs.Logger,
+		suite.testConfigs.CedarClient,
+		input,
+		suite.testConfigs.Principal,
+		suite.testConfigs.Store,
+	)
 	suite.NoError(err)
 	return pd
 }

--- a/pkg/worker/worker_test_utilities.go
+++ b/pkg/worker/worker_test_utilities.go
@@ -1,7 +1,9 @@
 package worker
 
 import (
+	"github.com/cmsgov/mint-app/pkg/cedar/cedarldap"
 	"github.com/cmsgov/mint-app/pkg/email"
+	"github.com/cmsgov/mint-app/pkg/local"
 	"github.com/cmsgov/mint-app/pkg/userhelpers"
 
 	"github.com/cmsgov/mint-app/pkg/appconfig"
@@ -28,6 +30,7 @@ type TestConfigs struct {
 	PubSub               *pubsub.ServicePubSub
 	Principal            *authentication.ApplicationPrincipal
 	EmailTemplateService email.TemplateServiceImpl
+	CedarClient          cedarldap.Client
 }
 
 // GetDefaultTestConfigs returns a TestConfigs struct with all the dependencies needed to run a test
@@ -66,6 +69,7 @@ func (tc *TestConfigs) GetDefaults() {
 	tc.PubSub = ps
 	tc.Principal = princ
 	tc.EmailTemplateService = *emailTemplateService
+	tc.CedarClient = local.NewCedarLdapClient(logger)
 }
 
 // NewDBConfig returns a DBConfig struct with values from appconfig


### PR DESCRIPTION
# EASI-2521

## Changes and Description

- Added UserInfo to Discussion
- Added UserInfo to DiscussionReply

<!-- Put a description here! -->

## How to test this change

- Create a Discussion, observe that CreatedByUserInfo populates appropriately and ModifiedByUserInfo is nil
- Update a Discussion, observe that CreatedByUserInfo populates without change and ModifiedByUserInfo populates appropriately
- Create a DiscussionReply, observe that CreatedByUserInfo populates appropriately and ModifiedByUserInfo is nil
- Update a DiscussionReply, observe that CreatedByUserInfo populatese without change and ModifiedByUserInfo populates appropriately

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
