### PR TITLE
[NOREF] OnLockTaskListSectionContext Changed order of OnDisconnect Functionality to Fix Race Condition

### DIFF
--- a/pkg/graph/model/subscribers/task_list_section_lock_changed_subscriber.go
+++ b/pkg/graph/model/subscribers/task_list_section_lock_changed_subscriber.go
@@ -3,14 +3,20 @@ package subscribers
 import (
 	"github.com/google/uuid"
 
+	"github.com/cmsgov/mint-app/pkg/shared/pubsub"
+
 	"github.com/cmsgov/mint-app/pkg/graph/model"
 )
 
+// OnTaskListSectionLockChangedUnsubscribedCallback is a callback that will be called when a TaskListSectionLockChangedSubscriber is unsubscribed
+type OnTaskListSectionLockChangedUnsubscribedCallback func(ps pubsub.PubSub, subscriber pubsub.Subscriber, modelPlanID uuid.UUID)
+
 // TaskListSectionLockChangedSubscriber is a Subscriber definition to receive TaskListSectionLockStatusChanged payloads
 type TaskListSectionLockChangedSubscriber struct {
-	ID        uuid.UUID
-	Principal string
-	Channel   chan *model.TaskListSectionLockStatusChanged
+	ID             uuid.UUID
+	Principal      string
+	Channel        chan *model.TaskListSectionLockStatusChanged
+	onUnsubscribed OnTaskListSectionLockChangedUnsubscribedCallback
 }
 
 // NewTaskListSectionLockChangedSubscriber is a constructor to create a new TaskListSectionLockChangedSubscriber
@@ -29,22 +35,34 @@ func NewTaskListSectionLockChangedSubscriber(Principal string) (*TaskListSection
 }
 
 // GetID returns this Subscriber's unique identifying token
-func (t TaskListSectionLockChangedSubscriber) GetID() string {
+func (t *TaskListSectionLockChangedSubscriber) GetID() string {
 	return t.ID.String()
 }
 
 // GetPrincipal returns this Subscriber's associated EUAID
-func (t TaskListSectionLockChangedSubscriber) GetPrincipal() string {
+func (t *TaskListSectionLockChangedSubscriber) GetPrincipal() string {
 	return t.Principal
 }
 
 // Notify will be called by the PubSub service when an event this Subscriber is registered for is dispatched
-func (t TaskListSectionLockChangedSubscriber) Notify(payload interface{}) {
+func (t *TaskListSectionLockChangedSubscriber) Notify(payload interface{}) {
 	typedPayload := payload.(model.TaskListSectionLockStatusChanged)
 	t.Channel <- &typedPayload
 }
 
+// NotifyUnsubscribed will be called by the PubSub service when this Subscriber is unsubscribed
+func (t *TaskListSectionLockChangedSubscriber) NotifyUnsubscribed(ps *pubsub.ServicePubSub, sessionID uuid.UUID) {
+	if t.onUnsubscribed != nil {
+		t.onUnsubscribed(ps, t, sessionID)
+	}
+}
+
 // GetChannel provides this Subscriber's feedback channel
-func (t TaskListSectionLockChangedSubscriber) GetChannel() <-chan *model.TaskListSectionLockStatusChanged {
+func (t *TaskListSectionLockChangedSubscriber) GetChannel() <-chan *model.TaskListSectionLockStatusChanged {
 	return t.Channel
+}
+
+// SetOnUnsubscribedCallback is an optional callback that will be called when this Subscriber is unsubscribed
+func (t *TaskListSectionLockChangedSubscriber) SetOnUnsubscribedCallback(onUnsubscribed OnTaskListSectionLockChangedUnsubscribedCallback) {
+	t.onUnsubscribed = onUnsubscribed
 }

--- a/pkg/shared/pubsub/mockpubsub/subscriber.go
+++ b/pkg/shared/pubsub/mockpubsub/subscriber.go
@@ -8,6 +8,9 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	uuid "github.com/google/uuid"
+
+	pubsub "github.com/cmsgov/mint-app/pkg/shared/pubsub"
 )
 
 // MockSubscriber is a mock of Subscriber interface.
@@ -71,4 +74,16 @@ func (m *MockSubscriber) Notify(payload interface{}) {
 func (mr *MockSubscriberMockRecorder) Notify(payload interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Notify", reflect.TypeOf((*MockSubscriber)(nil).Notify), payload)
+}
+
+// NotifyUnsubscribed mocks base method.
+func (m *MockSubscriber) NotifyUnsubscribed(ps *pubsub.ServicePubSub, sessionID uuid.UUID) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NotifyUnsubscribed", ps, sessionID)
+}
+
+// NotifyUnsubscribed indicates an expected call of NotifyUnsubscribed.
+func (mr *MockSubscriberMockRecorder) NotifyUnsubscribed(ps, sessionID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyUnsubscribed", reflect.TypeOf((*MockSubscriber)(nil).NotifyUnsubscribed), ps, sessionID)
 }

--- a/pkg/shared/pubsub/servicepubsub.go
+++ b/pkg/shared/pubsub/servicepubsub.go
@@ -48,7 +48,14 @@ func (ps *ServicePubSub) Unsubscribe(sessionID uuid.UUID, eventType EventType, s
 		return
 	}
 
+	subscriber, wasSubscriberMapFound := subscriberMap[subscriberID]
+	if !wasSubscriberMapFound {
+		return
+	}
+
 	ps.deleteSubscriber(subscriberMap, subscriberID)
+
+	subscriber.NotifyUnsubscribed(ps, sessionID)
 
 	if len(subscriberMap) == 0 {
 		delete(session, eventType)

--- a/pkg/shared/pubsub/subscriber.go
+++ b/pkg/shared/pubsub/subscriber.go
@@ -1,5 +1,7 @@
 package pubsub
 
+import "github.com/google/uuid"
+
 // Subscriber is an abstract interface defining the necessary functionality for a subscription model
 //
 //	It is intended for the user to define their own version of a Subscriber to assign when subscribing to an EventType
@@ -7,4 +9,5 @@ type Subscriber interface {
 	GetID() string
 	GetPrincipal() string
 	Notify(payload interface{})
+	NotifyUnsubscribed(ps *ServicePubSub, sessionID uuid.UUID)
 }


### PR DESCRIPTION
Resolved race condition where unlocking task list sections and unsubscribing from pubsub on disconnect were not happening in sequence by adding a callback when a user is unsubscribed from pubsub and using it in the lock task list section context to then unlock all task list sections held by this user on this model plan ID.

# EASI-NOREF

## Changes and Description

- Removed onDisconnect handling from a go func() created in the OnTaskListLockCreation
- Added a callback for when a subscriber is unsubscribed from pubsub
- Used this callback to remove all locks held on a model plan by a subscriber when disconnected

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
