### PR TITLE
[NOREF] - Condensed task list queries, deprecated unneeded useQuery hook

### DIFF
--- a/src/queries/GetModelPlan.ts
+++ b/src/queries/GetModelPlan.ts
@@ -15,6 +15,15 @@ export default gql`
         readyForClearanceDts
         status
       }
+      collaborators {
+        id
+        fullName
+        euaUserID
+        email
+        teamRole
+        modelPlanID
+        createdDts
+      }
       documents {
         id
         fileName

--- a/src/queries/types/GetModelPlan.ts
+++ b/src/queries/types/GetModelPlan.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ModelStatus, TaskStatus, DiscussionStatus, PrepareForClearanceStatus } from "./../../types/graphql-global-types";
+import { ModelStatus, TaskStatus, TeamRole, DiscussionStatus, PrepareForClearanceStatus } from "./../../types/graphql-global-types";
 
 // ====================================================
 // GraphQL query operation: GetModelPlan
@@ -16,6 +16,17 @@ export interface GetModelPlan_modelPlan_basics {
   modifiedDts: Time | null;
   readyForClearanceDts: Time | null;
   status: TaskStatus;
+}
+
+export interface GetModelPlan_modelPlan_collaborators {
+  __typename: "PlanCollaborator";
+  id: UUID;
+  fullName: string;
+  euaUserID: string;
+  email: string;
+  teamRole: TeamRole;
+  modelPlanID: UUID;
+  createdDts: Time;
 }
 
 export interface GetModelPlan_modelPlan_documents {
@@ -125,6 +136,7 @@ export interface GetModelPlan_modelPlan {
   archived: boolean;
   status: ModelStatus;
   basics: GetModelPlan_modelPlan_basics;
+  collaborators: GetModelPlan_modelPlan_collaborators[];
   documents: GetModelPlan_modelPlan_documents[];
   crTdls: GetModelPlan_modelPlan_crTdls[];
   discussions: GetModelPlan_modelPlan_discussions[];

--- a/src/views/ModelPlan/Documents/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/Documents/__snapshots__/index.test.tsx.snap
@@ -110,24 +110,306 @@ exports[`Model Plan Documents page matches snapshot 1`] = `
           Add a document
         </a>
         <div
-          class="margin-y-10"
-          data-testid="page-loading"
+          class=""
         >
           <div
-            class="text-center"
+            class="model-plan-table"
+            data-testid="model-plan-documents-table"
           >
-            <span
-              aria-busy="true"
-              aria-valuetext="Loading the page"
-              class="mint-spinner mint-spinner--xl"
-              role="progressbar"
-            />
+            <div
+              class="usa-table-container--scrollable"
+              data-testid="scrollable-table-container"
+            >
+              <table
+                class="usa-table usa-table--borderless src-components-Table-Table-module__fullwidth--fOyj6"
+                data-testid="table"
+              >
+                <caption
+                  class="usa-sr-only"
+                >
+                  requestsTable.caption
+                </caption>
+                <thead>
+                  <tr
+                    role="row"
+                  >
+                    <th
+                      aria-sort="none"
+                      class="table-header"
+                      colspan="1"
+                      role="columnheader"
+                      scope="col"
+                      style="min-width: 138px; padding-left: 0px; padding-bottom: .5rem; position: relative;"
+                    >
+                      <button
+                        class="usa-button usa-button--unstyled"
+                        style="cursor: pointer;"
+                        title="Toggle SortBy"
+                        type="button"
+                      >
+                        File Name
+                        <svg
+                          class="usa-icon margin-left-05 position-absolute"
+                          data-testid="caret--sort"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                          <path
+                            d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="table-header"
+                      colspan="1"
+                      role="columnheader"
+                      scope="col"
+                      style="min-width: 138px; padding-left: 0px; padding-bottom: .5rem; position: relative;"
+                    >
+                      <button
+                        class="usa-button usa-button--unstyled"
+                        style="cursor: pointer;"
+                        title="Toggle SortBy"
+                        type="button"
+                      >
+                        Document Type
+                        <svg
+                          class="usa-icon margin-left-05 position-absolute"
+                          data-testid="caret--sort"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                          <path
+                            d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="table-header"
+                      colspan="1"
+                      role="columnheader"
+                      scope="col"
+                      style="min-width: 138px; padding-left: 0px; padding-bottom: .5rem; position: relative;"
+                    >
+                      <button
+                        class="usa-button usa-button--unstyled"
+                        style="cursor: pointer;"
+                        title="Toggle SortBy"
+                        type="button"
+                      >
+                        Notes
+                        <svg
+                          class="usa-icon margin-left-05 position-absolute"
+                          data-testid="caret--sort"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                          <path
+                            d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="table-header"
+                      colspan="1"
+                      role="columnheader"
+                      scope="col"
+                      style="min-width: 138px; padding-left: 0px; padding-bottom: .5rem; position: relative;"
+                    >
+                      <button
+                        class="usa-button usa-button--unstyled"
+                        style="cursor: pointer;"
+                        title="Toggle SortBy"
+                        type="button"
+                      >
+                        Upload date
+                        <svg
+                          class="usa-icon margin-left-05 position-absolute"
+                          data-testid="caret--sort"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                          <path
+                            d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="table-header"
+                      colspan="1"
+                      role="columnheader"
+                      scope="col"
+                      style="min-width: 138px; padding-left: 0px; padding-bottom: .5rem; position: relative;"
+                    >
+                      <button
+                        class="usa-button usa-button--unstyled"
+                        style="cursor: pointer;"
+                        title="Toggle SortBy"
+                        type="button"
+                      >
+                        Visibility
+                        <svg
+                          class="usa-icon margin-left-05 position-absolute"
+                          data-testid="caret--sort"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                          <path
+                            d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                    <th
+                      aria-sort="none"
+                      class="table-header"
+                      colspan="1"
+                      role="columnheader"
+                      scope="col"
+                      style="min-width: 138px; padding-left: 0px; padding-bottom: .5rem; position: relative;"
+                    >
+                      <button
+                        class="usa-button usa-button--unstyled"
+                        style="cursor: pointer;"
+                        title="Toggle SortBy"
+                        type="button"
+                      >
+                        Actions
+                        <svg
+                          class="usa-icon margin-left-05 position-absolute"
+                          data-testid="caret--sort"
+                          focusable="false"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width="1em"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                          <path
+                            d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
+                          />
+                        </svg>
+                      </button>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  role="rowgroup"
+                >
+                  <tr
+                    role="row"
+                  >
+                    <th
+                      role="cell"
+                      scope="row"
+                      style="padding-left: 0px;"
+                    >
+                      My MINT document
+                    </th>
+                    <td
+                      role="cell"
+                      style="padding-left: 0px;"
+                    >
+                      Concept Paper
+                    </td>
+                    <td
+                      role="cell"
+                      style="padding-left: 0px;"
+                    />
+                    <td
+                      role="cell"
+                      style="padding-left: 0px;"
+                    >
+                      Invalid DateTime
+                    </td>
+                    <td
+                      role="cell"
+                      style="padding-left: 0px;"
+                    >
+                      All
+                    </td>
+                    <td
+                      role="cell"
+                      style="padding-left: 0px;"
+                    >
+                      <button
+                        class="usa-button usa-button--unstyled margin-right-1"
+                        data-testid="button"
+                        type="button"
+                      >
+                        View
+                      </button>
+                      <button
+                        class="usa-button usa-button--unstyled text-red"
+                        data-testid="remove-document"
+                        type="button"
+                      >
+                        Remove
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div
+              aria-live="polite"
+              class="usa-sr-only usa-table__announcement-region"
+            >
+              Requests table reset to default sort order
+            </div>
           </div>
-          <h1
-            class="margin-top-6 text-center"
-          >
-            Loading the page
-          </h1>
         </div>
       </div>
     </div>

--- a/src/views/ModelPlan/Documents/index.test.tsx
+++ b/src/views/ModelPlan/Documents/index.test.tsx
@@ -2,46 +2,49 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 
 import { ASSESSMENT } from 'constants/jobCodes';
 import { MessageProvider } from 'hooks/useMessage';
-import GetModelPlan from 'queries/GetModelPlan';
-import {
-  CMMIGroup,
-  CMSCenter,
-  ModelCategory,
-  ModelStatus
-} from 'types/graphql-global-types';
+import GetModelPlanDocuments from 'queries/Documents/GetModelPlanDocuments';
+import { GetModelPlanDocuments as GetModelPlanDocumentsType } from 'queries/Documents/types/GetModelPlanDocuments';
+import { DocumentType } from 'types/graphql-global-types';
 
 import { DocumentsContent } from './index';
+
+const docMock: GetModelPlanDocumentsType = {
+  modelPlan: {
+    __typename: 'ModelPlan',
+    id: 'f11eb129-2c80-4080-9440-439cbe1a286f',
+    isCollaborator: true,
+    documents: [
+      {
+        __typename: 'PlanDocument',
+        id: '123',
+        virusScanned: true,
+        virusClean: true,
+        fileName: 'My MINT document',
+        fileType: '',
+        downloadUrl: '',
+        restricted: false,
+        documentType: DocumentType.CONCEPT_PAPER,
+        createdDts: '',
+        optionalNotes: '',
+        otherType: ''
+      }
+    ]
+  }
+};
 
 const mocks = [
   {
     request: {
-      query: GetModelPlan,
+      query: GetModelPlanDocuments,
       variables: { id: 'f11eb129-2c80-4080-9440-439cbe1a286f' }
     },
     result: {
-      data: {
-        modelPlan: {
-          modelName: 'My excellent plan that I just initiated',
-          __typename: 'ModelPlan',
-          id: 'f11eb129-2c80-4080-9440-439cbe1a286f',
-          status: ModelStatus.PLAN_DRAFT,
-          modelCategory: ModelCategory.PRIMARY_CARE_TRANSFORMATION,
-          cmmiGroups: [
-            CMMIGroup.STATE_INNOVATIONS_GROUP,
-            CMMIGroup.POLICY_AND_PROGRAMS_GROUP
-          ],
-          cmsCenters: [CMSCenter.CENTER_FOR_MEDICARE, CMSCenter.OTHER],
-          cmsOther: 'The Center for Awesomeness ',
-          archived: false,
-          basics: null,
-          documents: []
-        }
-      }
+      data: docMock
     }
   }
 ];
@@ -74,6 +77,11 @@ describe('Model Plan Documents page', () => {
         </MockedProvider>
       </MemoryRouter>
     );
+
+    await waitFor(() => {
+      expect(screen.getByText('My MINT document')).toBeInTheDocument();
+    });
+
     await waitFor(() => {
       expect(asFragment()).toMatchSnapshot();
     });

--- a/src/views/ModelPlan/Documents/index.tsx
+++ b/src/views/ModelPlan/Documents/index.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, Route, Switch, useParams } from 'react-router-dom';
-import { useQuery } from '@apollo/client';
 import {
   Breadcrumb,
   BreadcrumbBar,
@@ -17,12 +16,7 @@ import PageHeading from 'components/PageHeading';
 import Alert from 'components/shared/Alert';
 import Expire from 'components/shared/Expire';
 import useMessage from 'hooks/useMessage';
-import GetModelPlan from 'queries/GetModelPlan';
-import {
-  GetModelPlan as GetModelPlanType,
-  GetModelPlan_modelPlan as GetModelPlanTypes,
-  GetModelPlanVariables
-} from 'queries/types/GetModelPlan';
+import { ModelInfoContext } from 'views/ModelInfoWrapper';
 import NotFound from 'views/NotFound';
 
 import AddDocument from './AddDocument';
@@ -40,16 +34,7 @@ export const DocumentsContent = () => {
     'error'
   );
 
-  const { data } = useQuery<GetModelPlanType, GetModelPlanVariables>(
-    GetModelPlan,
-    {
-      variables: {
-        id: modelID
-      }
-    }
-  );
-
-  const modelPlan = data?.modelPlan || ({} as GetModelPlanTypes);
+  const { modelName } = useContext(ModelInfoContext);
 
   return (
     <MainContent data-testid="model-documents">
@@ -97,7 +82,7 @@ export const DocumentsContent = () => {
             className="margin-top-0 margin-bottom-2 font-body-lg"
             data-testid="model-plan-name"
           >
-            {h('for')} {modelPlan.modelName}
+            {h('for')} {modelName}
           </p>
 
           <p className="margin-bottom-2 font-body-md line-height-body-4">

--- a/src/views/ModelPlan/Status/index.tsx
+++ b/src/views/ModelPlan/Status/index.tsx
@@ -1,7 +1,7 @@
-import React, { useRef } from 'react';
+import React, { useContext, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
-import { useMutation, useQuery } from '@apollo/client';
+import { useMutation } from '@apollo/client';
 import {
   Breadcrumb,
   BreadcrumbBar,
@@ -20,12 +20,11 @@ import MainContent from 'components/MainContent';
 import PageHeading from 'components/PageHeading';
 import FieldGroup from 'components/shared/FieldGroup';
 import modelStatus from 'constants/enums/modelPlanStatuses';
-import GetModelPlan from 'queries/GetModelPlan';
-import { GetModelPlan as GetModelPlanType } from 'queries/types/GetModelPlan';
 import { UpdateModelPlan as UpdateModelPlanType } from 'queries/types/UpdateModelPlan';
 import UpdateModelPlan from 'queries/UpdateModelPlan';
 import { ModelStatus } from 'types/graphql-global-types';
 import { translateModelPlanStatus } from 'utils/modelPlan';
+import { ModelInfoContext } from 'views/ModelInfoWrapper';
 
 type StatusFormProps = {
   status: ModelStatus | undefined;
@@ -42,13 +41,7 @@ const Status = () => {
     status: Yup.string().required('Enter a role for this team member')
   });
 
-  const { data } = useQuery<GetModelPlanType>(GetModelPlan, {
-    variables: {
-      id: modelID
-    }
-  });
-
-  const { status } = data?.modelPlan || {};
+  const { status } = useContext(ModelInfoContext);
 
   const [update] = useMutation<UpdateModelPlanType>(UpdateModelPlan);
 

--- a/src/views/ModelPlan/TaskList/index.test.tsx
+++ b/src/views/ModelPlan/TaskList/index.test.tsx
@@ -48,6 +48,7 @@ describe('The Model Plan Task List', () => {
         fileName: 'test.pdf'
       }
     ],
+    collaborators: [],
     discussions: [
       {
         __typename: 'PlanDiscussion',

--- a/src/views/ModelPlan/TaskList/index.tsx
+++ b/src/views/ModelPlan/TaskList/index.tsx
@@ -29,11 +29,6 @@ import PageHeading from 'components/PageHeading';
 import PageLoading from 'components/PageLoading';
 import Divider from 'components/shared/Divider';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
-// import GetModelPlanCollaborators from 'queries/Collaborators/GetModelCollaborators';
-// import {
-//   GetModelCollaborators,
-//   GetModelCollaborators_modelPlan_collaborators as GetCollaboratorsType
-// } from 'queries/Collaborators/types/GetModelCollaborators';
 import GetModelPlan from 'queries/GetModelPlan';
 import { TaskListSubscription_onLockTaskListSectionContext_lockStatus as LockSectionType } from 'queries/TaskListSubscription/types/TaskListSubscription';
 import {

--- a/src/views/ModelPlan/TaskList/index.tsx
+++ b/src/views/ModelPlan/TaskList/index.tsx
@@ -29,11 +29,11 @@ import PageHeading from 'components/PageHeading';
 import PageLoading from 'components/PageLoading';
 import Divider from 'components/shared/Divider';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
-import GetModelPlanCollaborators from 'queries/Collaborators/GetModelCollaborators';
-import {
-  GetModelCollaborators,
-  GetModelCollaborators_modelPlan_collaborators as GetCollaboratorsType
-} from 'queries/Collaborators/types/GetModelCollaborators';
+// import GetModelPlanCollaborators from 'queries/Collaborators/GetModelCollaborators';
+// import {
+//   GetModelCollaborators,
+//   GetModelCollaborators_modelPlan_collaborators as GetCollaboratorsType
+// } from 'queries/Collaborators/types/GetModelCollaborators';
 import GetModelPlan from 'queries/GetModelPlan';
 import { TaskListSubscription_onLockTaskListSectionContext_lockStatus as LockSectionType } from 'queries/TaskListSubscription/types/TaskListSubscription';
 import {
@@ -140,20 +140,9 @@ const TaskList = () => {
     beneficiaries,
     payments,
     operationalNeeds = [],
-    prepareForClearance
+    prepareForClearance,
+    collaborators
   } = modelPlan;
-
-  const { data: collaboratorData } = useQuery<GetModelCollaborators>(
-    GetModelPlanCollaborators,
-    {
-      variables: {
-        id: modelID
-      }
-    }
-  );
-
-  const collaborators = (collaboratorData?.modelPlan?.collaborators ??
-    []) as GetCollaboratorsType[];
 
   const getITSolutionsStatus = (
     operationalNeedsArray: OperationalNeedsType[]


### PR DESCRIPTION
# NOREF

## Changes and Description

- Condensed `GetModelPlanCollabotors` and `GetModelPlan` queries on task list
- Deprecated unneeded `useQuery` hook in favor of `useContext` within `ModelInfoWrapper`


## How to test this change

- Run FE tests
- Check data is intact with collaborators in task list

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
