### PR TITLE
Easi 2652/user account data loader and generic GQL functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This application has the following main components:
 - [Docker Compose files and usage](./docs/docker_compose.md)
 - [Deployment Process](./docs/operations/deployment_process.md)
 - [Interacting with CEDAR](./docs/cedar.md) - CEDAR is a CMS system whose API we interact with; this includes instructions on how to connect to it
-- [Background Worker (Faktory)](./docks/faktory.md) - Faktory is our background job server and processor.
+- [Background Worker (Faktory)](./docs/faktory.md) - Faktory is our background job server and processor.
 
 
 ## Repository Structure

--- a/pkg/appcontext/context.go
+++ b/pkg/appcontext/context.go
@@ -18,6 +18,7 @@ const (
 	traceKey
 	principalKey
 	jwtKey
+	userAccountServiceKey
 )
 
 // WithLogger returns a context with the given logger
@@ -80,4 +81,14 @@ func EnhancedJWT(c context.Context) *authentication.EnhancedJwt {
 		return &jwt
 	}
 	return nil
+}
+
+// UserAccountService returns a GetUserAccountFromDBFunc that is decorating the context
+func UserAccountService(ctx context.Context) authentication.GetUserAccountFromDBFunc {
+	return ctx.Value(userAccountServiceKey).(authentication.GetUserAccountFromDBFunc)
+}
+
+// WithUserAccountService decorates the context with a GetUserAccountFromDBFunc
+func WithUserAccountService(ctx context.Context, accountFunction authentication.GetUserAccountFromDBFunc) context.Context {
+	return context.WithValue(ctx, userAccountServiceKey, accountFunction)
 }

--- a/pkg/authentication/user_account.go
+++ b/pkg/authentication/user_account.go
@@ -1,6 +1,10 @@
 package authentication
 
-import "github.com/google/uuid"
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
 
 // UserAccount represents a user from the database
 type UserAccount struct {
@@ -14,4 +18,23 @@ type UserAccount struct {
 	FamilyName  string    `json:"family_name" db:"family_name"`
 	ZoneInfo    string    `json:"zoneinfo" db:"zone_info"`
 	HasLoggedIn bool      `json:"hasLoggedIn" db:"has_logged_in"`
+}
+
+type ctxKey string
+
+const (
+	userAccountServiceKey = ctxKey("userAccountService")
+)
+
+// GetUserAccountFromDBFunc represents a type of function which takes a context and a user_id uuid and returns a UserAccount
+type GetUserAccountFromDBFunc func(ctx context.Context, id uuid.UUID) (*UserAccount, error)
+
+// UserAccountService returns a GetUserAccountFromDBFunc that is decorating the context
+func UserAccountService(ctx context.Context) GetUserAccountFromDBFunc {
+	return ctx.Value(userAccountServiceKey).(GetUserAccountFromDBFunc)
+}
+
+// CTXWithUserAccountService decorates the context with a GetUserAccountFromDBFunc
+func CTXWithUserAccountService(ctx context.Context, accountFunction GetUserAccountFromDBFunc) context.Context {
+	return context.WithValue(ctx, userAccountServiceKey, accountFunction)
 }

--- a/pkg/authentication/user_account.go
+++ b/pkg/authentication/user_account.go
@@ -20,21 +20,21 @@ type UserAccount struct {
 	HasLoggedIn bool      `json:"hasLoggedIn" db:"has_logged_in"`
 }
 
-type ctxKey string
+// type ctxKey string
 
-const (
-	userAccountServiceKey = ctxKey("userAccountService")
-)
+// const (
+// 	userAccountServiceKey = ctxKey("userAccountService")
+// )
 
 // GetUserAccountFromDBFunc represents a type of function which takes a context and a user_id uuid and returns a UserAccount
 type GetUserAccountFromDBFunc func(ctx context.Context, id uuid.UUID) (*UserAccount, error)
 
-// UserAccountService returns a GetUserAccountFromDBFunc that is decorating the context
-func UserAccountService(ctx context.Context) GetUserAccountFromDBFunc {
-	return ctx.Value(userAccountServiceKey).(GetUserAccountFromDBFunc)
-}
+// // UserAccountService returns a GetUserAccountFromDBFunc that is decorating the context
+// func UserAccountService(ctx context.Context) GetUserAccountFromDBFunc {
+// 	return ctx.Value(userAccountServiceKey).(GetUserAccountFromDBFunc)
+// }
 
-// CTXWithUserAccountService decorates the context with a GetUserAccountFromDBFunc
-func CTXWithUserAccountService(ctx context.Context, accountFunction GetUserAccountFromDBFunc) context.Context {
-	return context.WithValue(ctx, userAccountServiceKey, accountFunction)
-}
+// // WithUserAccountService decorates the context with a GetUserAccountFromDBFunc
+// func WithUserAccountService(ctx context.Context, accountFunction GetUserAccountFromDBFunc) context.Context {
+// 	return context.WithValue(ctx, userAccountServiceKey, accountFunction)
+// }

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -49,7 +49,6 @@ type ResolverRoot interface {
 	OperationalSolution() OperationalSolutionResolver
 	PlanBasics() PlanBasicsResolver
 	PlanBeneficiaries() PlanBeneficiariesResolver
-	PlanCollaborator() PlanCollaboratorResolver
 	PlanDiscussion() PlanDiscussionResolver
 	PlanDocument() PlanDocumentResolver
 	PlanGeneralCharacteristics() PlanGeneralCharacteristicsResolver
@@ -870,8 +869,6 @@ type ComplexityRoot struct {
 
 type AuditChangeResolver interface {
 	Fields(ctx context.Context, obj *models.AuditChange) (map[string]interface{}, error)
-
-	ModifiedByUserAccount(ctx context.Context, obj *models.AuditChange) (*authentication.UserAccount, error)
 }
 type DiscussionReplyResolver interface {
 	CreatedByUser(ctx context.Context, obj *models.DiscussionReply) (*models.UserInfo, error)
@@ -948,13 +945,6 @@ type PlanBeneficiariesResolver interface {
 	Beneficiaries(ctx context.Context, obj *models.PlanBeneficiaries) ([]model.BeneficiariesType, error)
 
 	BeneficiarySelectionMethod(ctx context.Context, obj *models.PlanBeneficiaries) ([]model.SelectionMethodType, error)
-}
-type PlanCollaboratorResolver interface {
-	UserAccount(ctx context.Context, obj *models.PlanCollaborator) (*authentication.UserAccount, error)
-
-	CreatedByUserAccount(ctx context.Context, obj *models.PlanCollaborator) (*authentication.UserAccount, error)
-
-	ModifiedByUserAccount(ctx context.Context, obj *models.PlanCollaborator) (*authentication.UserAccount, error)
 }
 type PlanDiscussionResolver interface {
 	Replies(ctx context.Context, obj *models.PlanDiscussion) ([]*models.DiscussionReply, error)
@@ -10209,7 +10199,7 @@ func (ec *executionContext) _AuditChange_modifiedByUserAccount(ctx context.Conte
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.AuditChange().ModifiedByUserAccount(rctx, obj)
+		return obj.ModifiedByUserAccount(ctx), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -10228,7 +10218,7 @@ func (ec *executionContext) fieldContext_AuditChange_modifiedByUserAccount(ctx c
 		Object:     "AuditChange",
 		Field:      field,
 		IsMethod:   true,
-		IsResolver: true,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "id":
@@ -22369,7 +22359,7 @@ func (ec *executionContext) _PlanCollaborator_userAccount(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.PlanCollaborator().UserAccount(rctx, obj)
+		return obj.UserAccount(ctx), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -22391,7 +22381,7 @@ func (ec *executionContext) fieldContext_PlanCollaborator_userAccount(ctx contex
 		Object:     "PlanCollaborator",
 		Field:      field,
 		IsMethod:   true,
-		IsResolver: true,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "id":
@@ -22523,7 +22513,7 @@ func (ec *executionContext) _PlanCollaborator_createdByUserAccount(ctx context.C
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.PlanCollaborator().CreatedByUserAccount(rctx, obj)
+		return obj.CreatedByUserAccount(ctx), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -22545,7 +22535,7 @@ func (ec *executionContext) fieldContext_PlanCollaborator_createdByUserAccount(c
 		Object:     "PlanCollaborator",
 		Field:      field,
 		IsMethod:   true,
-		IsResolver: true,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "id":
@@ -22674,7 +22664,7 @@ func (ec *executionContext) _PlanCollaborator_modifiedByUserAccount(ctx context.
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.PlanCollaborator().ModifiedByUserAccount(rctx, obj)
+		return obj.ModifiedByUserAccount(ctx), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -22693,7 +22683,7 @@ func (ec *executionContext) fieldContext_PlanCollaborator_modifiedByUserAccount(
 		Object:     "PlanCollaborator",
 		Field:      field,
 		IsMethod:   true,
-		IsResolver: true,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "id":

--- a/pkg/graph/resolvers/base_struct_test.go
+++ b/pkg/graph/resolvers/base_struct_test.go
@@ -5,9 +5,9 @@ import "github.com/cmsgov/mint-app/pkg/models"
 func (suite *ResolverSuite) TestCreatedByUserAccount() {
 	plan := suite.createModelPlan("My Test plan")
 	colab := suite.createPlanCollaborator(plan, "FRND", models.TeamRoleArchitect)
-	createdAcount := colab.CreatedByUserAccount(suite.testConfigs.Context) //the same as the config test principal
+	createdAccount := colab.CreatedByUserAccount(suite.testConfigs.Context) //the same as the config test principal
 
-	suite.Equal(suite.testConfigs.Principal.UserAccount, createdAcount)
+	suite.Equal(suite.testConfigs.Principal.UserAccount, createdAccount)
 }
 
 func (suite *ResolverSuite) TestModifiedByUserAccount() {

--- a/pkg/graph/resolvers/base_struct_test.go
+++ b/pkg/graph/resolvers/base_struct_test.go
@@ -1,0 +1,36 @@
+package resolvers
+
+import "github.com/cmsgov/mint-app/pkg/models"
+
+func (suite *ResolverSuite) TestCreatedByUserAccount() {
+	plan := suite.createModelPlan("My Test plan")
+	colab := suite.createPlanCollaborator(plan, "FRND", models.TeamRoleArchitect)
+	createdAcount := colab.CreatedByUserAccount(suite.testConfigs.Context) //the same as the config test principal
+
+	suite.EqualValues(suite.testConfigs.Principal.UserAccount.ID, createdAcount.ID)
+	suite.EqualValues(suite.testConfigs.Principal.UserAccount.CommonName, createdAcount.CommonName)
+	suite.EqualValues(suite.testConfigs.Principal.UserAccount.Email, createdAcount.Email)
+	suite.EqualValues(suite.testConfigs.Principal.UserAccount.Username, createdAcount.Username)
+
+}
+
+func (suite *ResolverSuite) TestModifiedByUserAccount() {
+	updaterPrincipal := getTestPrincipal(suite.testConfigs.Store, "BTMN")
+
+	plan := suite.createModelPlan("My Test plan")
+	colab := suite.createPlanCollaborator(plan, "FRND", models.TeamRoleArchitect)
+	// createdAcount := colab.CreatedByUserAccount(suite.testConfigs.Context) //the same as the config test principal
+
+	nilModifiedAccount := colab.ModifiedByUserAccount(suite.testConfigs.Context)
+	suite.Nil(nilModifiedAccount)
+
+	updatedCollab, err := UpdatePlanCollaborator(suite.testConfigs.Logger, colab.ID, models.TeamRoleITLead, updaterPrincipal, suite.testConfigs.Store)
+	suite.NoError(err)
+	modifiedAccount := updatedCollab.ModifiedByUserAccount(suite.testConfigs.Context)
+
+	suite.EqualValues(updaterPrincipal.UserAccount.ID, modifiedAccount.ID)
+	suite.EqualValues(updaterPrincipal.UserAccount.CommonName, modifiedAccount.CommonName)
+	suite.EqualValues(updaterPrincipal.UserAccount.Email, modifiedAccount.Email)
+	suite.EqualValues(updaterPrincipal.UserAccount.Username, modifiedAccount.Username)
+
+}

--- a/pkg/graph/resolvers/base_struct_test.go
+++ b/pkg/graph/resolvers/base_struct_test.go
@@ -7,11 +7,7 @@ func (suite *ResolverSuite) TestCreatedByUserAccount() {
 	colab := suite.createPlanCollaborator(plan, "FRND", models.TeamRoleArchitect)
 	createdAcount := colab.CreatedByUserAccount(suite.testConfigs.Context) //the same as the config test principal
 
-	suite.EqualValues(suite.testConfigs.Principal.UserAccount.ID, createdAcount.ID)
-	suite.EqualValues(suite.testConfigs.Principal.UserAccount.CommonName, createdAcount.CommonName)
-	suite.EqualValues(suite.testConfigs.Principal.UserAccount.Email, createdAcount.Email)
-	suite.EqualValues(suite.testConfigs.Principal.UserAccount.Username, createdAcount.Username)
-
+	suite.Equal(suite.testConfigs.Principal.UserAccount, createdAcount)
 }
 
 func (suite *ResolverSuite) TestModifiedByUserAccount() {
@@ -19,7 +15,6 @@ func (suite *ResolverSuite) TestModifiedByUserAccount() {
 
 	plan := suite.createModelPlan("My Test plan")
 	colab := suite.createPlanCollaborator(plan, "FRND", models.TeamRoleArchitect)
-	// createdAcount := colab.CreatedByUserAccount(suite.testConfigs.Context) //the same as the config test principal
 
 	nilModifiedAccount := colab.ModifiedByUserAccount(suite.testConfigs.Context)
 	suite.Nil(nilModifiedAccount)
@@ -28,9 +23,5 @@ func (suite *ResolverSuite) TestModifiedByUserAccount() {
 	suite.NoError(err)
 	modifiedAccount := updatedCollab.ModifiedByUserAccount(suite.testConfigs.Context)
 
-	suite.EqualValues(updaterPrincipal.UserAccount.ID, modifiedAccount.ID)
-	suite.EqualValues(updaterPrincipal.UserAccount.CommonName, modifiedAccount.CommonName)
-	suite.EqualValues(updaterPrincipal.UserAccount.Email, modifiedAccount.Email)
-	suite.EqualValues(updaterPrincipal.UserAccount.Username, modifiedAccount.Username)
-
+	suite.Equal(updaterPrincipal.UserAccount, modifiedAccount)
 }

--- a/pkg/graph/resolvers/operational_solution_test.go
+++ b/pkg/graph/resolvers/operational_solution_test.go
@@ -60,7 +60,7 @@ func (suite *ResolverSuite) TestOperationalSolutionLoader() {
 	g, ctx := errgroup.WithContext(suite.testConfigs.Context)
 
 	for _, opNeedID := range opNeedIds {
-		theFunc := getVerificationFunction(ctx, opNeedID, verifySolutionsLoader)
+		theFunc := getSolutionLoaderVerificationFunction(ctx, opNeedID, verifySolutionsLoader)
 		g.Go(theFunc)
 	}
 
@@ -91,7 +91,7 @@ func verifySolutionsLoader(ctx context.Context, operationalNeedID uuid.UUID) err
 	}
 	return nil
 }
-func getVerificationFunction(ctx context.Context, operationalNeedID uuid.UUID, verifySolutionsFunc func(ctx context.Context, operationalNeedID uuid.UUID) error) func() error {
+func getSolutionLoaderVerificationFunction(ctx context.Context, operationalNeedID uuid.UUID, verifySolutionsFunc func(ctx context.Context, operationalNeedID uuid.UUID) error) func() error {
 	return func() error {
 		return verifySolutionsFunc(ctx, operationalNeedID)
 	}

--- a/pkg/graph/resolvers/resolver_test_utilities.go
+++ b/pkg/graph/resolvers/resolver_test_utilities.go
@@ -78,6 +78,7 @@ func (tc *TestConfigs) GetDefaults() {
 	dataLoaders := loaders.NewDataLoaders(tc.Store)
 	tc.Context = loaders.CTXWithLoaders(context.Background(), dataLoaders)
 	tc.Context = appcontext.WithLogger(tc.Context, tc.Logger)
+	tc.Context = authentication.CTXWithUserAccountService(tc.Context, userhelpers.UserAccountGetByIDLOADER)
 
 }
 

--- a/pkg/graph/resolvers/resolver_test_utilities.go
+++ b/pkg/graph/resolvers/resolver_test_utilities.go
@@ -78,7 +78,7 @@ func (tc *TestConfigs) GetDefaults() {
 	dataLoaders := loaders.NewDataLoaders(tc.Store)
 	tc.Context = loaders.CTXWithLoaders(context.Background(), dataLoaders)
 	tc.Context = appcontext.WithLogger(tc.Context, tc.Logger)
-	tc.Context = authentication.CTXWithUserAccountService(tc.Context, userhelpers.UserAccountGetByIDLOADER)
+	tc.Context = appcontext.WithUserAccountService(tc.Context, userhelpers.UserAccountGetByIDLOADER)
 
 }
 

--- a/pkg/graph/resolvers/user_account.go
+++ b/pkg/graph/resolvers/user_account.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cmsgov/mint-app/pkg/authentication"
 	"github.com/cmsgov/mint-app/pkg/storage"
-	"github.com/cmsgov/mint-app/pkg/storage/loaders"
+	"github.com/cmsgov/mint-app/pkg/userhelpers"
 )
 
 // UserAccountGetByUsername returns a user account by it's EUAID
@@ -19,26 +19,8 @@ func UserAccountGetByUsername(logger *zap.Logger, store *storage.Store, euaID st
 
 }
 
-// // UserAccountGetByID returns a user account by it's internal ID
-// func UserAccountGetByID(logger *zap.Logger, store *storage.Store, id uuid.UUID) (*authentication.UserAccount, error) {
-// 	return store.UserAccountGetByID(id)
-
-// }
-
 // UserAccountGetByIDLOADER returns a user account by it's internal ID, utilizing a data loader
 func UserAccountGetByIDLOADER(ctx context.Context, id uuid.UUID) (*authentication.UserAccount, error) {
-	allLoaders := loaders.Loaders(ctx)
-	userAccountLoader := allLoaders.UserAccountLoader
-
-	key := loaders.NewKeyArgs()
-	key.Args["id"] = id
-
-	thunk := userAccountLoader.Loader.Load(ctx, key)
-	result, err := thunk()
-	if err != nil {
-		return nil, err
-	}
-
-	return result.(*authentication.UserAccount), nil
+	return userhelpers.UserAccountGetByIDLOADER(ctx, id)
 
 }

--- a/pkg/graph/resolvers/user_account.go
+++ b/pkg/graph/resolvers/user_account.go
@@ -12,10 +12,10 @@ import (
 	"github.com/cmsgov/mint-app/pkg/userhelpers"
 )
 
-// UserAccountGetByUsername returns a user account by it's EUAID
-func UserAccountGetByUsername(logger *zap.Logger, store *storage.Store, euaID string) (*authentication.UserAccount, error) {
+// UserAccountGetByUsername returns a user account by it's userName
+func UserAccountGetByUsername(logger *zap.Logger, store *storage.Store, userName string) (*authentication.UserAccount, error) {
 
-	return store.UserAccountGetByUsername(euaID)
+	return store.UserAccountGetByUsername(userName)
 
 }
 

--- a/pkg/graph/resolvers/user_account.go
+++ b/pkg/graph/resolvers/user_account.go
@@ -1,12 +1,15 @@
 package resolvers
 
 import (
+	"context"
+
 	"go.uber.org/zap"
 
 	"github.com/google/uuid"
 
 	"github.com/cmsgov/mint-app/pkg/authentication"
 	"github.com/cmsgov/mint-app/pkg/storage"
+	"github.com/cmsgov/mint-app/pkg/storage/loaders"
 )
 
 // UserAccountGetByUsername returns a user account by it's EUAID
@@ -16,8 +19,26 @@ func UserAccountGetByUsername(logger *zap.Logger, store *storage.Store, euaID st
 
 }
 
-// UserAccountGetByID returns a user account by it's internal ID
-func UserAccountGetByID(logger *zap.Logger, store *storage.Store, id uuid.UUID) (*authentication.UserAccount, error) {
-	return store.UserAccountGetByID(id)
+// // UserAccountGetByID returns a user account by it's internal ID
+// func UserAccountGetByID(logger *zap.Logger, store *storage.Store, id uuid.UUID) (*authentication.UserAccount, error) {
+// 	return store.UserAccountGetByID(id)
+
+// }
+
+// UserAccountGetByIDLOADER returns a user account by it's internal ID, utilizing a data loader
+func UserAccountGetByIDLOADER(ctx context.Context, id uuid.UUID) (*authentication.UserAccount, error) {
+	allLoaders := loaders.Loaders(ctx)
+	userAccountLoader := allLoaders.UserAccountLoader
+
+	key := loaders.NewKeyArgs()
+	key.Args["id"] = id
+
+	thunk := userAccountLoader.Loader.Load(ctx, key)
+	result, err := thunk()
+	if err != nil {
+		return nil, err
+	}
+
+	return result.(*authentication.UserAccount), nil
 
 }

--- a/pkg/graph/resolvers/user_account_test.go
+++ b/pkg/graph/resolvers/user_account_test.go
@@ -1,0 +1,63 @@
+package resolvers
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/cmsgov/mint-app/pkg/authentication"
+)
+
+// UserAccountGetByUsername returns a user account by it's EUAID
+func (suite *ResolverSuite) TestUserAccountGetByUsername() {
+	username := "USER NUMBER 1"
+
+	princ1 := getTestPrincipal(suite.testConfigs.Store, username)
+
+	account, err := UserAccountGetByUsername(suite.testConfigs.Logger, suite.testConfigs.Store, username)
+	suite.NoError(err)
+	suite.EqualValues(princ1.UserAccount.CommonName, account.CommonName)
+	suite.EqualValues(princ1.UserAccount.Email, account.Email)
+
+}
+
+// UserAccountGetByIDLOADER returns a user account by it's internal ID, utilizing a data loader
+func (suite *ResolverSuite) TestUserAccountGetByIDLOADER() {
+	princ1 := getTestPrincipal(suite.testConfigs.Store, "USER NUMBER 1")
+	princ2 := getTestPrincipal(suite.testConfigs.Store, "USER NUMBER 2")
+	princ3 := getTestPrincipal(suite.testConfigs.Store, "TEST")
+	princ4 := getTestPrincipal(suite.testConfigs.Store, "COLB")
+	princ5 := getTestPrincipal(suite.testConfigs.Store, "BTMN")
+
+	princArray := []*authentication.ApplicationPrincipal{princ1, princ2, princ3, princ4, princ5}
+
+	g, ctx := errgroup.WithContext(suite.testConfigs.Context)
+
+	for _, princ := range princArray {
+		theFunc := getUserAccountLoaderVerificationFunction(ctx, princ, verifyUserAccountLoader)
+		g.Go(theFunc)
+	}
+	err := g.Wait()
+	suite.NoError(err)
+
+}
+
+func verifyUserAccountLoader(ctx context.Context, princ *authentication.ApplicationPrincipal) error {
+
+	retAccount, err := UserAccountGetByIDLOADER(ctx, princ.UserAccount.ID)
+	if err != nil {
+		return err
+	}
+	if retAccount.CommonName != princ.UserAccount.CommonName {
+		return fmt.Errorf("name from DB (%s) loader doesn't match expected (%s)", retAccount.CommonName, princ.Account().CommonName)
+	}
+	return nil
+
+}
+
+func getUserAccountLoaderVerificationFunction(ctx context.Context, princ *authentication.ApplicationPrincipal, verifyAccountFunc func(ctx context.Context, princ *authentication.ApplicationPrincipal) error) func() error {
+	return func() error {
+		return verifyUserAccountLoader(ctx, princ)
+	}
+}

--- a/pkg/graph/resolvers/user_id_relation_test.go
+++ b/pkg/graph/resolvers/user_id_relation_test.go
@@ -1,0 +1,20 @@
+package resolvers
+
+import (
+	"github.com/cmsgov/mint-app/pkg/models"
+)
+
+func (suite *ResolverSuite) UserAccount() {
+
+	updaterPrincipal := getTestPrincipal(suite.testConfigs.Store, "BTMN")
+
+	plan := suite.createModelPlan("My Test plan")
+	colab := suite.createPlanCollaborator(plan, "BTMN", models.TeamRoleArchitect)
+
+	userAccount := colab.UserAccount(suite.testConfigs.Context)
+
+	suite.EqualValues(updaterPrincipal.UserAccount.ID, userAccount.ID)
+	suite.EqualValues(updaterPrincipal.UserAccount.CommonName, userAccount.CommonName)
+	suite.EqualValues(updaterPrincipal.UserAccount.Email, userAccount.Email)
+	suite.EqualValues(updaterPrincipal.UserAccount.Username, userAccount.Username)
+}

--- a/pkg/graph/resolvers/user_id_relation_test.go
+++ b/pkg/graph/resolvers/user_id_relation_test.go
@@ -13,8 +13,5 @@ func (suite *ResolverSuite) UserAccount() {
 
 	userAccount := colab.UserAccount(suite.testConfigs.Context)
 
-	suite.EqualValues(updaterPrincipal.UserAccount.ID, userAccount.ID)
-	suite.EqualValues(updaterPrincipal.UserAccount.CommonName, userAccount.CommonName)
-	suite.EqualValues(updaterPrincipal.UserAccount.Email, userAccount.Email)
-	suite.EqualValues(updaterPrincipal.UserAccount.Username, userAccount.Username)
+	suite.Equal(updaterPrincipal.UserAccount, userAccount)
 }

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -26,11 +26,11 @@ func (r *auditChangeResolver) Fields(ctx context.Context, obj *models.AuditChang
 
 // ModifiedByUserAccount is the resolver for the modifiedByUserAccount field.
 func (r *auditChangeResolver) ModifiedByUserAccount(ctx context.Context, obj *models.AuditChange) (*authentication.UserAccount, error) {
-	logger := appcontext.ZLogger(ctx)
+	// logger := appcontext.ZLogger(ctx)
 	if obj.ModifiedBy == nil {
 		return nil, nil //no user
 	}
-	return resolvers.UserAccountGetByID(logger, r.store, *obj.ModifiedBy)
+	return resolvers.UserAccountGetByIDLOADER(ctx, *obj.ModifiedBy)
 }
 
 // CreatedByUser is the resolver for the createdByUser field.
@@ -472,23 +472,24 @@ func (r *planBeneficiariesResolver) BeneficiarySelectionMethod(ctx context.Conte
 
 // UserAccount is the resolver for the userAccount field.
 func (r *planCollaboratorResolver) UserAccount(ctx context.Context, obj *models.PlanCollaborator) (*authentication.UserAccount, error) {
-	logger := appcontext.ZLogger(ctx)
-	return resolvers.UserAccountGetByID(logger, r.store, obj.UserID)
+	// logger := appcontext.ZLogger(ctx)
+	return resolvers.UserAccountGetByIDLOADER(ctx, obj.UserID)
 }
 
 // CreatedByUserAccount is the resolver for the createdByUserAccount field.
 func (r *planCollaboratorResolver) CreatedByUserAccount(ctx context.Context, obj *models.PlanCollaborator) (*authentication.UserAccount, error) {
-	logger := appcontext.ZLogger(ctx)
-	return resolvers.UserAccountGetByID(logger, r.store, obj.CreatedBy)
+	// logger := appcontext.ZLogger(ctx)
+	return resolvers.UserAccountGetByIDLOADER(ctx, obj.CreatedBy)
 }
 
 // ModifiedByUserAccount is the resolver for the modifiedByUserAccount field.
 func (r *planCollaboratorResolver) ModifiedByUserAccount(ctx context.Context, obj *models.PlanCollaborator) (*authentication.UserAccount, error) {
-	logger := appcontext.ZLogger(ctx)
+	// logger := appcontext.ZLogger(ctx)
 	if obj.ModifiedBy == nil {
 		return nil, nil //no user
 	}
-	return resolvers.UserAccountGetByID(logger, r.store, *obj.ModifiedBy)
+	// return resolvers.UserAccountGetByID(logger, r.store, *obj.ModifiedBy)
+	return resolvers.UserAccountGetByIDLOADER(ctx, *obj.ModifiedBy)
 }
 
 // Replies is the resolver for the replies field.

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -24,15 +24,6 @@ func (r *auditChangeResolver) Fields(ctx context.Context, obj *models.AuditChang
 	return obj.Fields.ToInterface()
 }
 
-// ModifiedByUserAccount is the resolver for the modifiedByUserAccount field.
-func (r *auditChangeResolver) ModifiedByUserAccount(ctx context.Context, obj *models.AuditChange) (*authentication.UserAccount, error) {
-	// logger := appcontext.ZLogger(ctx)
-	if obj.ModifiedBy == nil {
-		return nil, nil //no user
-	}
-	return resolvers.UserAccountGetByIDLOADER(ctx, *obj.ModifiedBy)
-}
-
 // CreatedByUser is the resolver for the createdByUser field.
 func (r *discussionReplyResolver) CreatedByUser(ctx context.Context, obj *models.DiscussionReply) (*models.UserInfo, error) {
 	return r.service.FetchUserInfo(ctx, obj.CreatedBy)
@@ -468,28 +459,6 @@ func (r *planBeneficiariesResolver) Beneficiaries(ctx context.Context, obj *mode
 func (r *planBeneficiariesResolver) BeneficiarySelectionMethod(ctx context.Context, obj *models.PlanBeneficiaries) ([]model.SelectionMethodType, error) {
 	sTypes := models.ConvertEnums[model.SelectionMethodType](obj.BeneficiarySelectionMethod)
 	return sTypes, nil
-}
-
-// UserAccount is the resolver for the userAccount field.
-func (r *planCollaboratorResolver) UserAccount(ctx context.Context, obj *models.PlanCollaborator) (*authentication.UserAccount, error) {
-	// logger := appcontext.ZLogger(ctx)
-	return resolvers.UserAccountGetByIDLOADER(ctx, obj.UserID)
-}
-
-// CreatedByUserAccount is the resolver for the createdByUserAccount field.
-func (r *planCollaboratorResolver) CreatedByUserAccount(ctx context.Context, obj *models.PlanCollaborator) (*authentication.UserAccount, error) {
-	// logger := appcontext.ZLogger(ctx)
-	return resolvers.UserAccountGetByIDLOADER(ctx, obj.CreatedBy)
-}
-
-// ModifiedByUserAccount is the resolver for the modifiedByUserAccount field.
-func (r *planCollaboratorResolver) ModifiedByUserAccount(ctx context.Context, obj *models.PlanCollaborator) (*authentication.UserAccount, error) {
-	// logger := appcontext.ZLogger(ctx)
-	if obj.ModifiedBy == nil {
-		return nil, nil //no user
-	}
-	// return resolvers.UserAccountGetByID(logger, r.store, *obj.ModifiedBy)
-	return resolvers.UserAccountGetByIDLOADER(ctx, *obj.ModifiedBy)
 }
 
 // Replies is the resolver for the replies field.
@@ -1073,11 +1042,6 @@ func (r *Resolver) PlanBeneficiaries() generated.PlanBeneficiariesResolver {
 	return &planBeneficiariesResolver{r}
 }
 
-// PlanCollaborator returns generated.PlanCollaboratorResolver implementation.
-func (r *Resolver) PlanCollaborator() generated.PlanCollaboratorResolver {
-	return &planCollaboratorResolver{r}
-}
-
 // PlanDiscussion returns generated.PlanDiscussionResolver implementation.
 func (r *Resolver) PlanDiscussion() generated.PlanDiscussionResolver {
 	return &planDiscussionResolver{r}
@@ -1129,7 +1093,6 @@ type operationalNeedResolver struct{ *Resolver }
 type operationalSolutionResolver struct{ *Resolver }
 type planBasicsResolver struct{ *Resolver }
 type planBeneficiariesResolver struct{ *Resolver }
-type planCollaboratorResolver struct{ *Resolver }
 type planDiscussionResolver struct{ *Resolver }
 type planDocumentResolver struct{ *Resolver }
 type planGeneralCharacteristicsResolver struct{ *Resolver }

--- a/pkg/models/audit_change.go
+++ b/pkg/models/audit_change.go
@@ -1,12 +1,15 @@
 package models
 
 import (
+	"context"
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/cmsgov/mint-app/pkg/authentication"
 )
 
 // SortDirection represents ASC or DESC for sort directions
@@ -76,4 +79,15 @@ func (a *AuditFields) Scan(src interface{}) error {
 	}
 
 	return nil
+}
+
+// ModifiedByUserAccount returns the user account of the user who created the struct from the DB using the UserAccount service
+func (ac *AuditChange) ModifiedByUserAccount(ctx context.Context) *authentication.UserAccount { //TODO should this be moved to a shared struct? This isn't a base struct
+	if ac.ModifiedBy == nil {
+		return nil
+	}
+	service := authentication.UserAccountService(ctx)
+	account, _ := service(ctx, *ac.ModifiedBy)
+	return account
+
 }

--- a/pkg/models/audit_change.go
+++ b/pkg/models/audit_change.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/cmsgov/mint-app/pkg/appcontext"
 	"github.com/cmsgov/mint-app/pkg/authentication"
 )
 
@@ -86,7 +87,7 @@ func (ac *AuditChange) ModifiedByUserAccount(ctx context.Context) *authenticatio
 	if ac.ModifiedBy == nil {
 		return nil
 	}
-	service := authentication.UserAccountService(ctx)
+	service := appcontext.UserAccountService(ctx)
 	account, _ := service(ctx, *ac.ModifiedBy)
 	return account
 

--- a/pkg/models/base_struct_user_table.go
+++ b/pkg/models/base_struct_user_table.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"time"
 
 	"github.com/google/uuid"
@@ -56,4 +57,25 @@ func (b baseStructUserTable) GetModifiedBy() *string {
 // GetCreatedBy implements the CreatedBy property
 func (b baseStructUserTable) GetCreatedBy() string {
 	return b.CreatedBy.String()
+}
+
+// CreatedByUserAccount returns the user account of the user who created the struct from the DB using the UserAccount service
+func (b *baseStructUserTable) CreatedByUserAccount(ctx context.Context) *authentication.UserAccount {
+
+	service := authentication.UserAccountService(ctx)
+	account, _ := service(ctx, b.CreatedBy)
+	return account
+
+}
+
+// ModifiedByUserAccount returns the user account of the user who created the struct from the DB using the UserAccount service
+func (b *baseStructUserTable) ModifiedByUserAccount(ctx context.Context) *authentication.UserAccount {
+
+	if b.ModifiedBy == nil {
+		return nil
+	}
+	service := authentication.UserAccountService(ctx)
+	account, _ := service(ctx, *b.ModifiedBy)
+	return account
+
 }

--- a/pkg/models/base_struct_user_table.go
+++ b/pkg/models/base_struct_user_table.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/cmsgov/mint-app/pkg/appcontext"
 	"github.com/cmsgov/mint-app/pkg/authentication"
 )
 
@@ -62,7 +63,7 @@ func (b baseStructUserTable) GetCreatedBy() string {
 // CreatedByUserAccount returns the user account of the user who created the struct from the DB using the UserAccount service
 func (b *baseStructUserTable) CreatedByUserAccount(ctx context.Context) *authentication.UserAccount {
 
-	service := authentication.UserAccountService(ctx)
+	service := appcontext.UserAccountService(ctx)
 	account, _ := service(ctx, b.CreatedBy)
 	return account
 
@@ -74,7 +75,8 @@ func (b *baseStructUserTable) ModifiedByUserAccount(ctx context.Context) *authen
 	if b.ModifiedBy == nil {
 		return nil
 	}
-	service := authentication.UserAccountService(ctx)
+	service := appcontext.UserAccountService(ctx)
+	// service := authentication.UserAccountService(ctx)
 	account, _ := service(ctx, *b.ModifiedBy)
 	return account
 

--- a/pkg/models/plan_collaborator.go
+++ b/pkg/models/plan_collaborator.go
@@ -1,6 +1,8 @@
 package models
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+)
 
 // PlanCollaborator represents a plan collaborator
 // FullName and Email are stored as a result from the initial CEDAR query that's made when we create the collaborator
@@ -8,14 +10,15 @@ import "github.com/google/uuid"
 type PlanCollaborator struct {
 	baseStructUserTable
 	modelPlanRelation
-	UserID   uuid.UUID `json:"userId" db:"user_id"`
-	TeamRole TeamRole  `json:"teamRole" db:"team_role"`
+	userIDRelation
+	TeamRole TeamRole `json:"teamRole" db:"team_role"`
 }
 
 // NewPlanCollaborator returns a plan collaborator object
 func NewPlanCollaborator(createdBy uuid.UUID, modelPlanID uuid.UUID, userID uuid.UUID, teamRole TeamRole) *PlanCollaborator {
 	return &PlanCollaborator{
-		UserID:              userID,
+		// UserID:              userID,
+		userIDRelation:      NewUserIDRelation(userID),
 		TeamRole:            teamRole,
 		modelPlanRelation:   NewModelPlanRelation(modelPlanID),
 		baseStructUserTable: NewBaseStructUser(createdBy),

--- a/pkg/models/user_id_relation.go
+++ b/pkg/models/user_id_relation.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/cmsgov/mint-app/pkg/authentication"
+)
+
+type userIDRelation struct {
+	UserID uuid.UUID `json:"userId" db:"user_id"`
+}
+
+// NewUserIDRelation returns a user ID relation object
+func NewUserIDRelation(userID uuid.UUID) userIDRelation {
+	return userIDRelation{
+		UserID: userID,
+	}
+}
+func (b *userIDRelation) UserAccount(ctx context.Context) *authentication.UserAccount { //TODO, can we move this to an embedded struct to just share the method? (we can't )
+	service := authentication.UserAccountService(ctx)
+	account, _ := service(ctx, b.UserID)
+	return account
+
+}

--- a/pkg/models/user_id_relation.go
+++ b/pkg/models/user_id_relation.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/cmsgov/mint-app/pkg/appcontext"
 	"github.com/cmsgov/mint-app/pkg/authentication"
 )
 
@@ -19,7 +20,7 @@ func NewUserIDRelation(userID uuid.UUID) userIDRelation {
 	}
 }
 func (b *userIDRelation) UserAccount(ctx context.Context) *authentication.UserAccount {
-	service := authentication.UserAccountService(ctx)
+	service := appcontext.UserAccountService(ctx)
 	account, _ := service(ctx, b.UserID)
 	return account
 

--- a/pkg/models/user_id_relation.go
+++ b/pkg/models/user_id_relation.go
@@ -18,7 +18,7 @@ func NewUserIDRelation(userID uuid.UUID) userIDRelation {
 		UserID: userID,
 	}
 }
-func (b *userIDRelation) UserAccount(ctx context.Context) *authentication.UserAccount { //TODO, can we move this to an embedded struct to just share the method? (we can't )
+func (b *userIDRelation) UserAccount(ctx context.Context) *authentication.UserAccount {
 	service := authentication.UserAccountService(ctx)
 	account, _ := service(ctx, b.UserID)
 	return account

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cmsgov/mint-app/pkg/shared/oddmail"
 	"github.com/cmsgov/mint-app/pkg/storage/loaders"
+	"github.com/cmsgov/mint-app/pkg/userhelpers"
 	"github.com/cmsgov/mint-app/pkg/worker"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -113,6 +114,10 @@ func (s *Server) routes(
 	dataLoaders := loaders.NewDataLoaders(store)
 	dataLoaderMiddleware := loaders.NewDataLoaderMiddleware(dataLoaders)
 	s.router.Use(dataLoaderMiddleware)
+
+	userAccountServiceMiddleware := userhelpers.NewUserAccountServiceMiddleware(userhelpers.UserAccountGetByIDLOADER)
+
+	s.router.Use(userAccountServiceMiddleware)
 
 	requirePrincipalMiddleware := authorization.NewRequirePrincipalMiddleware(s.logger)
 

--- a/pkg/storage/SQL/user_account/get_by_id_LOADER.sql
+++ b/pkg/storage/SQL/user_account/get_by_id_LOADER.sql
@@ -1,0 +1,22 @@
+WITH QUERIED_IDS AS (
+    /*Translate the input to a table */
+    SELECT id
+    FROM
+        JSON_TO_RECORDSET(:paramTableJSON)
+        AS x("id" UUID) --noqa
+)
+
+SELECT
+    user_account.id,
+    user_account.username,
+    user_account.is_euaid,
+    user_account.common_name,
+    user_account.locale,
+    user_account.email,
+    user_account.given_name,
+    user_account.family_name,
+    user_account.zone_info,
+    user_account.has_logged_in
+
+FROM QUERIED_IDS AS qIDs
+INNER JOIN user_account ON user_account.id = qIDs.id

--- a/pkg/storage/access_controlStore.go
+++ b/pkg/storage/access_controlStore.go
@@ -20,7 +20,7 @@ var checkIfCollaboratorBySolutionIDSQL string
 var checkIfCollaboratorByOperationalNeedIDSQL string
 
 // CheckIfCollaborator returns true if the principal is a collaborator on a model plan.
-func (s *Store) CheckIfCollaborator(logger *zap.Logger, principalID uuid.UUID, modelPlanID uuid.UUID) (bool, error) { //TODO update to take user_account_id intead of eua
+func (s *Store) CheckIfCollaborator(logger *zap.Logger, principalID uuid.UUID, modelPlanID uuid.UUID) (bool, error) {
 
 	isCollaborator := false
 

--- a/pkg/storage/loaders/data_loaders.go
+++ b/pkg/storage/loaders/data_loaders.go
@@ -7,6 +7,7 @@ type DataLoaders struct {
 	BasicsLoader            *WrappedDataLoader
 	OperationalNeedLoader   *WrappedDataLoader
 	OperationSolutionLoader *WrappedDataLoader
+	UserAccountLoader       *WrappedDataLoader
 	DataReader              *DataReader
 }
 
@@ -20,6 +21,7 @@ func NewDataLoaders(store *storage.Store) *DataLoaders {
 	loaders.BasicsLoader = newWrappedDataLoader(loaders.GetPlanBasicsByModelPlanID)
 	loaders.OperationalNeedLoader = newWrappedDataLoader(loaders.GetOperationalNeedsByModelPlanID)
 	loaders.OperationSolutionLoader = newWrappedDataLoader(loaders.GetOperationalSolutionAndPossibleCollectionByOperationalNeedID)
+	loaders.UserAccountLoader = newWrappedDataLoader(loaders.GetUserAccountsByIDLoader)
 
 	return loaders
 }

--- a/pkg/storage/loaders/user_account_loader.go
+++ b/pkg/storage/loaders/user_account_loader.go
@@ -1,0 +1,64 @@
+package loaders
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/graph-gophers/dataloader"
+	"github.com/samber/lo"
+	"go.uber.org/zap"
+
+	"github.com/cmsgov/mint-app/pkg/appcontext"
+	"github.com/cmsgov/mint-app/pkg/authentication"
+)
+
+// GetUserAccountsByIDLoader Uses a DataLoader to return many User Accounts by ID
+func (loaders *DataLoaders) GetUserAccountsByIDLoader(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
+	dr := loaders.DataReader
+
+	logger := appcontext.ZLogger(ctx)
+	arrayCK, err := ConvertToKeyArgsArray(keys)
+	if err != nil {
+		logger.Error("issue converting keys for data loader in Operational Solutions", zap.Error(*err))
+	}
+	marshaledParams, err := arrayCK.ToJSONArray()
+	if err != nil {
+		logger.Error("issue converting keys to JSON for data loader in Operational Solutions", zap.Error(*err))
+	}
+	output := make([]*dataloader.Result, len(keys))
+
+	userAccounts, err2 := dr.Store.UserAccountGetByIDLOADER(logger, marshaledParams)
+	if err2 != nil { //IF THERE IS A DB error, return error for every result
+		for _, result := range output {
+			result.Error = err2
+			result.Data = nil
+		}
+		return output
+	}
+
+	userByID := lo.Associate(userAccounts, func(user *authentication.UserAccount) (string, *authentication.UserAccount) { //TRANSLATE TO MAP
+		return user.ID.String(), user
+	})
+
+	// RETURN IN THE SAME ORDER REQUESTED
+
+	for index, key := range keys {
+		ck, ok := key.Raw().(KeyArgs)
+		if ok {
+			resKey := fmt.Sprint(ck.Args["id"])
+			user, ok := userByID[resKey]
+			if ok {
+				output[index] = &dataloader.Result{Data: user, Error: nil}
+			} else {
+				err := fmt.Errorf("user account not found for id %s", resKey)
+				output[index] = &dataloader.Result{Data: nil, Error: err}
+			}
+		} else {
+			err := fmt.Errorf("could not retrive key from %s", key.String())
+			output[index] = &dataloader.Result{Data: nil, Error: err}
+		}
+	}
+
+	return output
+
+}

--- a/pkg/storage/user_accountStore.go
+++ b/pkg/storage/user_accountStore.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 
 	"github.com/cmsgov/mint-app/pkg/authentication"
 )
@@ -13,6 +14,9 @@ var userAccountGetByUsername string
 
 //go:embed SQL/user_account/get_by_id.sql
 var userAccountGetByID string
+
+//go:embed SQL/user_account/get_by_id_LOADER.sql
+var userAccountGetByIDLOADER string
 
 //go:embed SQL/user_account/insert_by_username.sql
 var userAccountInsertByUsername string
@@ -65,6 +69,27 @@ func (s *Store) UserAccountGetByID(id uuid.UUID) (*authentication.UserAccount, e
 	}
 
 	return user, nil
+}
+
+// UserAccountGetByIDLOADER gets multiple User account from the database by it's internal id.
+func (s *Store) UserAccountGetByIDLOADER(logger *zap.Logger, paramTableJSON string) ([]*authentication.UserAccount, error) {
+	userSlice := []*authentication.UserAccount{}
+
+	stmt, err := s.db.PrepareNamed(userAccountGetByIDLOADER)
+	if err != nil {
+		return nil, err
+	}
+	arg := map[string]interface{}{
+		"paramTableJSON": paramTableJSON,
+	}
+
+	err = stmt.Select(&userSlice, arg)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return userSlice, nil
 }
 
 // UserAccountInsertByUsername creates a new user account for a given EUAID

--- a/pkg/userhelpers/user_account_middleware.go
+++ b/pkg/userhelpers/user_account_middleware.go
@@ -3,12 +3,13 @@ package userhelpers
 import (
 	"net/http"
 
+	"github.com/cmsgov/mint-app/pkg/appcontext"
 	"github.com/cmsgov/mint-app/pkg/authentication"
 )
 
 func userAccountServiceMiddleware(userFunction authentication.GetUserAccountFromDBFunc, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		nextCtx := authentication.CTXWithUserAccountService(r.Context(), userFunction)
+		nextCtx := appcontext.WithUserAccountService(r.Context(), userFunction)
 		r = r.WithContext(nextCtx)
 		next.ServeHTTP(w, r)
 	})

--- a/pkg/userhelpers/user_account_middleware.go
+++ b/pkg/userhelpers/user_account_middleware.go
@@ -1,0 +1,22 @@
+package userhelpers
+
+import (
+	"net/http"
+
+	"github.com/cmsgov/mint-app/pkg/authentication"
+)
+
+func userAccountServiceMiddleware(userFunction authentication.GetUserAccountFromDBFunc, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCtx := authentication.CTXWithUserAccountService(r.Context(), userFunction)
+		r = r.WithContext(nextCtx)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// NewUserAccountServiceMiddleware creates a new middleware which decorates the context with a authentication.GetUserAccountFromDBFunc
+func NewUserAccountServiceMiddleware(userFunction authentication.GetUserAccountFromDBFunc) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return userAccountServiceMiddleware(userFunction, next)
+	}
+}

--- a/pkg/userhelpers/user_account_utils.go
+++ b/pkg/userhelpers/user_account_utils.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cmsgov/mint-app/pkg/authentication"
 	"github.com/cmsgov/mint-app/pkg/models"
 	"github.com/cmsgov/mint-app/pkg/storage"
+	"github.com/cmsgov/mint-app/pkg/storage/loaders"
 )
 
 // OktaAccountInfo represents the information you get if you query an account from Okta
@@ -182,5 +183,23 @@ func GetUserInfoFromOktaLocal(ctx context.Context, username string) (*OktaAccoun
 		ZoneInfo:          "America/Los_Angeles",
 	}
 	return accountInfo, nil
+
+}
+
+// UserAccountGetByIDLOADER uses a data loader to return a user account from the database
+func UserAccountGetByIDLOADER(ctx context.Context, id uuid.UUID) (*authentication.UserAccount, error) {
+	allLoaders := loaders.Loaders(ctx)
+	userAccountLoader := allLoaders.UserAccountLoader
+
+	key := loaders.NewKeyArgs()
+	key.Args["id"] = id
+
+	thunk := userAccountLoader.Loader.Load(ctx, key)
+	result, err := thunk()
+	if err != nil {
+		return nil, err
+	}
+
+	return result.(*authentication.UserAccount), nil
 
 }


### PR DESCRIPTION
# EASI-2652

## Changes and Description

- Data Loader to get User Account by ID
- Generic functionality to get user account info from a Middleware service
    - GQL will try to call the method provided anytime that there is a method named the same as a property in the GQL
        - So GQL with a createdByUserAccount, or modifiedByUserAccount will call those functions on base struct
        - Likewise, there is a new embedded struct for a user_id_relation. If embedded in any model, GQL will call that method for returning the user account for that ID.

<!-- Put a description here! -->

## How to test this change
1. Make a few model plans
2. On each model plan, make a few different collaborators. 
3. Update the collaborators if you like, optionally with a different account (so you can have more values to test with)
4.  Use this GQL to invoke the dataloader (note these separate fields all call the same data loader)

```GQL
query modelPlanCollection {
    modelPlanCollection(filter: INCLUDE_ALL) {
        id
        basics{
            modelPlanID
            id         
        }
        modelName
        archived
        createdBy
        createdDts
        modifiedBy
        modifiedDts
        status
        isFavorite
        isCollaborator
        collaborators {
            createdByUserAccount 
            {
                commonName
                familyName
                givenName
                email
                locale
            }   
            userAccount 
            {
                commonName
                familyName
                givenName
                email
                locale
            }
            modifiedByUserAccount
            {
                commonName
                familyName
                givenName
                email
                locale
            }  
        }
    }
}
```
## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
