### PR TITLE
[EASI-2646] - Document upload and alert updates

### DIFF
--- a/src/components/ITToolsWarning/__snapshots__/index.test.tsx.snap
+++ b/src/components/ITToolsWarning/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`The ITToolsWarning component matches snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="usa-alert usa-alert--warning it-tools-warning"
+    class="usa-alert usa-alert--warning flex it-tools-warning"
     data-testid="alert"
   >
     <div

--- a/src/components/ITToolsWarning/index.tsx
+++ b/src/components/ITToolsWarning/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Alert, Button } from '@trussworks/react-uswds';
+import { Button } from '@trussworks/react-uswds';
 import classNames from 'classnames';
 import { useFlags } from 'launchdarkly-react-client-sdk';
+
+import Alert from 'components/shared/Alert';
 
 import './index.scss';
 

--- a/src/components/shared/Alert/__snapshots__/index.test.tsx.snap
+++ b/src/components/shared/Alert/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The Alert component matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="usa-alert usa-alert--info mint-alert-text flex"
+    data-testid="alert"
+  >
+    <div
+      class="usa-alert__body"
+    >
+      <h4
+        class="usa-alert__heading"
+      >
+        Info Alert
+      </h4>
+      <p
+        class="usa-alert__text"
+      >
+        This is information
+        <button
+          aria-label="Close Button"
+          class="usa-button usa-button usa-button--unstyled text-no-underline text-black flex-align-end"
+          data-testid="button"
+          role="button"
+          tabindex="0"
+          type="button"
+        >
+          ✕
+        </button>
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/shared/Alert/index.scss
+++ b/src/components/shared/Alert/index.scss
@@ -1,0 +1,11 @@
+.usa-alert__body {
+    padding-right: 2rem !important;
+    max-width: 100% !important;
+}
+
+.mint-alert-text {
+    .usa-alert__text {
+        justify-content: space-between !important;
+        display: flex !important;
+    }
+}

--- a/src/components/shared/Alert/index.test.tsx
+++ b/src/components/shared/Alert/index.test.tsx
@@ -1,61 +1,35 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 
-import Alert, { AlertText } from './index';
+import Alert from './index';
 
 describe('The Alert component', () => {
-  it('renders without crashing', () => {
-    shallow(<Alert type="success" />);
-  });
-
-  it('renders a heading', () => {
-    const component = shallow(<Alert type="success" heading="Hello" />);
-
-    expect(component.find('h3').exists()).toEqual(true);
-    expect(component.find('h3').text()).toEqual('Hello');
-  });
-
-  describe('children', () => {
-    it('renders string children', () => {
-      const component = mount(<Alert type="success">Hello</Alert>);
-
-      expect(component.find('p').exists()).toEqual(true);
-      expect(component.find('p').text()).toEqual('Hello');
-    });
-  });
-
-  it('renders JSX children', () => {
-    const component = shallow(
-      <Alert type="success">
-        <div data-testid="test-child">Hello</div>
+  it('renders a closable information alert', async () => {
+    const { getByRole } = render(
+      <Alert type="info" isClosable heading="Info Alert">
+        This is information
       </Alert>
     );
 
-    expect(component.find('p').exists()).toEqual(false);
-    expect(component.find('[data-testid="test-child"]').text()).toEqual(
-      'Hello'
-    );
-  });
-});
-
-describe('The AlertText component', () => {
-  it('renders without crashing', () => {
-    shallow(<AlertText>Hello</AlertText>);
+    expect(getByRole('button', { name: /Close Button/ })).toBeInTheDocument();
   });
 
-  it('renders custom class name', () => {
-    const component = shallow(
-      <AlertText className="test-class">Hello</AlertText>
+  it('renders a closable default success alert', async () => {
+    const { getByRole } = render(
+      <Alert type="success" heading="Success Alert">
+        This is successful
+      </Alert>
     );
 
-    expect(component.find('.test-class').exists()).toEqual(true);
+    expect(getByRole('button', { name: /Close Button/ })).toBeInTheDocument();
   });
 
-  it('renders custom HTML attributes', () => {
-    const component = shallow(
-      <AlertText aria-label="I am aria label">Hello</AlertText>
+  it('matches snapshot', async () => {
+    const { asFragment } = render(
+      <Alert type="info" isClosable heading="Info Alert">
+        This is information
+      </Alert>
     );
-
-    expect(component.props()['aria-label']).toEqual('I am aria label');
+    expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/src/components/shared/Alert/index.tsx
+++ b/src/components/shared/Alert/index.tsx
@@ -1,31 +1,24 @@
-import React from 'react';
+/*
+Wrapper for Truss' <Alert> component to allow for manually closing the component
+*/
+
+import React, { useState } from 'react';
+import { Alert as TrussAlert, Button } from '@trussworks/react-uswds';
 import classnames from 'classnames';
+
+import './index.scss';
 
 type AlertProps = {
   type: 'success' | 'warning' | 'error' | 'info';
   heading?: React.ReactNode;
   children?: React.ReactNode;
+  'data-testid'?: string;
   slim?: boolean;
   noIcon?: boolean;
   inline?: boolean;
+  isClosable?: boolean;
 } & JSX.IntrinsicElements['div'];
 
-type AlertTextProps = {
-  className?: string;
-  children: React.ReactNode;
-} & JSX.IntrinsicElements['p'];
-
-export const AlertText = ({
-  className,
-  children,
-  ...props
-}: AlertTextProps) => {
-  return (
-    <p className={classnames('usa-alert__text', className)} {...props}>
-      {children}
-    </p>
-  );
-};
 export const Alert = ({
   type,
   heading,
@@ -34,39 +27,48 @@ export const Alert = ({
   noIcon,
   className,
   inline,
+  // Default to closable button if type = success or error
+  isClosable = type === 'success' || type === 'error',
   ...props
 }: AlertProps & React.HTMLAttributes<HTMLDivElement>): React.ReactElement => {
   const classes = classnames(
-    'usa-alert',
     {
-      'usa-alert--success': type === 'success',
-      'usa-alert--warning': type === 'warning',
-      'usa-alert--error': type === 'error',
-      'usa-alert--info': type === 'info',
-      'usa-alert--slim': slim,
-      'usa-alert--no-icon': noIcon,
-      'mint-inline-alert': inline
+      'mint-inline-alert': inline,
+      'mint-alert-text': isClosable
     },
+    'flex',
     className
   );
 
-  const renderChildren = () => {
-    if (children) {
-      if (typeof children === 'string') {
-        return <AlertText>{children}</AlertText>;
-      }
-      return children;
-    }
-    return <></>;
-  };
+  const [isClosed, setClosed] = useState<boolean>(false);
 
   return (
-    <div className={classes} data-testid="alert" {...props}>
-      <div className="usa-alert__body">
-        {heading && <h3 className="usa-alert__heading">{heading}</h3>}
-        {renderChildren()}
-      </div>
-    </div>
+    <>
+      {!isClosed && (
+        <TrussAlert
+          type={type}
+          heading={heading}
+          slim={slim}
+          noIcon={noIcon}
+          className={classes}
+          {...props}
+        >
+          {children}
+          {isClosable && (
+            <Button
+              type="button"
+              role="button"
+              className="usa-button usa-button--unstyled text-no-underline text-black flex-align-end"
+              tabIndex={0}
+              aria-label="Close Button"
+              onClick={() => setClosed(true)}
+            >
+              &#10005;
+            </Button>
+          )}
+        </TrussAlert>
+      )}
+    </>
   );
 };
 

--- a/src/i18n/en-US/draftModelPlan/documents.ts
+++ b/src/i18n/en-US/draftModelPlan/documents.ts
@@ -24,6 +24,9 @@ const documents = {
       body: 'Failed to fetch Model Plan documents'
     }
   },
+  requiredHint: 'All fields marked with ',
+  requiredHint2: ' are required',
+  fileTypes: 'Select a PDF, DOC, DOCX, XLS, or XLSX',
   uploadError: {
     heading: 'There is a problem',
     body:

--- a/src/views/ModelPlan/CRTDL/CRTDLs/index.tsx
+++ b/src/views/ModelPlan/CRTDL/CRTDLs/index.tsx
@@ -69,10 +69,10 @@ export const CRTDLs = () => {
             <Breadcrumb current>{t('heading')}</Breadcrumb>
           </BreadcrumbBar>
 
-          {message && <Expire delay={4000}>{message}</Expire>}
+          {message && <Expire delay={45000}>{message}</Expire>}
 
           {crtdlMessage && (
-            <Expire delay={4000}>
+            <Expire delay={45000}>
               <Alert
                 type={crtdlStatus}
                 slim

--- a/src/views/ModelPlan/Collaborators/AddCollaborator/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/Collaborators/AddCollaborator/__snapshots__/index.test.tsx.snap
@@ -119,17 +119,21 @@ exports[`Adding a collaborator page matches snapshot 1`] = `
             </select>
           </div>
           <div
-            class="usa-alert usa-alert--info usa-alert--slim margin-y-4"
+            class="usa-alert usa-alert--info usa-alert--slim flex margin-y-4"
             data-testid="mandatory-fields-alert"
           >
             <div
               class="usa-alert__body"
             >
-              <span
-                class="mandatory-fields-alert__text"
+              <p
+                class="usa-alert__text"
               >
-                This team member will be able to view and edit anything about a model plan. Please make sure this individual should be able to do this before you proceed.
-              </span>
+                <span
+                  class="mandatory-fields-alert__text"
+                >
+                  This team member will be able to view and edit anything about a model plan. Please make sure this individual should be able to do this before you proceed.
+                </span>
+              </p>
             </div>
           </div>
           <div

--- a/src/views/ModelPlan/Collaborators/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/Collaborators/__snapshots__/index.test.tsx.snap
@@ -71,17 +71,20 @@ exports[`Collaborator/Team Member page w/table matches snapshot 1`] = `
             Add team member
           </a>
           <div
-            class="usa-alert usa-alert--info"
+            class="usa-alert usa-alert--info flex"
             data-testid="alert"
           >
             <div
               class="usa-alert__body"
             >
-              <h3
+              <h4
                 class="usa-alert__heading"
               >
                 No associated team members
-              </h3>
+              </h4>
+              <p
+                class="usa-alert__text"
+              />
             </div>
           </div>
           <div

--- a/src/views/ModelPlan/Discussions/index.tsx
+++ b/src/views/ModelPlan/Discussions/index.tsx
@@ -229,7 +229,7 @@ const Discussions = ({ modelID, askAQuestion, readOnly }: DiscussionsProps) => {
 
         {/* General error message for mutations that expires after 3 seconds */}
         {discussionStatusMessage && (
-          <Expire delay={3000} callback={setDiscussionStatusMessage}>
+          <Expire delay={45000} callback={setDiscussionStatusMessage}>
             <Alert className="margin-bottom-4" type={discussionStatus}>
               {discussionStatusMessage}
             </Alert>
@@ -451,7 +451,7 @@ const Discussions = ({ modelID, askAQuestion, readOnly }: DiscussionsProps) => {
 
         {/* General error message for mutations that expires after 3 seconds */}
         {discussionStatusMessage && (
-          <Expire delay={3000} callback={setDiscussionStatusMessage}>
+          <Expire delay={45000} callback={setDiscussionStatusMessage}>
             <Alert type={discussionStatus} className="margin-bottom-4">
               {discussionStatusMessage}
             </Alert>

--- a/src/views/ModelPlan/Documents/AddDocument/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/Documents/AddDocument/__snapshots__/index.test.tsx.snap
@@ -80,6 +80,17 @@ exports[`Model Plan Add Documents page matches snapshot 1`] = `
         >
           Choose a document to upload, such as a recent concept document, policy paper, or any additional model background information.
         </p>
+        <p
+          class="margin-bottom-2 font-body-md line-height-body-4"
+        >
+          All fields marked with  
+          <span
+            class="text-red margin-x-05"
+          >
+            *
+          </span>
+            are required
+        </p>
         <div>
           <div>
             <form
@@ -95,6 +106,21 @@ exports[`Model Plan Add Documents page matches snapshot 1`] = `
                   for="FileUpload-File"
                 >
                   Document upload
+                  <span
+                    class="text-red margin-x-05"
+                  >
+                    *
+                  </span>
+                </label>
+                <label
+                  class="usa-label text-normal text-base margin-y-1"
+                  data-testid="label"
+                  for="FileUpload-File"
+                >
+                  Select a PDF, DOC, DOCX, XLS, or XLSX
+                  <span
+                    class="usa-hint"
+                  />
                 </label>
                 <div
                   aria-disabled="false"
@@ -154,6 +180,11 @@ exports[`Model Plan Add Documents page matches snapshot 1`] = `
                     class="usa-label"
                   >
                     What type of document are you uploading?
+                    <span
+                      class="text-red margin-x-05"
+                    >
+                      *
+                    </span>
                   </legend>
                   <div
                     class="usa-radio"
@@ -252,6 +283,11 @@ exports[`Model Plan Add Documents page matches snapshot 1`] = `
                   for="document-upload-restricted-yes"
                 >
                   Does this document contain cost information?
+                  <span
+                    class="text-red margin-x-05"
+                  >
+                    *
+                  </span>
                 </label>
                 <p
                   class="margin-0 line-height-body-4"
@@ -323,17 +359,21 @@ exports[`Model Plan Add Documents page matches snapshot 1`] = `
                 class="padding-top-2 margin-top-2"
               >
                 <div
-                  class="usa-alert usa-alert--info usa-alert--slim margin-bottom-4"
+                  class="usa-alert usa-alert--info usa-alert--slim flex margin-bottom-4"
                   data-testid="mandatory-fields-alert"
                 >
                   <div
                     class="usa-alert__body"
                   >
-                    <span
-                      class="mandatory-fields-alert__text"
+                    <p
+                      class="usa-alert__text"
                     >
-                      To keep CMS safe, documents are scanned for viruses after uploading. If something goes wrong, we’ll let you know
-                    </span>
+                      <span
+                        class="mandatory-fields-alert__text"
+                      >
+                        To keep CMS safe, documents are scanned for viruses after uploading. If something goes wrong, we’ll let you know
+                      </span>
+                    </p>
                   </div>
                 </div>
                 <button

--- a/src/views/ModelPlan/Documents/AddDocument/documentUpload.tsx
+++ b/src/views/ModelPlan/Documents/AddDocument/documentUpload.tsx
@@ -11,6 +11,7 @@ import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
 import { RadioField } from 'components/shared/RadioField';
+import RequiredAsterisk from 'components/shared/RequiredAsterisk';
 import TextAreaField from 'components/shared/TextAreaField';
 import TextField from 'components/shared/TextField';
 import useMessage from 'hooks/useMessage';
@@ -141,8 +142,19 @@ const DocumentUpload = () => {
                   <FieldGroup scrollElement="file" error={!!flatErrors.file}>
                     <Label htmlFor="FileUpload-File">
                       {t('documentUpload')}
+                      <RequiredAsterisk />
                     </Label>
+
+                    <Label
+                      htmlFor="FileUpload-File"
+                      hint
+                      className="text-normal text-base margin-y-1"
+                    >
+                      {t('fileTypes')}
+                    </Label>
+
                     <FieldErrorMsg>{flatErrors.file}</FieldErrorMsg>
+
                     <Field
                       as={FileUpload}
                       id="FileUpload-File"
@@ -163,7 +175,10 @@ const DocumentUpload = () => {
                     error={!!flatErrors.documentType}
                   >
                     <fieldset className="usa-fieldset margin-top-4">
-                      <legend className="usa-label">{t('whatType')}</legend>
+                      <legend className="usa-label">
+                        {t('whatType')}
+                        <RequiredAsterisk />
+                      </legend>
                       <FieldErrorMsg>{flatErrors.documentType}</FieldErrorMsg>
                       {(Object.keys(DocumentType) as Array<
                         keyof typeof DocumentType
@@ -197,7 +212,7 @@ const DocumentUpload = () => {
                         value="OTHER"
                       />
                       {values.documentType === 'OTHER' && (
-                        <div className="width-card-lg margin-left-4 margin-bottom-1">
+                        <div className="margin-left-4 margin-bottom-1">
                           <FieldGroup
                             scrollElement="otherTypeDescription"
                             error={!!flatErrors.otherTypeDescription}
@@ -207,6 +222,7 @@ const DocumentUpload = () => {
                               className="margin-bottom-1"
                             >
                               {t('documentKind')}
+                              <RequiredAsterisk />
                             </Label>
                             <FieldErrorMsg>
                               {flatErrors.otherTypeDescription}
@@ -233,6 +249,7 @@ const DocumentUpload = () => {
                       className="maxw-none"
                     >
                       {t('costQuestion')}
+                      <RequiredAsterisk />
                     </Label>
 
                     <p className="margin-0 line-height-body-4">
@@ -301,7 +318,12 @@ const DocumentUpload = () => {
                     <Button
                       type="submit"
                       onClick={() => setErrors({})}
-                      disabled={isSubmitting || !values.file}
+                      disabled={
+                        isSubmitting ||
+                        !values.file ||
+                        !values.documentType ||
+                        values.restricted === null
+                      }
                       data-testid="upload-document"
                     >
                       {t('uploadButton')}

--- a/src/views/ModelPlan/Documents/AddDocument/documentUpload.tsx
+++ b/src/views/ModelPlan/Documents/AddDocument/documentUpload.tsx
@@ -322,7 +322,9 @@ const DocumentUpload = () => {
                         isSubmitting ||
                         !values.file ||
                         !values.documentType ||
-                        values.restricted === null
+                        values.restricted === null ||
+                        (values.documentType === DocumentType.OTHER &&
+                          !values.otherTypeDescription.trim())
                       }
                       data-testid="upload-document"
                     >

--- a/src/views/ModelPlan/Documents/AddDocument/index.tsx
+++ b/src/views/ModelPlan/Documents/AddDocument/index.tsx
@@ -13,6 +13,7 @@ import {
 
 import MainContent from 'components/MainContent';
 import PageHeading from 'components/PageHeading';
+import RequiredAsterisk from 'components/shared/RequiredAsterisk';
 
 import DocumentUpload from './documentUpload';
 
@@ -58,6 +59,10 @@ const AddDocument = () => {
 
           <p className="margin-bottom-2 font-body-md line-height-body-4">
             {t('uploadDescription')}
+          </p>
+
+          <p className="margin-bottom-2 font-body-md line-height-body-4">
+            {t('requiredHint')} <RequiredAsterisk /> {t('requiredHint2')}
           </p>
 
           <DocumentUpload />

--- a/src/views/ModelPlan/Documents/index.tsx
+++ b/src/views/ModelPlan/Documents/index.tsx
@@ -57,10 +57,10 @@ export const DocumentsContent = () => {
             <Breadcrumb current>{t('heading')}</Breadcrumb>
           </BreadcrumbBar>
 
-          {message && <Expire delay={4000}>{message}</Expire>}
+          {message && <Expire delay={45000}>{message}</Expire>}
 
           {documentMessage && (
-            <Expire delay={4000}>
+            <Expire delay={45000}>
               <Alert
                 type={documentStatus}
                 slim

--- a/src/views/ModelPlan/ModelPlanOverview/index.tsx
+++ b/src/views/ModelPlan/ModelPlanOverview/index.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import {
-  Alert,
   Button,
   Grid,
   GridContainer,
@@ -18,6 +17,7 @@ import MainContent from 'components/MainContent';
 import NDABanner from 'components/NDABanner';
 import PageHeading from 'components/PageHeading';
 import PageLoading from 'components/PageLoading';
+import Alert from 'components/shared/Alert';
 import useFavoritePlan from 'hooks/useFavoritePlan';
 import useMessage from 'hooks/useMessage';
 import GetAllModelPlans from 'queries/ReadOnly/GetAllModelPlans';

--- a/src/views/ModelPlan/NewPlan/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/NewPlan/__snapshots__/index.test.tsx.snap
@@ -52,17 +52,21 @@ exports[`New Model Plan page matches snapshot 1`] = `
           Model name
         </h1>
         <div
-          class="usa-alert usa-alert--info usa-alert--slim margin-bottom-4"
+          class="usa-alert usa-alert--info usa-alert--slim flex margin-bottom-4"
           data-testid="mandatory-fields-alert"
         >
           <div
             class="usa-alert__body"
           >
-            <span
-              class="mandatory-fields-alert__text"
+            <p
+              class="usa-alert__text"
             >
-              This is not a permanent name. If needed, you may update it later.
-            </span>
+              <span
+                class="mandatory-fields-alert__text"
+              >
+                This is not a permanent name. If needed, you may update it later.
+              </span>
+            </p>
           </div>
         </div>
         <form

--- a/src/views/ModelPlan/ReadOnly/CRTDLs/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/CRTDLs/index.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Alert, Link } from '@trussworks/react-uswds';
+import { Link } from '@trussworks/react-uswds';
 
+import Alert from 'components/shared/Alert';
 import Expire from 'components/shared/Expire';
 import CRTDLTable from 'views/ModelPlan/CRTDL/CRTDLs/table';
 
@@ -30,7 +31,7 @@ const ReadOnlyCRTDLs = ({
       </p>
 
       {crtdlMessage && (
-        <Expire delay={4000}>
+        <Expire delay={45000}>
           <Alert
             type={crtdlStatus}
             slim

--- a/src/views/ModelPlan/ReadOnly/Documents/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/Documents/index.tsx
@@ -31,7 +31,7 @@ const ReadOnlyDocuments = ({
       </div>
 
       {documentMessage && (
-        <Expire delay={4000}>
+        <Expire delay={45000}>
           <Alert
             type={documentStatus}
             slim

--- a/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
@@ -333,7 +333,7 @@ exports[`Read Only Model Plan Summary matches snapshot 1`] = `
       data-testid="section-wrapper"
     >
       <div
-        class="usa-alert usa-alert--warning margin-bottom-5 desktop:margin-y-3"
+        class="usa-alert usa-alert--warning flex margin-bottom-5 desktop:margin-y-3"
         data-testid="alert"
       >
         <div

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -4,7 +4,6 @@ import { RootStateOrAny, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import {
-  Alert,
   Button,
   Grid,
   GridContainer,
@@ -20,6 +19,7 @@ import UswdsReactLink from 'components/LinkWrapper';
 import MainContent from 'components/MainContent';
 import ModelSubNav from 'components/ModelSubNav';
 import PageHeading from 'components/PageHeading';
+import Alert from 'components/shared/Alert';
 import CollapsableLink from 'components/shared/CollapsableLink';
 import {
   DescriptionDefinition,

--- a/src/views/ModelPlan/TaskList/Basics/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/Basics/__snapshots__/index.test.tsx.snap
@@ -97,17 +97,21 @@ exports[`Model Plan Documents page matches snapshot 1`] = `
           </div>
         </div>
         <div
-          class="usa-alert usa-alert--info usa-alert--slim margin-bottom-4"
+          class="usa-alert usa-alert--info usa-alert--slim flex margin-bottom-4"
           data-testid="mandatory-fields-alert"
         >
           <div
             class="usa-alert__body"
           >
-            <span
-              class="mandatory-fields-alert__text"
+            <p
+              class="usa-alert__text"
             >
-              All fields are mandatory
-            </span>
+              <span
+                class="mandatory-fields-alert__text"
+              >
+                All fields are mandatory
+              </span>
+            </p>
           </div>
         </div>
         <div

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/KeyCharacteristics/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/KeyCharacteristics/__snapshots__/index.test.tsx.snap
@@ -107,17 +107,21 @@ exports[`Model Plan Characteristics matches snapshot 1`] = `
         What type of Alternative Payment Model (APM) do you think the model could be?
       </legend>
       <div
-        class="usa-alert usa-alert--info usa-alert--slim"
+        class="usa-alert usa-alert--info usa-alert--slim flex"
         data-testid="mandatory-fields-alert"
       >
         <div
           class="usa-alert__body"
         >
-          <span
-            class="mandatory-fields-alert__text"
+          <p
+            class="usa-alert__text"
           >
-            In order to be considered by the Quality Payment Program (QPP), and to be MIPS or Advanced APM, you will need to collect TINs and NPIs for providers.
-          </span>
+            <span
+              class="mandatory-fields-alert__text"
+            >
+              In order to be considered by the Quality Payment Program (QPP), and to be MIPS or Advanced APM, you will need to collect TINs and NPIs for providers.
+            </span>
+          </p>
         </div>
       </div>
       <fieldset

--- a/src/views/ModelPlan/TaskList/ITSolutions/AddCustomSolution/index.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/AddCustomSolution/index.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
-  Alert,
   Breadcrumb,
   BreadcrumbBar,
   BreadcrumbLink,
@@ -19,6 +18,7 @@ import { Field, Form, Formik, FormikProps } from 'formik';
 import AskAQuestion from 'components/AskAQuestion';
 import UswdsReactLink from 'components/LinkWrapper';
 import PageHeading from 'components/PageHeading';
+import Alert from 'components/shared/Alert';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';

--- a/src/views/ModelPlan/TaskList/ITSolutions/AddSolution/index.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/AddSolution/index.tsx
@@ -9,7 +9,6 @@ import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
-  Alert,
   Breadcrumb,
   BreadcrumbBar,
   BreadcrumbLink,
@@ -25,6 +24,7 @@ import { Field, Form, Formik, FormikProps } from 'formik';
 import AskAQuestion from 'components/AskAQuestion';
 import UswdsReactLink from 'components/LinkWrapper';
 import PageHeading from 'components/PageHeading';
+import Alert from 'components/shared/Alert';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';

--- a/src/views/ModelPlan/TaskList/ITSolutions/Home/index.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Home/index.tsx
@@ -49,7 +49,7 @@ const ITSolutionsHome = () => {
         <Breadcrumb current>{t('breadcrumb')}</Breadcrumb>
       </BreadcrumbBar>
 
-      <Expire delay={4000}>{message}</Expire>
+      <Expire delay={45000}>{message}</Expire>
 
       <PageHeading className="margin-top-4 margin-bottom-2">
         {t('heading')}

--- a/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
@@ -19,17 +19,14 @@ import {
   useTable
 } from 'react-table';
 import { useQuery } from '@apollo/client';
-import {
-  Alert,
-  IconArrowForward,
-  Table as UswdsTable
-} from '@trussworks/react-uswds';
+import { IconArrowForward, Table as UswdsTable } from '@trussworks/react-uswds';
 import classNames from 'classnames';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 import { DateTime } from 'luxon';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import PageLoading from 'components/PageLoading';
+import Alert from 'components/shared/Alert';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import GlobalClientFilter from 'components/TableFilter';
 import TablePagination from 'components/TablePagination';

--- a/src/views/ModelPlan/TaskList/ITSolutions/SelectSolutions/index.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/SelectSolutions/index.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
-  Alert,
   Button,
   CardGroup,
   Grid,
@@ -19,6 +18,7 @@ import { Form, Formik, FormikProps } from 'formik';
 import AskAQuestion from 'components/AskAQuestion';
 import Breadcrumbs from 'components/Breadcrumbs';
 import PageHeading from 'components/PageHeading';
+import Alert from 'components/shared/Alert';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import useMessage from 'hooks/useMessage';
 import GetOperationalNeed from 'queries/ITSolutions/GetOperationalNeed';

--- a/src/views/ModelPlan/TaskList/ITSolutions/SolutionDetails/index.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/SolutionDetails/index.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import {
-  Alert,
   Breadcrumb,
   BreadcrumbBar,
   BreadcrumbLink,
@@ -20,6 +19,7 @@ import AskAQuestion from 'components/AskAQuestion';
 import UswdsReactLink from 'components/LinkWrapper';
 import PageHeading from 'components/PageHeading';
 import PageLoading from 'components/PageLoading';
+import Alert from 'components/shared/Alert';
 import Expire from 'components/shared/Expire';
 import useMessage from 'hooks/useMessage';
 import GetOperationalSolution from 'queries/ITSolutions/GetOperationalSolution';
@@ -125,7 +125,7 @@ const SolutionDetails = () => {
       {message}
 
       {documentMessage && (
-        <Expire delay={4000}>
+        <Expire delay={45000}>
           <Alert
             type={documentStatus}
             slim

--- a/src/views/ModelPlan/TaskList/ITSolutions/SolutionImplementation/index.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/SolutionImplementation/index.tsx
@@ -7,18 +7,13 @@ import React, { useContext, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
-import {
-  Alert,
-  Button,
-  Fieldset,
-  Grid,
-  IconArrowBack
-} from '@trussworks/react-uswds';
+import { Button, Fieldset, Grid, IconArrowBack } from '@trussworks/react-uswds';
 import { Form, Formik, FormikProps } from 'formik';
 
 import AskAQuestion from 'components/AskAQuestion';
 import Breadcrumbs from 'components/Breadcrumbs';
 import PageHeading from 'components/PageHeading';
+import Alert from 'components/shared/Alert';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import useMessage from 'hooks/useMessage';
 import GetOperationalNeed from 'queries/ITSolutions/GetOperationalNeed';

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCTesting/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCTesting/__snapshots__/index.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`Model Plan Ops Eval and Learning IDDOC matches snapshot 1`] = `
       Testing questions
     </h3>
     <div
-      class="usa-alert usa-alert--info usa-alert--slim margin-bottom-4"
+      class="usa-alert usa-alert--info usa-alert--slim flex margin-bottom-4"
       data-testid="mandatory-fields-alert"
     >
       <div

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCTesting/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCTesting/index.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
-  Alert,
   Breadcrumb,
   BreadcrumbBar,
   BreadcrumbLink,
@@ -18,6 +17,7 @@ import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
+import Alert from 'components/shared/Alert';
 import AutoSave from 'components/shared/AutoSave';
 import CheckboxField from 'components/shared/CheckboxField';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Performance/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Performance/__snapshots__/index.test.tsx.snap
@@ -526,7 +526,7 @@ exports[`Model Plan Ops Eval and Learning Performance matches snapshot 1`] = `
         Will participants be able to appeal the following?
       </label>
       <div
-        class="usa-alert usa-alert--info usa-alert--slim"
+        class="usa-alert usa-alert--info usa-alert--slim flex"
         data-testid="alert"
       >
         <div

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Performance/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Performance/index.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
-  Alert,
   Breadcrumb,
   BreadcrumbBar,
   BreadcrumbLink,
@@ -20,6 +19,7 @@ import AskAQuestion from 'components/AskAQuestion';
 import ITToolsWarning from 'components/ITToolsWarning';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
+import Alert from 'components/shared/Alert';
 import AutoSave from 'components/shared/AutoSave';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';

--- a/src/views/ModelPlan/TaskList/Payment/AnticipateDependencies/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/Payment/AnticipateDependencies/__snapshots__/index.test.tsx.snap
@@ -350,7 +350,7 @@ exports[`Model Plan -- Anticipate Dependencies matches snapshot 1`] = `
             </fieldset>
           </div>
           <div
-            class="usa-alert usa-alert--info usa-alert--slim margin-y-6"
+            class="usa-alert usa-alert--info usa-alert--slim flex margin-y-6"
             data-testid="alert"
           >
             <div

--- a/src/views/ModelPlan/TaskList/Payment/AnticipateDependencies/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/AnticipateDependencies/index.tsx
@@ -3,7 +3,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/client';
 import {
-  Alert,
   Breadcrumb,
   BreadcrumbBar,
   BreadcrumbLink,
@@ -21,6 +20,7 @@ import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
+import Alert from 'components/shared/Alert';
 import AutoSave from 'components/shared/AutoSave';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';

--- a/src/views/ModelPlan/TaskList/_components/TaskListButton/index.tsx
+++ b/src/views/ModelPlan/TaskList/_components/TaskListButton/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
-import { Alert, Button } from '@trussworks/react-uswds';
+import { Button } from '@trussworks/react-uswds';
 
+import Alert from 'components/shared/Alert';
 import {
   PrepareForClearanceStatus,
   TaskStatus

--- a/src/views/NDA/__snapshots__/index.test.tsx.snap
+++ b/src/views/NDA/__snapshots__/index.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`NDA Page matches snapshot 1`] = `
           data-testid="accepted-nda"
         >
           <div
-            class="usa-alert usa-alert--success usa-alert--slim margin-y-3"
+            class="usa-alert usa-alert--success usa-alert--slim flex margin-y-3"
             data-testid="alert"
             id="nda-alert"
           >

--- a/src/views/NDA/index.tsx
+++ b/src/views/NDA/index.tsx
@@ -3,17 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { RootStateOrAny, useDispatch, useSelector } from 'react-redux';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
-import {
-  Alert,
-  Button,
-  Checkbox,
-  Grid,
-  GridContainer
-} from '@trussworks/react-uswds';
+import { Button, Checkbox, Grid, GridContainer } from '@trussworks/react-uswds';
 import { Field, Form, Formik, FormikProps } from 'formik';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import MainContent from 'components/MainContent';
+import Alert from 'components/shared/Alert';
 import UpdateNDA from 'queries/NDA/UpdateNDA';
 import { setUser } from 'reducers/authReducer';
 import { formatDate } from 'utils/date';
@@ -62,7 +57,13 @@ const NDA = () => {
 
           {acceptedNDA?.agreed && acceptedNDA?.agreedDts ? (
             <div data-testid="accepted-nda">
-              <Alert type="success" slim className="margin-y-3" id="nda-alert">
+              <Alert
+                type="success"
+                slim
+                className="margin-y-3"
+                id="nda-alert"
+                isClosable={false}
+              >
                 {t('accepted')}
                 {formatDate(acceptedNDA?.agreedDts, 'MM/d/yyyy')}
               </Alert>


### PR DESCRIPTION
# EASI-2646

## Changes and Description

- Added document types hint to upload
- Added required icons for documents fields
- Disabled upload button until all required fields filled
- Updated MINT custom alert to allow for Truss `Alert` to closable
  Updated snapshots and tests (lots fo files)
- Extended all closable alerts to expire after 45 seconds


## How to test this change

Verify success and error `Alert` components are closable and document updates match figma

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
