### PR TITLE
[NOREF] Adding a NONPROD_JOB_CODES constant to jobCodes.ts

### DIFF
--- a/src/constants/jobCodes.ts
+++ b/src/constants/jobCodes.ts
@@ -4,6 +4,14 @@ export const ASSESSMENT_NONPROD = 'MINT_ASSESSMENT_NONPROD';
 export const ASSESSMENT = 'MINT_ASSESSMENT';
 export const MAC = 'MINT MAC Users';
 
-export const JOB_CODES = [BASIC, ASSESSMENT, MAC];
+export const NONPROD_JOB_CODES = [BASIC_NONPROD, ASSESSMENT_NONPROD, MAC];
+
+export const JOB_CODES = [
+  BASIC,
+  ASSESSMENT,
+  BASIC_NONPROD,
+  ASSESSMENT_NONPROD,
+  MAC
+];
 
 export default JOB_CODES;

--- a/src/views/AuthenticationWrapper/DevLogin.tsx
+++ b/src/views/AuthenticationWrapper/DevLogin.tsx
@@ -1,10 +1,10 @@
 import React, { Fragment, ReactEventHandler, useState } from 'react';
 
-import JOB_CODES from 'constants/jobCodes';
+import { NONPROD_JOB_CODES } from 'constants/jobCodes';
 import { localAuthStorageKey } from 'constants/localAuth';
 
 const DevLogin = () => {
-  const availableJobCodes: any = JOB_CODES.reduce(
+  const availableJobCodes: any = NONPROD_JOB_CODES.reduce(
     (codes: any, code: any) => ({ ...codes, [code]: false }),
     {}
   );


### PR DESCRIPTION
# NOREF

## Changes and Description

This is a fast follow to what @StevenWadeOddball [mentioned](https://github.com/CMSgov/mint-app/pull/433#pullrequestreview-1283617573) in #433, which was addressing a PROD side error on job codes. 

- Add a `NONPROD_JOB_CODES` constant
- Add all possible job codes in `JOB_CODES`
- Adjusted `DevLogin` to check the `NONPROD_JOB_CODES`

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
