### PR TITLE
[NOREF] Migration Generation Utility: scripts/dev genmigration

### DIFF
--- a/scripts/dev
+++ b/scripts/dev
@@ -474,7 +474,7 @@ end
 
 desc "Generate a new migration with the current utc timestamp prefix"
 task genmigration: :consume_args do |t, args|
-  migrationName = Time.now.utc.strftime("v%Y%m%d%H%M%S__.sql")
+  migrationName = Time.now.utc.strftime("V%Y%m%d%H%M%S__.sql")
   FileUtils.touch("migrations/#{migrationName}")
 end
 

--- a/scripts/dev
+++ b/scripts/dev
@@ -5,6 +5,7 @@ require "json"
 require "yaml"
 require "irb"        # debugging
 require "io/console" # for IO#getch
+require "fileutils"
 
 # ExtraArguments is a hack that alters how the command line arguments are parsed.
 #
@@ -469,6 +470,12 @@ end
 desc "Run all linters and checks managed by pre-commit"
 task :lint do
   sh "pre-commit run -a"
+end
+
+desc "Generate a new migration with the current utc timestamp prefix"
+task genmigration: :consume_args do |t, args|
+  migrationName = Time.now.utc.strftime("v%Y%m%d%H%M%S__.sql")
+  FileUtils.touch("migrations/#{migrationName}")
 end
 
 begin


### PR DESCRIPTION
Added genmigration to scripts/dev which generates a migration prefixed with the current UTC timestamp in YYYYmmddHHMMSS format.

# NOREF

## Changes and Description

- Added scripts/dev genmigration

<!-- Put a description here! -->

## How to test this change

- Call scripts/dev genmigration
- Observe that a migration is generated with the format "v%Y%m%d%H%M%S__.sql"

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
