### PR TITLE
EASI-2653 Task List Locking to use User Account

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -887,10 +887,10 @@ type ComplexityRoot struct {
 	}
 
 	TaskListSectionLockStatus struct {
-		IsAssessment func(childComplexity int) int
-		LockedBy     func(childComplexity int) int
-		ModelPlanID  func(childComplexity int) int
-		Section      func(childComplexity int) int
+		IsAssessment        func(childComplexity int) int
+		LockedByUserAccount func(childComplexity int) int
+		ModelPlanID         func(childComplexity int) int
+		Section             func(childComplexity int) int
 	}
 
 	TaskListSectionLockStatusChanged struct {
@@ -6590,12 +6590,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TaskListSectionLockStatus.IsAssessment(childComplexity), true
 
-	case "TaskListSectionLockStatus.lockedBy":
-		if e.complexity.TaskListSectionLockStatus.LockedBy == nil {
+	case "TaskListSectionLockStatus.lockedByUserAccount":
+		if e.complexity.TaskListSectionLockStatus.LockedByUserAccount == nil {
 			break
 		}
 
-		return e.complexity.TaskListSectionLockStatus.LockedBy(childComplexity), true
+		return e.complexity.TaskListSectionLockStatus.LockedByUserAccount(childComplexity), true
 
 	case "TaskListSectionLockStatus.modelPlanID":
 		if e.complexity.TaskListSectionLockStatus.ModelPlanID == nil {
@@ -6991,7 +6991,7 @@ type TaskListSectionLockStatusChanged {
 type TaskListSectionLockStatus {
   modelPlanID: UUID!
   section: TaskListSection!
-  lockedBy: String!
+  lockedByUserAccount: UserAccount!
   isAssessment: Boolean!
 }
 
@@ -17508,8 +17508,8 @@ func (ec *executionContext) fieldContext_Mutation_unlockAllTaskListSections(ctx 
 				return ec.fieldContext_TaskListSectionLockStatus_modelPlanID(ctx, field)
 			case "section":
 				return ec.fieldContext_TaskListSectionLockStatus_section(ctx, field)
-			case "lockedBy":
-				return ec.fieldContext_TaskListSectionLockStatus_lockedBy(ctx, field)
+			case "lockedByUserAccount":
+				return ec.fieldContext_TaskListSectionLockStatus_lockedByUserAccount(ctx, field)
 			case "isAssessment":
 				return ec.fieldContext_TaskListSectionLockStatus_isAssessment(ctx, field)
 			}
@@ -46365,8 +46365,8 @@ func (ec *executionContext) fieldContext_Query_taskListSectionLocks(ctx context.
 				return ec.fieldContext_TaskListSectionLockStatus_modelPlanID(ctx, field)
 			case "section":
 				return ec.fieldContext_TaskListSectionLockStatus_section(ctx, field)
-			case "lockedBy":
-				return ec.fieldContext_TaskListSectionLockStatus_lockedBy(ctx, field)
+			case "lockedByUserAccount":
+				return ec.fieldContext_TaskListSectionLockStatus_lockedByUserAccount(ctx, field)
 			case "isAssessment":
 				return ec.fieldContext_TaskListSectionLockStatus_isAssessment(ctx, field)
 			}
@@ -47687,8 +47687,8 @@ func (ec *executionContext) fieldContext_TaskListSectionLockStatus_section(ctx c
 	return fc, nil
 }
 
-func (ec *executionContext) _TaskListSectionLockStatus_lockedBy(ctx context.Context, field graphql.CollectedField, obj *model.TaskListSectionLockStatus) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_TaskListSectionLockStatus_lockedBy(ctx, field)
+func (ec *executionContext) _TaskListSectionLockStatus_lockedByUserAccount(ctx context.Context, field graphql.CollectedField, obj *model.TaskListSectionLockStatus) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TaskListSectionLockStatus_lockedByUserAccount(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -47701,7 +47701,7 @@ func (ec *executionContext) _TaskListSectionLockStatus_lockedBy(ctx context.Cont
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.LockedBy, nil
+		return obj.LockedByUserAccount, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -47713,19 +47713,41 @@ func (ec *executionContext) _TaskListSectionLockStatus_lockedBy(ctx context.Cont
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*authentication.UserAccount)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNUserAccount2ᚖgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋauthenticationᚐUserAccount(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_TaskListSectionLockStatus_lockedBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_TaskListSectionLockStatus_lockedByUserAccount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "TaskListSectionLockStatus",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_UserAccount_id(ctx, field)
+			case "username":
+				return ec.fieldContext_UserAccount_username(ctx, field)
+			case "isEUAID":
+				return ec.fieldContext_UserAccount_isEUAID(ctx, field)
+			case "commonName":
+				return ec.fieldContext_UserAccount_commonName(ctx, field)
+			case "locale":
+				return ec.fieldContext_UserAccount_locale(ctx, field)
+			case "email":
+				return ec.fieldContext_UserAccount_email(ctx, field)
+			case "givenName":
+				return ec.fieldContext_UserAccount_givenName(ctx, field)
+			case "familyName":
+				return ec.fieldContext_UserAccount_familyName(ctx, field)
+			case "zoneInfo":
+				return ec.fieldContext_UserAccount_zoneInfo(ctx, field)
+			case "hasLoggedIn":
+				return ec.fieldContext_UserAccount_hasLoggedIn(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UserAccount", field.Name)
 		},
 	}
 	return fc, nil
@@ -47862,8 +47884,8 @@ func (ec *executionContext) fieldContext_TaskListSectionLockStatusChanged_lockSt
 				return ec.fieldContext_TaskListSectionLockStatus_modelPlanID(ctx, field)
 			case "section":
 				return ec.fieldContext_TaskListSectionLockStatus_section(ctx, field)
-			case "lockedBy":
-				return ec.fieldContext_TaskListSectionLockStatus_lockedBy(ctx, field)
+			case "lockedByUserAccount":
+				return ec.fieldContext_TaskListSectionLockStatus_lockedByUserAccount(ctx, field)
 			case "isAssessment":
 				return ec.fieldContext_TaskListSectionLockStatus_isAssessment(ctx, field)
 			}
@@ -57114,9 +57136,9 @@ func (ec *executionContext) _TaskListSectionLockStatus(ctx context.Context, sel 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "lockedBy":
+		case "lockedByUserAccount":
 
-			out.Values[i] = ec._TaskListSectionLockStatus_lockedBy(ctx, field, obj)
+			out.Values[i] = ec._TaskListSectionLockStatus_lockedByUserAccount(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
+	"github.com/cmsgov/mint-app/pkg/authentication"
 	"github.com/cmsgov/mint-app/pkg/models"
 	"github.com/google/uuid"
 )
@@ -79,10 +80,10 @@ type PrepareForClearance struct {
 }
 
 type TaskListSectionLockStatus struct {
-	ModelPlanID  uuid.UUID              `json:"modelPlanID"`
-	Section      models.TaskListSection `json:"section"`
-	LockedBy     string                 `json:"lockedBy"`
-	IsAssessment bool                   `json:"isAssessment"`
+	ModelPlanID         uuid.UUID                   `json:"modelPlanID"`
+	Section             models.TaskListSection      `json:"section"`
+	LockedByUserAccount *authentication.UserAccount `json:"lockedByUserAccount"`
+	IsAssessment        bool                        `json:"isAssessment"`
 }
 
 type TaskListSectionLockStatusChanged struct {

--- a/pkg/graph/model/subscribers/task_list_section_lock_changed_subscriber.go
+++ b/pkg/graph/model/subscribers/task_list_section_lock_changed_subscriber.go
@@ -3,6 +3,7 @@ package subscribers
 import (
 	"github.com/google/uuid"
 
+	"github.com/cmsgov/mint-app/pkg/authentication"
 	"github.com/cmsgov/mint-app/pkg/shared/pubsub"
 
 	"github.com/cmsgov/mint-app/pkg/graph/model"
@@ -14,13 +15,13 @@ type OnTaskListSectionLockChangedUnsubscribedCallback func(ps pubsub.PubSub, sub
 // TaskListSectionLockChangedSubscriber is a Subscriber definition to receive TaskListSectionLockStatusChanged payloads
 type TaskListSectionLockChangedSubscriber struct {
 	ID             uuid.UUID
-	Principal      string
+	Principal      authentication.Principal
 	Channel        chan *model.TaskListSectionLockStatusChanged
 	onUnsubscribed OnTaskListSectionLockChangedUnsubscribedCallback
 }
 
 // NewTaskListSectionLockChangedSubscriber is a constructor to create a new TaskListSectionLockChangedSubscriber
-func NewTaskListSectionLockChangedSubscriber(Principal string) (*TaskListSectionLockChangedSubscriber, error) {
+func NewTaskListSectionLockChangedSubscriber(Principal authentication.Principal) (*TaskListSectionLockChangedSubscriber, error) {
 	id, err := uuid.NewUUID()
 	if err != nil {
 		return nil, err
@@ -40,7 +41,7 @@ func (t *TaskListSectionLockChangedSubscriber) GetID() string {
 }
 
 // GetPrincipal returns this Subscriber's associated EUAID
-func (t *TaskListSectionLockChangedSubscriber) GetPrincipal() string {
+func (t *TaskListSectionLockChangedSubscriber) GetPrincipal() authentication.Principal {
 	return t.Principal
 }
 

--- a/pkg/graph/resolvers/plan_task_list_section_locks_test.go
+++ b/pkg/graph/resolvers/plan_task_list_section_locks_test.go
@@ -38,8 +38,8 @@ func (suite *ResolverSuite) TestGetTaskListSectionLocksWithLockedSections() {
 	assert.Len(suite.T(), resultsFilled, 2)
 	assert.Contains(suite.T(), sections, (*resultsFilled[0]).Section)
 	assert.Contains(suite.T(), sections, (*resultsFilled[1]).Section)
-	assert.Equal(suite.T(), "TEST", (*resultsFilled[0]).LockedBy)
-	assert.Equal(suite.T(), "TEST", (*resultsFilled[1]).LockedBy)
+	assert.Equal(suite.T(), "TEST", (*resultsFilled[0]).LockedByUserAccount.Username)
+	assert.Equal(suite.T(), "TEST", (*resultsFilled[1]).LockedByUserAccount.Username)
 }
 
 func (suite *ResolverSuite) TestLockTaskListSection() {

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -174,7 +174,7 @@ type TaskListSectionLockStatusChanged {
 type TaskListSectionLockStatus {
   modelPlanID: UUID!
   section: TaskListSection!
-  lockedBy: String!
+  lockedByUserAccount: UserAccount!
   isAssessment: Boolean!
 }
 

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -305,9 +305,9 @@ func (r *mutationResolver) LockTaskListSection(ctx context.Context, modelPlanID 
 
 // UnlockTaskListSection is the resolver for the unlockTaskListSection field.
 func (r *mutationResolver) UnlockTaskListSection(ctx context.Context, modelPlanID uuid.UUID, section models.TaskListSection) (bool, error) {
-	principal := appcontext.Principal(ctx).ID()
+	userID := appcontext.Principal(ctx).Account().ID
 
-	return resolvers.UnlockTaskListSection(r.pubsub, modelPlanID, section, principal, model.ActionTypeNormal)
+	return resolvers.UnlockTaskListSection(r.pubsub, modelPlanID, section, userID, model.ActionTypeNormal)
 }
 
 // UnlockAllTaskListSections is the resolver for the unlockAllTaskListSections field.
@@ -1014,14 +1014,14 @@ func (r *queryResolver) UserAccount(ctx context.Context, username string) (*auth
 
 // OnTaskListSectionLocksChanged is the resolver for the onTaskListSectionLocksChanged field.
 func (r *subscriptionResolver) OnTaskListSectionLocksChanged(ctx context.Context, modelPlanID uuid.UUID) (<-chan *model.TaskListSectionLockStatusChanged, error) {
-	principal := appcontext.Principal(ctx).ID()
+	principal := appcontext.Principal(ctx)
 
 	return resolvers.SubscribeTaskListSectionLockChanges(r.pubsub, modelPlanID, principal, ctx.Done())
 }
 
 // OnLockTaskListSectionContext is the resolver for the onLockTaskListSectionContext field.
 func (r *subscriptionResolver) OnLockTaskListSectionContext(ctx context.Context, modelPlanID uuid.UUID) (<-chan *model.TaskListSectionLockStatusChanged, error) {
-	principal := appcontext.Principal(ctx).ID()
+	principal := appcontext.Principal(ctx)
 
 	return resolvers.OnLockTaskListSectionContext(r.pubsub, modelPlanID, principal, ctx.Done())
 }

--- a/pkg/shared/pubsub/mockpubsub/subscriber.go
+++ b/pkg/shared/pubsub/mockpubsub/subscriber.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	uuid "github.com/google/uuid"
 
+	"github.com/cmsgov/mint-app/pkg/authentication"
 	pubsub "github.com/cmsgov/mint-app/pkg/shared/pubsub"
 )
 
@@ -51,10 +52,10 @@ func (mr *MockSubscriberMockRecorder) GetID() *gomock.Call {
 }
 
 // GetPrincipal mocks base method.
-func (m *MockSubscriber) GetPrincipal() string {
+func (m *MockSubscriber) GetPrincipal() authentication.Principal {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPrincipal")
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(authentication.Principal)
 	return ret0
 }
 

--- a/pkg/shared/pubsub/subscriber.go
+++ b/pkg/shared/pubsub/subscriber.go
@@ -1,13 +1,17 @@
 package pubsub
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+
+	"github.com/cmsgov/mint-app/pkg/authentication"
+)
 
 // Subscriber is an abstract interface defining the necessary functionality for a subscription model
 //
 //	It is intended for the user to define their own version of a Subscriber to assign when subscribing to an EventType
 type Subscriber interface {
 	GetID() string
-	GetPrincipal() string
+	GetPrincipal() authentication.Principal
 	Notify(payload interface{})
 	NotifyUnsubscribed(ps *ServicePubSub, sessionID uuid.UUID)
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -110,7 +110,7 @@ const client = new ApolloClient({
         keyFields: ['key', 'nameOther', 'id']
       },
       TaskListSectionLockStatus: {
-        keyFields: ['section', 'lockedBy', 'modelPlanID']
+        keyFields: ['section', 'lockedByUserAccount', 'modelPlanID'] // TODO: this needs to be updated to get a field off of the lockedByUserAccount
       }
     }
   }),

--- a/src/queries/TaskListSubscription/GetTaskListSubscriptions.ts
+++ b/src/queries/TaskListSubscription/GetTaskListSubscriptions.ts
@@ -5,7 +5,12 @@ export default gql`
     taskListSectionLocks(modelPlanID: $modelPlanID) {
       modelPlanID
       section
-      lockedBy
+      # lockedBy
+      lockedByUserAccount {
+        id
+        username
+        commonName
+      }
       isAssessment
     }
   }

--- a/src/queries/TaskListSubscription/SubscribeToTaskList.ts
+++ b/src/queries/TaskListSubscription/SubscribeToTaskList.ts
@@ -7,7 +7,11 @@ export default gql`
       lockStatus {
         modelPlanID
         section
-        lockedBy
+        lockedByUserAccount {
+          id
+          username
+          commonName
+        }
         isAssessment
       }
       actionType

--- a/src/queries/TaskListSubscription/types/GetTaskListSubscriptions.ts
+++ b/src/queries/TaskListSubscription/types/GetTaskListSubscriptions.ts
@@ -9,11 +9,18 @@ import { TaskListSection } from "./../../../types/graphql-global-types";
 // GraphQL query operation: GetTaskListSubscriptions
 // ====================================================
 
+export interface GetTaskListSubscriptions_taskListSectionLocks_lockedByUserAccount {
+  __typename: "UserAccount";
+  id: UUID;
+  username: string;
+  commonName: string;
+}
+
 export interface GetTaskListSubscriptions_taskListSectionLocks {
   __typename: "TaskListSectionLockStatus";
   modelPlanID: UUID;
   section: TaskListSection;
-  lockedBy: string;
+  lockedByUserAccount: GetTaskListSubscriptions_taskListSectionLocks_lockedByUserAccount;
   isAssessment: boolean;
 }
 

--- a/src/queries/TaskListSubscription/types/TaskListSubscription.ts
+++ b/src/queries/TaskListSubscription/types/TaskListSubscription.ts
@@ -9,11 +9,18 @@ import { ChangeType, TaskListSection, ActionType } from "./../../../types/graphq
 // GraphQL subscription operation: TaskListSubscription
 // ====================================================
 
+export interface TaskListSubscription_onLockTaskListSectionContext_lockStatus_lockedByUserAccount {
+  __typename: "UserAccount";
+  id: UUID;
+  username: string;
+  commonName: string;
+}
+
 export interface TaskListSubscription_onLockTaskListSectionContext_lockStatus {
   __typename: "TaskListSectionLockStatus";
   modelPlanID: UUID;
   section: TaskListSection;
-  lockedBy: string;
+  lockedByUserAccount: TaskListSubscription_onLockTaskListSectionContext_lockStatus_lockedByUserAccount;
   isAssessment: boolean;
 }
 

--- a/src/views/ModelPlan/TaskList/index.tsx
+++ b/src/views/ModelPlan/TaskList/index.tsx
@@ -306,7 +306,8 @@ const TaskList = () => {
                           path={t(`numberedList.${key}.path`)}
                           disabled={
                             !!getTaskListLockedStatus(key) &&
-                            getTaskListLockedStatus(key)?.lockedBy !== euaId
+                            getTaskListLockedStatus(key)?.lockedByUserAccount
+                              .username !== euaId
                           }
                           status={taskListSections[key].status}
                         />
@@ -316,12 +317,14 @@ const TaskList = () => {
                             !!getTaskListLockedStatus(key)?.isAssessment
                           }
                           selfLocked={
-                            getTaskListLockedStatus(key)?.lockedBy === euaId
+                            getTaskListLockedStatus(key)?.lockedByUserAccount
+                              .username !== euaId
                           }
                           collaborator={collaborators.find(
                             collaborator =>
                               collaborator.userAccount.username ===
-                              getTaskListLockedStatus(key)?.lockedBy
+                              getTaskListLockedStatus(key)?.lockedByUserAccount
+                                .username
                           )}
                         />
                       </TaskListItem>

--- a/src/views/SubscriptionHandler/index.test.tsx
+++ b/src/views/SubscriptionHandler/index.test.tsx
@@ -8,14 +8,24 @@ const locks: LockSectionType[] = [
     __typename: 'TaskListSectionLockStatus',
     modelPlanID: '123',
     section: TaskListSection.BENEFICIARIES,
-    lockedBy: 'MINT',
+    lockedByUserAccount: {
+      id: '00000001-0001-0001-0001-000000000001',
+      username: 'MINT',
+      commonName: 'MINT Doe',
+      __typename: 'UserAccount'
+    },
     isAssessment: true
   },
   {
     __typename: 'TaskListSectionLockStatus',
     modelPlanID: '123',
     section: TaskListSection.PAYMENT,
-    lockedBy: 'ABCD',
+    lockedByUserAccount: {
+      id: '00000001-0001-0001-0001-000000000001',
+      username: 'MINT',
+      commonName: 'MINT Doe',
+      __typename: 'UserAccount'
+    },
     isAssessment: false
   }
 ];

--- a/src/views/SubscriptionHandler/index.tsx
+++ b/src/views/SubscriptionHandler/index.tsx
@@ -62,7 +62,10 @@ export const findLockedSection = (
   if (!foundLockedSection) {
     return LockStatus.UNLOCKED;
   }
-  if (foundLockedSection && foundLockedSection.lockedBy !== userEUA) {
+  if (
+    foundLockedSection &&
+    foundLockedSection.lockedByUserAccount.username !== userEUA
+  ) {
     // If the locked section is found - render locked screen
     return LockStatus.LOCKED;
   }
@@ -194,7 +197,7 @@ const SubscriptionHandler = ({ children }: SubscriptionHandlerProps) => {
     // Located section to be removed
     const lockedSection = taskListSectionLocks.find(
       (section: LockSectionType) =>
-        section.lockedBy === euaId &&
+        section.lockedByUserAccount.username === euaId &&
         section.section === taskListSectionMap[taskListRouteParser(from)]
     );
 
@@ -215,7 +218,7 @@ const SubscriptionHandler = ({ children }: SubscriptionHandlerProps) => {
     // i.e. end of task list section or any react-router redirect from one section directly to another
     const prevLockedSection = taskListSectionLocks.find(
       (section: LockSectionType) =>
-        section.lockedBy === euaId &&
+        section.lockedByUserAccount.username === euaId &&
         taskListSectionMap[taskListRouteParser(from)] === section.section &&
         taskListSectionMap[taskListRouteParser(to)] !== section.section &&
         from !== to

--- a/src/views/SubscriptionWrapper/index.test.tsx
+++ b/src/views/SubscriptionWrapper/index.test.tsx
@@ -9,7 +9,12 @@ describe('SubscriptionWrapper functions', () => {
       __typename: 'TaskListSectionLockStatus',
       modelPlanID: '123',
       section: TaskListSection.BENEFICIARIES,
-      lockedBy: 'MINT',
+      lockedByUserAccount: {
+        id: '00000001-0001-0001-0001-000000000001',
+        username: 'MINT',
+        commonName: 'MINT Doe',
+        __typename: 'UserAccount'
+      },
       isAssessment: true
     };
 
@@ -18,7 +23,12 @@ describe('SubscriptionWrapper functions', () => {
         __typename: 'TaskListSectionLockStatus',
         modelPlanID: '123',
         section: TaskListSection.BENEFICIARIES,
-        lockedBy: 'MINT',
+        lockedByUserAccount: {
+          id: '00000001-0001-0001-0001-000000000001',
+          username: 'MINT',
+          commonName: 'MINT Doe',
+          __typename: 'UserAccount'
+        },
         isAssessment: true
       }
     ];
@@ -33,7 +43,12 @@ describe('SubscriptionWrapper functions', () => {
       __typename: 'TaskListSectionLockStatus',
       modelPlanID: '123',
       section: TaskListSection.BENEFICIARIES,
-      lockedBy: 'ABCD',
+      lockedByUserAccount: {
+        id: '00000000-0000-0000-0000-000000000000',
+        username: 'ABCD',
+        commonName: 'ABCD Doe',
+        __typename: 'UserAccount'
+      },
       isAssessment: false
     };
 
@@ -42,7 +57,12 @@ describe('SubscriptionWrapper functions', () => {
         __typename: 'TaskListSectionLockStatus',
         modelPlanID: '123',
         section: TaskListSection.BENEFICIARIES,
-        lockedBy: 'ABCD',
+        lockedByUserAccount: {
+          id: '00000000-0000-0000-0000-000000000000',
+          username: 'ABCD',
+          commonName: 'ABCD Doe',
+          __typename: 'UserAccount'
+        },
         isAssessment: false
       }
     ];
@@ -53,7 +73,12 @@ describe('SubscriptionWrapper functions', () => {
           __typename: 'TaskListSectionLockStatus',
           modelPlanID: '123',
           section: TaskListSection.BENEFICIARIES,
-          lockedBy: 'MINT',
+          lockedByUserAccount: {
+            id: '00000001-0001-0001-0001-000000000001',
+            username: 'MINT',
+            commonName: 'MINT Doe',
+            __typename: 'UserAccount'
+          },
           isAssessment: false
         }
       ],
@@ -68,7 +93,12 @@ describe('SubscriptionWrapper functions', () => {
       __typename: 'TaskListSectionLockStatus',
       modelPlanID: '123',
       section: TaskListSection.BENEFICIARIES,
-      lockedBy: 'ABCD',
+      lockedByUserAccount: {
+        id: '00000000-0000-0000-0000-000000000000',
+        username: 'ABCD',
+        commonName: 'ABCD Doe',
+        __typename: 'UserAccount'
+      },
       isAssessment: false
     };
 
@@ -80,7 +110,12 @@ describe('SubscriptionWrapper functions', () => {
           __typename: 'TaskListSectionLockStatus',
           modelPlanID: '123',
           section: TaskListSection.BENEFICIARIES,
-          lockedBy: 'ABCD',
+          lockedByUserAccount: {
+            id: '00000000-0000-0000-0000-000000000000',
+            username: 'ABCD',
+            commonName: 'ABCD Doe',
+            __typename: 'UserAccount'
+          },
           isAssessment: false
         }
       ],


### PR DESCRIPTION
# EASI-2653

## Changes and Description

Backend
- TaskList Status Lock
   - Embed user account instead of EUAID directly
   - 
- Change 2

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
