### PR TITLE
[NOREF] Add permissions to manual deploy to read credentials

### DIFF
--- a/.github/workflows/manual_deploy.yml
+++ b/.github/workflows/manual_deploy.yml
@@ -19,6 +19,10 @@ on:
         type: boolean
         description: Confirm that you want to deploy to production
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build_application_images:
     uses: ./.github/workflows/build_application_images.yml


### PR DESCRIPTION
# NOREF

## Changes and Description

- Add read/write permissions to manual deploy script
- [Example of job failing](https://github.com/CMSgov/mint-app/actions/runs/4126898076/jobs/7129579404)

## How to test this change

- This introduces the same permissions as the deploy_to_environment job, which is all that needs to be done to match.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
