### PR TITLE
NOREF: Create Missing Operational Needs for Existing Model plans

### DIFF
--- a/migrations/V85__Add_Missing_Needs_And_Update_Existing_Needs.sql
+++ b/migrations/V85__Add_Missing_Needs_And_Update_Existing_Needs.sql
@@ -1,0 +1,55 @@
+/* Find  Missing Needs, and insert them */
+
+WITH modelPlanNeedTable AS ( -- All Needs for existing models
+    SELECT
+        PoPn.id AS possible_operational_need_id,
+        model_plan.id AS model_plan_id,
+        model_plan.created_by
+
+    FROM model_plan
+    LEFT JOIN possible_operational_need AS PoPn ON PoPn.id = PoPn.id
+    ORDER BY model_plan_id, possible_operational_need_id
+),
+
+missingNeeds AS ( -- Needs that don't have an inserted record
+    SELECT
+        modelPlanNeedTable.possible_operational_need_id,
+        modelPlanNeedTable.model_plan_id,
+        modelPlanNeedTable.created_by
+    FROM modelPlanNeedTable
+    LEFT JOIN operational_need AS OpN ON OpN.need_type = modelPlanNeedTable.possible_operational_need_id AND OpN.model_plan_id = modelPlanNeedTable.model_plan_id
+    WHERE OpN.id IS NULL
+)
+
+INSERT INTO operational_need(
+    id,
+    model_plan_id,
+    need_type,
+    created_by,
+    created_dts
+)
+SELECT
+    gen_random_uuid() AS id,
+    missingNeeds.model_plan_id AS model_plan_id,
+    missingNeeds.possible_operational_need_id AS need_type,
+    missingNeeds.created_by AS created_by,
+    current_timestamp AS created_dts
+FROM missingNeeds;
+
+
+/* Call Function with a cross Join lateral  to get the result for each need */
+
+WITH NeedUpdates AS (
+
+    SELECT OpNeeds.* FROM model_plan mp, DETERMINE_MODEL_PLAN_NEEDS(mp.id) AS OpNeeds --noqa
+)
+
+
+
+UPDATE operational_need
+SET
+    needed = NeedUpdates.needed,
+    modified_by = '00000001-0001-0001-0001-000000000001', --System account
+    modified_dts = current_timestamp
+FROM NeedUpdates
+WHERE operational_need.id = NeedUpdates.operational_need_id;


### PR DESCRIPTION

## Changes and Description

- Create migration that inserts an operational need for every model plan that currently doesn't have one.
- Update those needs to set if they should be needed or not

## How to test this change
1. Comment out migration v79 to v85
2. Bring up the container. 
3. Create some model plans, answer task list sections in a way that will trigger a new need being considered needed as indicated by this [spreadsheet](https://docs.google.com/spreadsheets/d/1HtXBREHtP5hEMFqcGvNDn_HuhyYMy9NX0tCvfWnRJd8/edit#gid=1374666257)
    a. As an example, for General Characteristics, set what is the agreement type to participation agreement. That will make the need Sign Participation Agreements show up as needed.
4. run the commented out migrations
5. Verify that the needs inserted, and set as needed.
    
    



## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [x] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [x] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
