### PR TITLE
EASI-2461 Operational Solutions Data Loader allow empty

### DIFF
--- a/pkg/graph/resolvers/operational_solution_test.go
+++ b/pkg/graph/resolvers/operational_solution_test.go
@@ -67,6 +67,16 @@ func (suite *ResolverSuite) TestOperationalSolutionLoader() {
 	err := g.Wait()
 	suite.NoError(err)
 }
+func (suite *ResolverSuite) TestOperationalSolutionLoaderNotNeeded() {
+	numModels := 1
+	opNeedIds := makeMulipleModelsAndReturnNeedIDs(suite, numModels)
+
+	opSols, err := OperationaSolutionsAndPossibleGetByOPNeedIDLOADER(suite.testConfigs.Context, opNeedIds[0], false)
+	suite.Len(opSols, 0) // Should be an empty array, because there are no solutions at this point
+
+	suite.NoError(err)
+
+}
 
 func verifySolutionsLoader(ctx context.Context, operationalNeedID uuid.UUID) error { //TODO make this more robust, as we can't assert at this level
 	opSols, err := OperationaSolutionsAndPossibleGetByOPNeedIDLOADER(ctx, operationalNeedID, true)

--- a/pkg/storage/loaders/operational_solutions_loader.go
+++ b/pkg/storage/loaders/operational_solutions_loader.go
@@ -47,13 +47,10 @@ func (loaders *DataLoaders) GetOperationalSolutionAndPossibleCollectionByOperati
 		if ok {
 
 			resKey := fmt.Sprint(ck.Args["operational_need_id"])
-			sols, ok := solsByID[resKey]
-			if ok {
-				output[index] = &dataloader.Result{Data: sols, Error: nil}
-			} else {
-				err := fmt.Errorf("operational solutions not found for operationalNeed  %s", resKey)
-				output[index] = &dataloader.Result{Data: nil, Error: err}
-			}
+			sols := solsByID[resKey] //Any Solutions not found will return a zero state result eg empty array
+
+			output[index] = &dataloader.Result{Data: sols, Error: nil}
+
 		} else {
 			err := fmt.Errorf("could not retrive key from %s", key.String())
 			output[index] = &dataloader.Result{Data: nil, Error: err}


### PR DESCRIPTION
# EASI-2461

## Changes and Description

- Remove check for value in data loader logic
    - If there isn't a result, it will return the `ZERO` value of the object ( an empty `[]*models.OperationalSolution{}`
- Unit Test to assert this behavior

## How to test this change
You can test this two ways,
1. Load the front end, and go to the IT lead section
     a. Assert that there are no errors when the page loads
2. Make a model plan, and query it for needs and solutions with include not needed = `false`
    a. Assert that there are no errors
```GQL
   query ModelPlan{  
  modelPlan(id:"{{modelPlanID}}"){
    id
    modelName
    isCollaborator
    operationalNeeds { 
        id
        modelPlanID
        name
        key
        # section
        nameOther
        needed
        solutions(includeNotNeeded:false) {
        id
        operationalNeedID        
        name
        key   
        needed
        nameOther
        pocEmail
        pocName     
        createdBy
        createdDts
    }
    }
  }
}
``` 
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
