### PR TITLE
[NOREF] Require flags for isAssessment, remove from others

### DIFF
--- a/src/utils/user.test.ts
+++ b/src/utils/user.test.ts
@@ -48,32 +48,31 @@ describe('user', () => {
   });
 
   describe('isBasicUser', () => {
-    const defaultFlags = {} as Flags;
     describe('only user job code exists in groups', () => {
       const groups = [BASIC];
       it('returns true', () => {
-        expect(isBasicUser(groups, defaultFlags)).toBe(true);
+        expect(isBasicUser(groups)).toBe(true);
       });
     });
 
     describe('only assessment job code', () => {
       const groups = [ASSESSMENT];
       it('returns false', () => {
-        expect(isBasicUser(groups, defaultFlags)).toBe(false);
+        expect(isBasicUser(groups)).toBe(false);
       });
     });
 
     describe('both job codes', () => {
       const groups = [BASIC, ASSESSMENT];
       it('returns true', () => {
-        expect(isBasicUser(groups, defaultFlags)).toBe(true);
+        expect(isBasicUser(groups)).toBe(true);
       });
     });
 
     describe('no job code exists in groups', () => {
       const groups: Array<String> = [];
       it('returns false', () => {
-        expect(isBasicUser(groups, defaultFlags)).toBe(false);
+        expect(isBasicUser(groups)).toBe(false);
       });
     });
   });

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,7 +1,7 @@
 import { ASSESSMENT, BASIC, MAC } from 'constants/jobCodes';
 import { Flags } from 'types/flags';
 
-export const isAssessment = (groups: Array<String> = [], flags?: Flags) => {
+export const isAssessment = (groups: Array<String> = [], flags: Flags) => {
   if (flags?.downgradeAssessmentTeam) {
     return false;
   }
@@ -12,7 +12,7 @@ export const isAssessment = (groups: Array<String> = [], flags?: Flags) => {
   return false;
 };
 
-export const isBasicUser = (groups: Array<String> = [], flags?: Flags) => {
+export const isBasicUser = (groups: Array<String> = []) => {
   if (groups.includes(BASIC)) {
     return true;
   }
@@ -20,7 +20,7 @@ export const isBasicUser = (groups: Array<String> = [], flags?: Flags) => {
   return false;
 };
 
-export const isMAC = (groups: Array<String> = [], flags?: Flags) => {
+export const isMAC = (groups: Array<String> = []) => {
   if (groups.includes(MAC)) {
     return true;
   }

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -29,7 +29,7 @@ const Home = () => {
   const { message } = useMessage();
 
   const headingType = (groups: typeof JOB_CODES) => {
-    if (isAssessment(groups)) {
+    if (isAssessment(groups, flags)) {
       return t('requestsTable.admin.heading');
     }
     if (isMAC(userGroups)) {
@@ -78,7 +78,7 @@ const Home = () => {
               </div>
               <DraftModelPlansTable
                 isAssessment={isAssessment(userGroups, flags)}
-                isMAC={isMAC(userGroups, flags)}
+                isMAC={isMAC(userGroups)}
               />
               <SummaryBox
                 heading=""

--- a/src/views/ModelAccessWrapper/index.tsx
+++ b/src/views/ModelAccessWrapper/index.tsx
@@ -9,6 +9,7 @@ import React, { useEffect } from 'react';
 import { RootStateOrAny, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import GetIsCollaborator from 'queries/Collaborators/GetIsCollaborator';
 import {
@@ -25,6 +26,7 @@ type ModelAccessWrapperProps = {
 const ModelAccessWrapper = ({ children }: ModelAccessWrapperProps) => {
   const { pathname } = useLocation();
   const history = useHistory();
+  const flags = useFlags();
 
   const modelID: string | undefined = pathname.split('/')[2];
   const validModelID: boolean = isUUID(modelID);
@@ -60,7 +62,7 @@ const ModelAccessWrapper = ({ children }: ModelAccessWrapperProps) => {
       modelID &&
       validModelID &&
       editable &&
-      !isAssessment(groups)
+      !isAssessment(groups, flags)
     ) {
       history.replace(`/models/${modelID}/read-only/model-basics`);
     }
@@ -72,7 +74,8 @@ const ModelAccessWrapper = ({ children }: ModelAccessWrapperProps) => {
     modelID,
     validModelID,
     editable,
-    groups
+    groups,
+    flags
   ]);
 
   return <>{children}</>;

--- a/src/views/ModelPlan/CRTDL/CRTDLs/table.tsx
+++ b/src/views/ModelPlan/CRTDL/CRTDLs/table.tsx
@@ -4,6 +4,7 @@ import { RootStateOrAny, useSelector } from 'react-redux';
 import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
 import { useMutation, useQuery } from '@apollo/client';
 import { Button, Table as UswdsTable } from '@trussworks/react-uswds';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 import { DateTime } from 'luxon';
 
 import UswdsReactLink from 'components/LinkWrapper';
@@ -59,6 +60,8 @@ const CRTDLTable = ({
     }
   });
 
+  const flags = useFlags();
+
   const crtdls = (data?.modelPlan?.crTdls ?? []) as CDTRLType[];
 
   const modelName = data?.modelPlan.modelName;
@@ -66,7 +69,7 @@ const CRTDLTable = ({
   const isCollaborator = data?.modelPlan?.isCollaborator;
   const { groups } = useSelector((state: RootStateOrAny) => state.auth);
   const hasEditAccess: boolean =
-    !isHelpArticle && (isCollaborator || isAssessment(groups));
+    !isHelpArticle && (isCollaborator || isAssessment(groups, flags));
 
   if (loading) {
     return <PageLoading />;

--- a/src/views/ModelPlan/Discussions/index.tsx
+++ b/src/views/ModelPlan/Discussions/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@trussworks/react-uswds';
 import classNames from 'classnames';
 import { Field, Form, Formik, FormikProps } from 'formik';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 import * as Yup from 'yup';
 
 import PageHeading from 'components/PageHeading';
@@ -69,10 +70,12 @@ const Discussions = ({ modelID, askAQuestion, readOnly }: DiscussionsProps) => {
     }
   });
 
+  const flags = useFlags();
+
   const { groups } = useSelector((state: RootStateOrAny) => state.auth);
   const isCollaborator = data?.modelPlan?.isCollaborator;
   const hasEditAccess: boolean =
-    (isCollaborator || isAssessment(groups)) && !isMAC(groups);
+    (isCollaborator || isAssessment(groups, flags)) && !isMAC(groups);
 
   const discussions = useMemo(() => {
     return data?.modelPlan?.discussions || ([] as DiscussionType[]);

--- a/src/views/ModelPlan/Documents/table.tsx
+++ b/src/views/ModelPlan/Documents/table.tsx
@@ -5,6 +5,7 @@ import { useFilters, usePagination, useSortBy, useTable } from 'react-table';
 import { useMutation, useQuery } from '@apollo/client';
 import { Button, Table as UswdsTable } from '@trussworks/react-uswds';
 import classNames from 'classnames';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 import { DateTime } from 'luxon';
 
 import Modal from 'components/Modal';
@@ -59,11 +60,13 @@ const PlanDocumentsTable = ({
     }
   });
 
+  const flags = useFlags();
+
   const documents = data?.modelPlan?.documents || ([] as DocumentType[]);
   const isCollaborator = data?.modelPlan?.isCollaborator;
   const { groups } = useSelector((state: RootStateOrAny) => state.auth);
   const hasEditAccess: boolean =
-    !isHelpArticle && (isCollaborator || isAssessment(groups));
+    !isHelpArticle && (isCollaborator || isAssessment(groups, flags));
 
   if (loading) {
     return <PageLoading />;

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -179,7 +179,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   const hasEditAccess: boolean =
     !isHelpArticle &&
     !isMAC(groups) &&
-    (isCollaborator || isAssessment(groups));
+    (isCollaborator || isAssessment(groups, flags));
 
   const formattedApplicationStartDate =
     basics?.applicationsStart && formatDate(basics?.applicationsStart);

--- a/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
@@ -25,6 +25,7 @@ import {
   Table as UswdsTable
 } from '@trussworks/react-uswds';
 import classNames from 'classnames';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 import { DateTime } from 'luxon';
 
 import UswdsReactLink from 'components/LinkWrapper';
@@ -88,6 +89,8 @@ const OperationalNeedsTable = ({
     }
   });
 
+  const flags = useFlags();
+
   // Memoized function to return/filter possible needs and needed solutions
   const operationalNeeds = useMemo(() => {
     const needData = data?.modelPlan?.operationalNeeds
@@ -103,7 +106,7 @@ const OperationalNeedsTable = ({
 
   const { groups } = useSelector((state: RootStateOrAny) => state.auth);
 
-  const hasEditAccess: boolean = isCollaborator || isAssessment(groups);
+  const hasEditAccess: boolean = isCollaborator || isAssessment(groups, flags);
 
   const needsColumns = useMemo<Column<any>[]>(() => {
     return [

--- a/src/views/ModelPlan/TaskList/index.tsx
+++ b/src/views/ModelPlan/TaskList/index.tsx
@@ -112,7 +112,7 @@ const TaskList = () => {
   const { euaId, groups } = useSelector((state: RootStateOrAny) => state.auth);
 
   // Used to conditonally render role specific text in task list
-  const userRole = isAssessment(groups) ? 'assessment' : 'team';
+  const userRole = isAssessment(groups, flags) ? 'assessment' : 'team';
 
   const { taskListSectionLocks } = useContext(SubscriptionContext);
 

--- a/src/views/User/index.tsx
+++ b/src/views/User/index.tsx
@@ -25,7 +25,7 @@ const UserInfo = () => {
             <li key={group}>{group}</li>
           ))}
         </ul>
-        <p>User is basic user: {`${user.isBasicUser(userGroups, flags)}`}</p>
+        <p>User is basic user: {`${user.isBasicUser(userGroups)}`}</p>
         <p>
           User is assessment user: {`${user.isAssessment(userGroups, flags)}`}
         </p>


### PR DESCRIPTION
# NOREF

## Changes and Description

- Require `flags` parameter for `isAssessment`, as it's needed within every context.
- Remove `flags` parameter for user utility functions that don't require flag data.

<!-- Put a description here! -->

## How to test this change

- Start the server with `scripts/dev up`
- Log in with your EUA account locally
- Downgrade yourself locally (https://app.launchdarkly.com/mint/local/features/downgradeAssessmentTeam/targeting)
- Seed the DB with `scripts/dev db:seed`
- Ensure that viewing a model plan you're not a collaborator for doesn't allow you to switch to the task list view

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
