### PR TITLE
[EASI-2602] Save and Start Next Section Please

### DIFF
--- a/cypress/e2e/characteristics.spec.js
+++ b/cypress/e2e/characteristics.spec.js
@@ -64,16 +64,12 @@ describe('The Model Plan General Characteristics Form', () => {
 
     cy.wait(500);
 
-    cy.get('#plan-characteristics-alternative-payment')
-      .check({ force: true })
-      .should('be.checked');
-
     cy.get('#plan-characteristics-alternative-payment-MIPS')
       .check({ force: true })
       .should('be.checked');
 
     cy.get('[data-testid="mandatory-fields-alert"]').contains(
-      'In order to be considered by QPP (and to be MIPS or Advanced APM), you will need to collect TINS and NPIs for provider.'
+      'In order to be considered by the Quality Payment Program (QPP), and to be MIPS or Advanced APM, you will need to collect TINs and NPIs for providers.'
     );
 
     cy.get('#plan-characteristics-key-characteristics').within(() => {
@@ -199,11 +195,11 @@ describe('The Model Plan General Characteristics Form', () => {
     cy.contains('button', 'Save and start next Model Plan section').click();
 
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/\/models\/.{36}\/task-list$/);
+      expect(loc.pathname).to.match(
+        /\/models\/.{36}\/task-list\/participants-and-providers$/
+      );
     });
 
-    cy.get(
-      '[data-testid="task-list-intake-form-generalCharacteristics"]'
-    ).contains('In progress');
+    cy.get('h1.mint-h1').contains('Participants and Providers');
   });
 });

--- a/cypress/e2e/opsEvalAndLearning.spec.js
+++ b/cypress/e2e/opsEvalAndLearning.spec.js
@@ -249,9 +249,7 @@ describe('The Model Plan Ops Eval and Learning Form', () => {
 
     cy.clickOutside();
 
-    cy.get('[data-testid="multiselect-tag--Other-MIPS data"]')
-      .first()
-      .contains('Other');
+    cy.get('[data-testid="multiselect-tag--Other"]').last().contains('Other');
 
     cy.get('#ops-eval-and-learning-share-cclf-data-true')
       .check({ force: true })
@@ -361,11 +359,9 @@ describe('The Model Plan Ops Eval and Learning Form', () => {
     cy.contains('button', 'Save and start next Model Plan section').click();
 
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/\/models\/.{36}\/task-list/);
+      expect(loc.pathname).to.match(/\/models\/.{36}\/task-list\/payment$/);
     });
 
-    cy.get('[data-testid="task-list-intake-form-opsEvalAndLearning"]').contains(
-      'In progress'
-    );
+    cy.get('h1.mint-h1').contains('Payment');
   });
 });

--- a/cypress/e2e/participantsAndProviders.spec.js
+++ b/cypress/e2e/participantsAndProviders.spec.js
@@ -213,7 +213,7 @@ describe('The Model Plan Participants and Providers Form', () => {
 
     cy.location().should(loc => {
       expect(loc.pathname).to.match(
-        /\/models\/.{36}\/task-list\/beneficiaries/
+        /\/models\/.{36}\/task-list\/beneficiaries$/
       );
     });
 

--- a/cypress/e2e/participantsAndProviders.spec.js
+++ b/cypress/e2e/participantsAndProviders.spec.js
@@ -212,11 +212,11 @@ describe('The Model Plan Participants and Providers Form', () => {
     cy.contains('button', 'Save and start next Model Plan section').click();
 
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/\/models\/.{36}\/task-list/);
+      expect(loc.pathname).to.match(
+        /\/models\/.{36}\/task-list\/beneficiaries/
+      );
     });
 
-    cy.get(
-      '[data-testid="task-list-intake-form-participantsAndProviders"]'
-    ).contains('In progress');
+    cy.get('h1.mint-h1').contains('Beneficiaries');
   });
 });

--- a/cypress/e2e/payments.spec.js
+++ b/cypress/e2e/payments.spec.js
@@ -247,10 +247,14 @@ describe('The Model Plan Payment Form', () => {
       .type('10/26/2028')
       .should('have.value', '10/26/2028');
 
-    cy.contains('button', 'Save and start next Model Plan section').click();
+    cy.contains('button', 'Save and start next Model Plan section').should(
+      'not.exist'
+    );
 
-    cy.location().should(loc => {
-      expect(loc.pathname).to.match(/\/models\/.{36}\/task-list/);
-    });
+    // Uncomment the code below once IT Lead Experience is PROD
+    // cy.contains('button', 'Continue to IT solutions and implementation status').click();
+    // cy.location().should(loc => {
+    //   expect(loc.pathname).to.match(/\/models\/.{36}\/task-list\/it-solutions$/);
+    // });
   });
 });

--- a/src/i18n/en-US/draftModelPlan/payments.ts
+++ b/src/i18n/en-US/draftModelPlan/payments.ts
@@ -260,7 +260,8 @@ const payments = {
   paymentStartDate: 'When will payments start? (Enter an approximate date)',
   paymentStartDateQuestion: 'When will payments start?',
   paymentStartDateSubcopy:
-    'Note: If you are unsure of an approximate date, please select the first day of the approximate month.'
+    'Note: If you are unsure of an approximate date, please select the first day of the approximate month.',
+  continueToITSolutions: 'Continue to IT solutions and implementation status'
 };
 
 export default payments;

--- a/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
@@ -109,7 +109,7 @@ const Milestones = () => {
           } else if (redirect === 'back') {
             history.push(`/models/${modelID}/task-list/basics/overview`);
           } else {
-            history.push(`/models/${modelID}/task-list`);
+            history.push(`/models/${modelID}/task-list/characteristics`);
           }
         }
       })

--- a/src/views/ModelPlan/TaskList/Beneficiaries/Frequency/index.tsx
+++ b/src/views/ModelPlan/TaskList/Beneficiaries/Frequency/index.tsx
@@ -119,6 +119,8 @@ const Frequency = () => {
             history.push(`/models/${modelID}/task-list/`);
           } else if (redirect) {
             history.push(redirect);
+          } else {
+            history.push(`/models/${modelID}/task-list/ops-eval-and-learning`);
           }
         }
       })
@@ -180,7 +182,7 @@ const Frequency = () => {
       <Formik
         initialValues={initialValues}
         onSubmit={() => {
-          handleFormSubmit('task-list');
+          handleFormSubmit();
         }}
         enableReinitialize
         innerRef={formikRef}

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/Authority/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/Authority/index.tsx
@@ -114,6 +114,10 @@ const Authority = () => {
             );
           } else if (redirect === 'task-list') {
             history.push(`/models/${modelID}/task-list`);
+          } else {
+            history.push(
+              `/models/${modelID}/task-list/participants-and-providers`
+            );
           }
         }
       })
@@ -175,7 +179,7 @@ const Authority = () => {
       <Formik
         initialValues={initialValues}
         onSubmit={values => {
-          handleFormSubmit('task-list');
+          handleFormSubmit();
         }}
         enableReinitialize
         innerRef={formikRef}

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Learning/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Learning/index.tsx
@@ -123,6 +123,8 @@ const Learning = () => {
             history.push(`/models/${modelID}/task-list`);
           } else if (redirect) {
             history.push(redirect);
+          } else {
+            history.push(`/models/${modelID}/task-list/payment`);
           }
         }
       })
@@ -181,7 +183,7 @@ const Learning = () => {
       <Formik
         initialValues={initialValues}
         onSubmit={() => {
-          handleFormSubmit('task-list');
+          handleFormSubmit();
         }}
         enableReinitialize
         innerRef={formikRef}

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ProviderOptions/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ProviderOptions/index.tsx
@@ -135,6 +135,8 @@ export const ProviderOptions = () => {
             history.push(`/models/${modelID}/task-list`);
           } else if (redirect) {
             history.push(redirect);
+          } else {
+            history.push(`/models/${modelID}/task-list/beneficiaries`);
           }
         }
       })
@@ -199,7 +201,7 @@ export const ProviderOptions = () => {
       <Formik
         initialValues={initialValues}
         onSubmit={() => {
-          handleFormSubmit('task-list');
+          handleFormSubmit();
         }}
         enableReinitialize
         innerRef={formikRef}

--- a/src/views/ModelPlan/TaskList/Payment/Recover/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/Recover/index.tsx
@@ -15,6 +15,7 @@ import {
   Radio
 } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
@@ -45,6 +46,7 @@ import { NotFoundPartial } from 'views/NotFound';
 import { renderCurrentPage, renderTotalPages } from '..';
 
 const Recover = () => {
+  const flags = useFlags();
   const { t } = useTranslation('payments');
   const { t: h } = useTranslation('draftModelPlan');
   const { modelID } = useParams<{ modelID: string }>();
@@ -380,9 +382,11 @@ const Recover = () => {
                         >
                           {h('back')}
                         </Button>
-                        <Button type="submit" onClick={() => setErrors({})}>
-                          {h('saveAndStartNext')}
-                        </Button>
+                        {flags.hideITLeadExperience && (
+                          <Button type="submit" onClick={() => setErrors({})}>
+                            {t('continueToITSolutions')}
+                          </Button>
+                        )}
                       </div>
                       <Button
                         type="button"


### PR DESCRIPTION
# EASI-2602

## Changes and Description
- Update all `Save and start next Model Plan section` button (that appears on the last of each section) to take user to the next section, not back to task list
   - Except for Payment, as the button is hidden under a feature flag until IT Leads Experience is in PROD
- Add Payment's button's copy when it is ready
- Update corresponding cypress tests

<!-- Put a description here! -->

## How to test this change

1. Go through the task list
2. Ensure clicking `Save and start next Model Plan section` actually takes user to next section and not task list
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
