### PR TITLE
[NOREF] Modify link in digest body to link to task list

### DIFF
--- a/pkg/email/templates/daily_digest_body.template
+++ b/pkg/email/templates/daily_digest_body.template
@@ -382,7 +382,7 @@
                                 <tbody>
                                   <tr style="padding: 0; text-align: left; vertical-align: top;">
                                     <th style="Margin: 0; color: #1B1B1B; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; line-height: 1.3; margin: 0; padding: 0; text-align: left;">
-                                      <a href="{{$.ClientAddress}}/models/{{$audit.ModelPlanID}}" style="Margin: 0; color: #005EA2; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 700; letter-spacing: -0.01em; line-height: 25px; margin: 0; padding: 0; text-align: left; text-decoration: underline;"> View this Model Plan in MINT </a>
+                                      <a href="{{$.ClientAddress}}/models/{{$audit.ModelPlanID}}/task-list" style="Margin: 0; color: #005EA2; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: 700; letter-spacing: -0.01em; line-height: 25px; margin: 0; padding: 0; text-align: left; text-decoration: underline;"> View this Model Plan in MINT </a>
                                     </th>
                                     <th class="expander" style="Margin: 0; color: #1B1B1B; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; line-height: 1.3; margin: 0; padding: 0 !important; text-align: left; visibility: hidden; width: 0;"></th>
                                   </tr>


### PR DESCRIPTION
# NOREF

## Changes and Description

- Modify link in daily digest email to link to `${modelPlanID}/task-list` instead of `${modelPlanID}` (which results in a 404)

<!-- Put a description here! -->

## How to test this change

- Make a model plan
- make some changes
- Check the audit email in Mailcatcher (should fire off every 5 minutes)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
