### PR TITLE
[NOREF] - Debounce input for CEDAR API calls

### DIFF
--- a/src/components/CedarContactSelect/index.tsx
+++ b/src/components/CedarContactSelect/index.tsx
@@ -161,7 +161,6 @@ export default function CedarContactSelect({
     userSelected
   );
 
-  // If autoSearch, run initial query from name
   const { contacts, queryCedarContacts, loading } = useCedarContactLookup(
     debounceValue,
     userSelected
@@ -169,9 +168,6 @@ export default function CedarContactSelect({
 
   // Selected contact
   const selectedContact = useRef(value?.euaUserId);
-
-  // Show warning if autosearch returns multiple or no results
-  const showWarning = autoSearch && !value?.euaUserId && contacts.length !== 1;
 
   /** Update contact and reset search term */
   const updateContact = (contact?: CedarContactProps | null) => {
@@ -273,7 +269,6 @@ export default function CedarContactSelect({
         'cedar-contact-select',
         'maxw-none',
         'usa-combo-box',
-        { 'cedar-contact-select__warning': showWarning },
         {
           'cedar-contact-select__loading':
             (loading || debounceLoading) &&

--- a/src/components/CedarContactSelect/index.tsx
+++ b/src/components/CedarContactSelect/index.tsx
@@ -157,7 +157,7 @@ export default function CedarContactSelect({
 
   const { debounceValue, debounceLoading } = useDebounce(
     searchTerm,
-    1500,
+    250,
     userSelected
   );
 

--- a/src/hooks/useCedarContactLookup.tsx
+++ b/src/hooks/useCedarContactLookup.tsx
@@ -29,7 +29,7 @@ function useCedarContactLookup(query?: string | null): CedarHookProps {
     GetCedarUser,
     {
       variables: { commonName: searchTerm },
-      skip: !query || query.length < 2
+      skip: !query || query.length < 3
     }
   );
 

--- a/src/hooks/useCedarContactLookup.tsx
+++ b/src/hooks/useCedarContactLookup.tsx
@@ -20,7 +20,10 @@ type CedarHookProps = {
 /**
  * Custom hook for retrieving contacts from Cedar by common name
  * */
-function useCedarContactLookup(query?: string | null): CedarHookProps {
+function useCedarContactLookup(
+  query?: string | null,
+  userSelected?: boolean
+): CedarHookProps {
   const [searchTerm, setSearchTerm] = useState<string | null | undefined>(
     query
   );
@@ -29,7 +32,7 @@ function useCedarContactLookup(query?: string | null): CedarHookProps {
     GetCedarUser,
     {
       variables: { commonName: searchTerm },
-      skip: !query || query.length < 3
+      skip: !query || query.length < 3 || userSelected
     }
   );
 

--- a/src/hooks/useCedarContactLookup.tsx
+++ b/src/hooks/useCedarContactLookup.tsx
@@ -32,7 +32,7 @@ function useCedarContactLookup(
     GetCedarUser,
     {
       variables: { commonName: searchTerm },
-      skip: !query || query.length < 3 || userSelected
+      skip: !searchTerm || searchTerm.length < 3 || userSelected
     }
   );
 

--- a/src/hooks/useDebounce.tsx
+++ b/src/hooks/useDebounce.tsx
@@ -1,0 +1,27 @@
+/*
+Hook used to debounce input, return debounce loading, and stop debounce
+*/
+
+import { useEffect, useState } from 'react';
+
+function useDebounce(value: string | undefined, wait: number, stop: boolean) {
+  const [oldValue, setOldValue] = useState(value); // Used to compare again incoming value to reset loading state
+  const [debounceValue, setDebounceValue] = useState(value);
+  const [debounceLoading, setDebounceLoading] = useState<boolean>(false);
+  useEffect(() => {
+    if (!debounceLoading && value !== oldValue && !stop) {
+      // If value changes start loading
+      setDebounceLoading(true);
+    }
+    const timer = setTimeout(() => {
+      setDebounceValue(value);
+      setOldValue(value);
+      setDebounceLoading(false);
+    }, wait);
+    return () => clearTimeout(timer); // cleanup when unmounted
+  }, [value, wait, debounceLoading, oldValue, stop]);
+
+  return { debounceValue, debounceLoading };
+}
+
+export default useDebounce;


### PR DESCRIPTION
NOREF

## Changes and Description

- Created `useDebounce` hook
- Updated `CedarContactSelect` and `useCedarLookup` to be more tailored to MINT's needs


There was the option to use `lodash`, however I found this solution to be simpler and more customizable.  Even if using `lodash` a custom hook would still be necessary.  

## How to test this change

- Test difference debounce delays by changing line
https://github.com/CMSgov/mint-app/blob/b21d3ae5fa8ef5f7d27a13aaf09391b81830b7c7/src/components/CedarContactSelect/index.tsx#L160

- Inspect network calls to ensure the request is being properly debounced

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
