### PR TITLE
[NOREF] Fix migration that removes architect to set modified_by and modified_dts

### DIFF
--- a/migrations/V68__Remove_Architect_Role_From_Team_Roles.sql
+++ b/migrations/V68__Remove_Architect_Role_From_Team_Roles.sql
@@ -1,7 +1,11 @@
 DROP TRIGGER collaborator_lead_req_update ON plan_collaborator;
 DROP TRIGGER collaborator_lead_req_delete ON plan_collaborator;
 
-UPDATE plan_collaborator SET team_role = 'IT_LEAD' WHERE team_role = 'ARCHITECT';
+UPDATE plan_collaborator SET
+    team_role = 'IT_LEAD',
+    modified_by = '00000001-0001-0001-0001-000000000001', -- System Account
+    modified_dts = CURRENT_TIMESTAMP
+WHERE team_role = 'ARCHITECT';
 
 ALTER TYPE TEAM_ROLE RENAME TO TEAM_ROLE_OLD;
 
@@ -23,11 +27,11 @@ CREATE TRIGGER collaborator_lead_req_update
 BEFORE UPDATE ON plan_collaborator
 FOR EACH ROW
 WHEN ((old.team_role = 'MODEL_LEAD') AND (new.team_role != 'MODEL_LEAD'))
-EXECUTE FUNCTION collaborator_role_check_trigger();
+EXECUTE FUNCTION COLLABORATOR_ROLE_CHECK_TRIGGER();
 
 
 CREATE TRIGGER collaborator_lead_req_delete
 BEFORE DELETE ON plan_collaborator
 FOR EACH ROW
 WHEN (old.team_role = 'MODEL_LEAD')
-EXECUTE FUNCTION collaborator_role_check_trigger();
+EXECUTE FUNCTION COLLABORATOR_ROLE_CHECK_TRIGGER();


### PR DESCRIPTION
# EASI-000

## Changes and Description

- Adds `modified_by` and `modified_dts` to the migration that updates plan collaborators

https://github.com/CMSgov/mint-app/pull/465

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
