### PR TITLE
[EASI-2630] EUA showing on timestamp instead of user name

### DIFF
--- a/pkg/storage/SQL/plan_basics/get_by_model_plan_id_LOADER.sql
+++ b/pkg/storage/SQL/plan_basics/get_by_model_plan_id_LOADER.sql
@@ -36,6 +36,8 @@ SELECT
     plan_basics.modified_dts,
     plan_basics.ready_for_review_by,
     plan_basics.ready_for_review_dts,
+    plan_basics.ready_for_clearance_by,
+    plan_basics.ready_for_clearance_dts,
     plan_basics.status
 FROM QUERIED_IDS AS qIDs
 INNER JOIN plan_basics ON plan_basics.model_plan_id = qIDs.model_plan_id;

--- a/src/components/ReadyForReview/__snapshots__/index.test.tsx.snap
+++ b/src/components/ReadyForReview/__snapshots__/index.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`The ReadyForReview Component matches snapshot 1`] = `
               id="readyForReview"
               name="field"
               type="checkbox"
-              value=""
+              value="field"
             />
             <label
               class="usa-checkbox__label"

--- a/src/components/ReadyForReview/index.test.tsx
+++ b/src/components/ReadyForReview/index.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { MockedProvider } from '@apollo/react-testing';
 import { act, render, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
 
+import GetUserInfo from 'queries/GetUserInfo';
 import { TaskStatus } from 'types/graphql-global-types';
 
 import ReadyForReview from './index';
@@ -13,18 +15,41 @@ const intialValues = {
   field: 'field',
   sectionName: 'Basics',
   status: TaskStatus.IN_PROGRESS,
-  readyForReviewBy: 'ASDF',
-  readyForReviewDts: '2022-05-12T15:01:39.190679Z',
+  readyForReviewBy: 'MINT',
+  readyForReviewDts: '2024-05-12T15:01:39.190679Z',
   setFieldValue: (field: string, value: any) => {}
 };
+
+const mocks = [
+  {
+    request: {
+      query: GetUserInfo,
+      variables: { username: intialValues.readyForReviewBy }
+    },
+    result: {
+      data: {
+        userAccount: {
+          id: '',
+          username: '',
+          commonName: 'Jerry Seinfeld',
+          email: '',
+          givenName: '',
+          familyName: ''
+        }
+      }
+    }
+  }
+];
 
 describe('The ReadyForReview Component', () => {
   it('renders the component in formik', async () => {
     await act(async () => {
       const { getByTestId } = render(
-        <Formik initialValues={intialValues} onSubmit={onSubmit}>
-          <ReadyForReview {...intialValues} />
-        </Formik>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <Formik initialValues={intialValues} onSubmit={onSubmit}>
+            <ReadyForReview {...intialValues} />
+          </Formik>
+        </MockedProvider>
       );
 
       await waitFor(() => {
@@ -35,28 +60,33 @@ describe('The ReadyForReview Component', () => {
 
   it('renders the component with status = READY_FOR_REVIEW', async () => {
     await act(async () => {
-      const { getByTestId } = render(
-        <Formik initialValues={intialValues} onSubmit={onSubmit}>
-          <ReadyForReview
-            {...intialValues}
-            status={TaskStatus.READY_FOR_REVIEW}
-          />
-        </Formik>
+      const { getByText, getByTestId } = render(
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <Formik initialValues={intialValues} onSubmit={onSubmit}>
+            <ReadyForReview
+              {...intialValues}
+              status={TaskStatus.READY_FOR_REVIEW}
+            />
+          </Formik>
+        </MockedProvider>
       );
 
       await waitFor(() => {
         const component = getByTestId('readyForReview') as HTMLInputElement;
         expect(component).toBeInTheDocument();
         expect(component.checked).toEqual(true);
+        expect(getByText(/Jerry Seinfeld/)).toBeInTheDocument();
       });
     });
   });
 
   it('matches snapshot', async () => {
     const { asFragment } = render(
-      <Formik initialValues={{ testNote: '' }} onSubmit={onSubmit}>
-        <ReadyForReview {...intialValues} />
-      </Formik>
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Formik initialValues={intialValues} onSubmit={onSubmit}>
+          <ReadyForReview {...intialValues} />
+        </Formik>
+      </MockedProvider>
     );
     expect(asFragment()).toMatchSnapshot();
   });

--- a/src/components/ReadyForReview/index.tsx
+++ b/src/components/ReadyForReview/index.tsx
@@ -1,10 +1,16 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQuery } from '@apollo/client';
 import { SummaryBox } from '@trussworks/react-uswds';
 import { Field } from 'formik';
 
 import CheckboxField from 'components/shared/CheckboxField';
 import FieldGroup from 'components/shared/FieldGroup';
+import GetUserInfo from 'queries/GetUserInfo';
+import {
+  GetUserInfo as GetUserInfoType,
+  GetUserInfoVariables
+} from 'queries/types/GetUserInfo';
 import { TaskStatus, TaskStatusInput } from 'types/graphql-global-types';
 import { formatDate } from 'utils/date';
 
@@ -32,6 +38,15 @@ const ReadyForReview = ({
   // This is so that when user unclicks the "Ready for review" checkbox, it will not cause the `markedReady` copy to disappear
   const [persistentCopy] = useState(status === TaskStatus.READY_FOR_REVIEW);
 
+  const { data } = useQuery<GetUserInfoType, GetUserInfoVariables>(
+    GetUserInfo,
+    {
+      variables: {
+        username: readyForReviewBy || ''
+      }
+    }
+  );
+
   return (
     <FieldGroup className="margin-top-8 margin-bottom-3">
       <SummaryBox heading="" className="bg-white border-base-light padding-2">
@@ -56,7 +71,7 @@ const ReadyForReview = ({
         {persistentCopy && readyForReviewBy && readyForReviewDts && (
           <p className="margin-top-1 margin-bottom-0 margin-left-4 text-base">
             {t('markedReady', {
-              reviewer: `${readyForReviewBy}`
+              reviewer: data?.userAccount.commonName
             })}
             {formatDate(readyForReviewDts, 'M/d/yyyy')}
           </p>

--- a/src/components/ReadyForReview/index.tsx
+++ b/src/components/ReadyForReview/index.tsx
@@ -47,6 +47,8 @@ const ReadyForReview = ({
     }
   );
 
+  const commonName = data?.userAccount.commonName;
+
   return (
     <FieldGroup className="margin-top-8 margin-bottom-3">
       <SummaryBox heading="" className="bg-white border-base-light padding-2">
@@ -68,10 +70,10 @@ const ReadyForReview = ({
             }
           }}
         />
-        {persistentCopy && readyForReviewBy && readyForReviewDts && (
+        {persistentCopy && commonName && readyForReviewDts && (
           <p className="margin-top-1 margin-bottom-0 margin-left-4 text-base">
             {t('markedReady', {
-              reviewer: data?.userAccount.commonName
+              reviewer: commonName
             })}
             {formatDate(readyForReviewDts, 'M/d/yyyy')}
           </p>

--- a/src/i18n/en-US/draftModelPlan/draftModelPlan.ts
+++ b/src/i18n/en-US/draftModelPlan/draftModelPlan.ts
@@ -27,7 +27,7 @@ const draftModelPlan = {
   modelPlanStatus: 'Model Plan status',
   modelPlanCopy:
     'This section of the Model Plan ({{-sectionName}}) is ready for review.',
-  markedReady: 'Marked ready for review {{-reviewer}} on ',
+  markedReady: 'Marked ready for review by {{-reviewer}} on ',
   validDate: 'Please use a valid date format.'
 };
 

--- a/src/queries/GetUserInfo.ts
+++ b/src/queries/GetUserInfo.ts
@@ -1,0 +1,14 @@
+import { gql } from '@apollo/client';
+
+export default gql`
+  query GetUserInfo($username: String!) {
+    userAccount(username: $username) {
+      id
+      username
+      commonName
+      email
+      givenName
+      familyName
+    }
+  }
+`;

--- a/src/queries/types/GetUserInfo.ts
+++ b/src/queries/types/GetUserInfo.ts
@@ -1,0 +1,26 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetUserInfo
+// ====================================================
+
+export interface GetUserInfo_userAccount {
+  __typename: "UserAccount";
+  id: UUID;
+  username: string;
+  commonName: string;
+  email: string;
+  givenName: string;
+  familyName: string;
+}
+
+export interface GetUserInfo {
+  userAccount: GetUserInfo_userAccount;
+}
+
+export interface GetUserInfoVariables {
+  username: string;
+}

--- a/src/views/ModelPlan/TaskList/PrepareForClearance/Checklist/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/PrepareForClearance/Checklist/__snapshots__/index.test.tsx.snap
@@ -389,57 +389,6 @@ exports[`Prepare for clearance checklist matches snapshot 1`] = `
                 </svg>
               </a>
             </div>
-            <div
-              class="mint-checkbox usa-checkbox"
-            >
-              <input
-                class="usa-checkbox__input"
-                data-testid="prepare-for-clearance-itSolutions"
-                id="prepare-for-clearance-itSolutions"
-                name="itSolutions.status"
-                type="checkbox"
-                value=""
-              />
-              <label
-                class="usa-checkbox__label"
-                for="prepare-for-clearance-itSolutions"
-              >
-                IT solutions and implementation status
-              </label>
-              <p
-                class="margin-y-1 margin-left-4 line-height-body-3 font-body-2xs"
-              />
-            </div>
-            <div
-              class="tablet:grid-col-8"
-              data-testid="grid"
-            >
-              <a
-                class="usa-link margin-left-4 margin-top-1 margin-bottom-2 display-flex flex-align-center"
-                data-testid="clearance-itSolutions"
-                href="/models/d94958a4-2259-4fe9-b94c-f62492c43287/task-list/prepare-for-clearance/it-solutions/undefined"
-              >
-                Review it solutions and implementation status
-                <svg
-                  aria-hidden="true"
-                  class="usa-icon margin-left-1"
-                  focusable="false"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 24 24"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                    fill="none"
-                  />
-                  <path
-                    d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-                  />
-                </svg>
-              </a>
-            </div>
           </div>
           <button
             class="usa-button margin-top-4"

--- a/src/views/ModelPlan/TaskList/PrepareForClearance/Checklist/index.test.tsx
+++ b/src/views/ModelPlan/TaskList/PrepareForClearance/Checklist/index.test.tsx
@@ -4,6 +4,7 @@ import { MockedProvider } from '@apollo/client/testing';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import GetUserInfo from 'queries/GetUserInfo';
 import GetClearanceStatuses from 'queries/PrepareForClearance/GetClearanceStatuses';
 import { TaskStatus } from 'types/graphql-global-types';
 
@@ -39,6 +40,27 @@ const clearanceMock = [
   }
 ];
 
+const sectionClearanceLabelMock = [
+  {
+    request: {
+      query: GetUserInfo,
+      variables: { username: readyForClearanceBy }
+    },
+    result: {
+      data: {
+        userAccount: {
+          id: '',
+          username: '',
+          commonName: 'Jerry Seinfeld',
+          email: '',
+          givenName: '',
+          familyName: ''
+        }
+      }
+    }
+  }
+];
+
 describe('Prepare for clearance checklist', () => {
   it('renders without errors and unchecks an item', async () => {
     render(
@@ -68,15 +90,17 @@ describe('Prepare for clearance checklist', () => {
 
   it('renders SectionClearanceLabel', async () => {
     render(
-      <SectionClearanceLabel
-        readyForClearanceBy={readyForClearanceBy}
-        readyForClearanceDts={readyForClearanceDts}
-      />
+      <MockedProvider mocks={sectionClearanceLabelMock} addTypename={false}>
+        <SectionClearanceLabel
+          readyForClearanceBy={readyForClearanceBy}
+          readyForClearanceDts={readyForClearanceDts}
+        />
+      </MockedProvider>
     );
 
     await waitFor(() => {
       expect(screen.getByTestId('clearance-label')).toHaveTextContent(
-        'Marked ready for clearance by MINT on 10/24/2022'
+        'Marked ready for clearance by Jerry Seinfeld on 10/24/2022'
       );
     });
   });

--- a/src/views/ModelPlan/TaskList/PrepareForClearance/Checklist/index.tsx
+++ b/src/views/ModelPlan/TaskList/PrepareForClearance/Checklist/index.tsx
@@ -272,9 +272,9 @@ const PrepareForClearanceCheckList = ({
                             section as keyof ClearanceStatusesModelPlanFormType
                           ]?.readyForClearanceDts;
 
-                        // Bypass/don't render itTools or prepareForClearance task list sections
+                        // Bypass/don't render itSolutions or prepareForClearance task list sections
                         if (
-                          section === 'itTools' ||
+                          section === 'itSolutions' ||
                           section === 'prepareForClearance'
                         )
                           return null;

--- a/src/views/ModelPlan/TaskList/PrepareForClearance/Checklist/index.tsx
+++ b/src/views/ModelPlan/TaskList/PrepareForClearance/Checklist/index.tsx
@@ -26,6 +26,7 @@ import CheckboxField from 'components/shared/CheckboxField';
 import { ErrorAlert, ErrorAlertMessage } from 'components/shared/ErrorAlert';
 import FieldErrorMsg from 'components/shared/FieldErrorMsg';
 import FieldGroup from 'components/shared/FieldGroup';
+import GetUserInfo from 'queries/GetUserInfo';
 import GetClearanceStatuses from 'queries/PrepareForClearance/GetClearanceStatuses';
 import {
   GetClearanceStatuses as GetClearanceStatusesType,
@@ -33,6 +34,10 @@ import {
 } from 'queries/PrepareForClearance/types/GetClearanceStatuses';
 import { UpdatePrepareForClearanceVariables } from 'queries/PrepareForClearance/types/UpdatePrepareForClearance';
 import UpdatePrepareForClearance from 'queries/PrepareForClearance/UpdatePrepareForClearance';
+import {
+  GetUserInfo as GetUserInfoType,
+  GetUserInfoVariables
+} from 'queries/types/GetUserInfo';
 import { TaskStatus } from 'types/graphql-global-types';
 import { formatDate } from 'utils/date';
 import flattenErrors from 'utils/flattenErrors';
@@ -374,13 +379,23 @@ export const SectionClearanceLabel = ({
   readyForClearanceDts
 }: SectionClearanceLabelProps): JSX.Element => {
   const { t } = useTranslation('prepareForClearance');
+
+  const { data } = useQuery<GetUserInfoType, GetUserInfoVariables>(
+    GetUserInfo,
+    {
+      variables: {
+        username: readyForClearanceBy
+      }
+    }
+  );
+
   return (
     <p
       data-testid="clearance-label"
       className={classNames(className, 'margin-left-4 text-base margin-y-0')}
     >
       {t('markedAsReady', {
-        readyForClearanceBy,
+        readyForClearanceBy: data?.userAccount.commonName,
         readyForClearanceDts: formatDate(readyForClearanceDts, 'MM/d/yyyy')
       })}
     </p>


### PR DESCRIPTION
# EASI-2630

## Changes and Description

- Quick pairing with @StevenWadeOddball  to make sure basics' `ready_for_review_by` and `ready_for_review_dts` gets updated
- `GetUserInfo` query and type
- Add `GetUserInfo` queries to render username instead of EUA ID
- Change `itTools` to `itSolutions` in Prepare for Clearance checklist

<!-- Put a description here! -->

## How to test this change

### Checking user name is rendering in the `Ready for Review` section

1. Make a Task List section as ready for review.
2. Return to page and make sure the text is rendering username 

### Checking user name is rendering in `Prepare for Clearance` section

1. Go through the task list to enable the `Prepare for Clearance` section
2. Mark the sections ready for clearance
3. Verify that the timestamp shows username, not eua id

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
