### PR TITLE
[EASI-2703] - Added banner and wrapper to display task list lock on routes

### DIFF
--- a/src/i18n/en-US/general.ts
+++ b/src/i18n/en-US/general.ts
@@ -13,7 +13,9 @@ const general = {
   edit: 'Edit',
   remove: 'Remove',
   pageLoading: 'Loading the page',
-  oktaWidget: 'Sign in with your EUA or IDM credentials.'
+  oktaWidget: 'Sign in with your EUA or IDM credentials.',
+  taskListLockBanner:
+    'Model Plan sections can only be accessed by one person at a time. If you are not actively editing or reviewing this section, please exit out of it so others can access it.'
 };
 
 export default general;

--- a/src/i18n/en-US/modelPlanTaskList.ts
+++ b/src/i18n/en-US/modelPlanTaskList.ts
@@ -131,10 +131,11 @@ const modelPlanTaskList = {
   },
   errorHeading: 'Failed to fetch model plan',
   errorMessage: 'Please try again',
-  locked: ' is editing this section. You may access it when they’re done.',
+  locked:
+    '{{-teamMember}} is editing this section. You may access it when they’re done.',
   selfLocked: 'You are editing this section.',
   assessmentLocked:
-    'The MINT Team is editing this section. You may access it when they’re done.',
+    'The MINT Team | {{-assessmentUser}} is editing this section. You may access it when they’re done.',
   lockedHeading:
     'Someone is currently editing the Model Plan section you’re trying to access.',
   lockedSubheading: 'Please try again later.',

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -51,6 +51,7 @@ import RouterProvider from 'views/RouterContext';
 import Sandbox from 'views/Sandbox';
 import SubscriptionHandler from 'views/SubscriptionHandler';
 import SubscriptionWrapper from 'views/SubscriptionWrapper';
+import TaskListBannerAlert from 'views/TaskListBannerAlert';
 import TermsAndConditions from 'views/TermsAndConditions';
 import TimeOutWrapper from 'views/TimeOutWrapper';
 import Unfollow from 'views/Unfollow';
@@ -234,6 +235,7 @@ const App = () => {
                               <NavContextProvider>
                                 <PageWrapper>
                                   <Header />
+                                  <TaskListBannerAlert />
                                   <AppRoutes />
                                   <Footer />
                                 </PageWrapper>

--- a/src/views/ModelPlan/TaskList/_components/TaskListLock/index.tsx
+++ b/src/views/ModelPlan/TaskList/_components/TaskListLock/index.tsx
@@ -25,11 +25,17 @@ const TaskListLock = ({
     return Math.floor(Math.random() * (max - min + 1)) + min;
   };
 
-  const lockMessage = isAssessment ? t('assessmentLocked') : t('locked');
+  const lockMessage = isAssessment
+    ? t('assessmentLocked', {
+        assessmentUser: lockedByUserAccount?.commonName
+      })
+    : t('locked', {
+        teamMember: lockedByUserAccount?.commonName
+      });
 
   return (
     <>
-      {(lockedByUserAccount || isAssessment) && (
+      {lockedByUserAccount && (
         <div className="display-inline-flex">
           {isAssessment ? (
             <AssessmentIcon size={3} />
@@ -39,11 +45,11 @@ const TaskListLock = ({
                 arrayOfColors[randomColorIndex(0, 3)]
               }`}
             >
-              {getUserInitials(lockedByUserAccount!.commonName)}
+              {getUserInitials(lockedByUserAccount.commonName)}
             </div>
           )}
 
-          <div className="display-flex flex-align-center line-height-body-4">
+          <div className="display-flex flex-align-center line-height-body-4 text-base">
             {selfLocked ? t('selfLocked') : lockMessage}
           </div>
         </div>

--- a/src/views/TaskListBannerAlert/index.scss
+++ b/src/views/TaskListBannerAlert/index.scss
@@ -1,0 +1,5 @@
+@use 'uswds-core' as *;
+
+.task-list-alert {
+    background-color: color($theme-color-info-lighter);
+}

--- a/src/views/TaskListBannerAlert/index.test.tsx
+++ b/src/views/TaskListBannerAlert/index.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router-dom';
+import { render } from '@testing-library/react';
+
+import TaskListBannerAlert from '.';
+
+describe('The Task List Alert Banner', () => {
+  it('renders banner on task list page', async () => {
+    const { findByTestId } = render(
+      <MemoryRouter
+        initialEntries={[
+          `/models/0272ca43-1ec1-45a6-a06f-8e2def7f6888/task-list/beneficiaries`
+        ]}
+      >
+        <Route
+          path="/models/:modelID/task-list"
+          component={TaskListBannerAlert}
+        />
+      </MemoryRouter>
+    );
+
+    expect(await findByTestId('task-list-alert')).toBeInTheDocument();
+  });
+
+  it('does not banner when not on task list page', async () => {
+    const { queryByTestId } = render(
+      <MemoryRouter
+        initialEntries={[
+          `/models/0272ca43-1ec1-45a6-a06f-8e2def7f6888/task-list`
+        ]}
+      >
+        <Route
+          path="/models/:modelID/task-list"
+          component={TaskListBannerAlert}
+        />
+      </MemoryRouter>
+    );
+
+    expect(queryByTestId('task-list-alert')).not.toBeInTheDocument();
+  });
+});

--- a/src/views/TaskListBannerAlert/index.tsx
+++ b/src/views/TaskListBannerAlert/index.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
+import { GridContainer } from '@trussworks/react-uswds';
+
+import Alert from 'components/shared/Alert';
+
+import './index.scss';
+
+const taskListRoutes: string[] = [
+  'basics',
+  'beneficiaries',
+  'characteristics',
+  'ops-eval-and-learning',
+  'participants-and-providers',
+  'payment'
+];
+
+const isTaskListRoute = (route: string | undefined) =>
+  taskListRoutes.includes(route || '');
+
+const TaskListBannerAlert = () => {
+  const { t } = useTranslation('general');
+  const location = useLocation();
+
+  const [banner, setBanner] = useState<JSX.Element>(<></>);
+
+  const isTaskList = location.pathname.split('/')[3] === 'task-list';
+
+  const taskListRoute = isTaskListRoute(location.pathname.split('/')[4]);
+
+  useEffect(() => {
+    if (isTaskList && taskListRoute) {
+      setBanner(
+        <div className="task-list-alert" data-testid="task-list-alert">
+          <GridContainer className="padding-left-0">
+            <Alert type="info" slim className="margin-top-0 border-0">
+              {t('taskListLockBanner')}
+            </Alert>
+          </GridContainer>
+        </div>
+      );
+    } else {
+      setBanner(<></>);
+    }
+  }, [isTaskList, taskListRoute, t]);
+
+  return banner;
+};
+
+export default TaskListBannerAlert;


### PR DESCRIPTION
# EASI-2703

## Changes and Description

- Wrapper component to render banner on relevant task list routes
  - Should not render on clearance or IT solutions
- Added user name to task list lock on task list sections
- Unit testing


![Screenshot 2023-03-06 at 12 28 36 PM](https://user-images.githubusercontent.com/95709965/223185739-fbb68353-0b09-47db-ad5f-05c1638e40af.png)

![Screenshot 2023-03-06 at 12 29 56 PM](https://user-images.githubusercontent.com/95709965/223186041-5d52aaff-0ad4-4367-bfb9-50545a4d1ff3.png)


## How to test this change

Verify task list locked and banner match figma mocks

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
