### PR TITLE
Replace print statements with Zap Logger Statements

### DIFF
--- a/pkg/graph/resolvers/plan_task_list_section_locks.go
+++ b/pkg/graph/resolvers/plan_task_list_section_locks.go
@@ -253,7 +253,7 @@ func onLockTaskListSectionUnsubscribeComplete(
 		_, err := UnlockTaskListSection(ps, modelPlanID, section, subscriber.GetPrincipal().Account().ID, model.ActionTypeNormal)
 
 		if err != nil {
-			fmt.Printf("Uncapturable error on websocket disconnect: %v\n", err.Error())
+			fmt.Printf("Uncapturable error on websocket disconnect: %v\n", err.Error()) //TODO: can we pass a reference to the logger to the pubsub?
 		}
 	}
 }

--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -95,8 +94,6 @@ func devUserContext(ctx context.Context, authHeader string, store *storage.Store
 func NewLocalWebSocketAuthenticationMiddleware(logger *zap.Logger, store *storage.Store) transport.WebsocketInitFunc {
 	return func(ctx context.Context, initPayload transport.InitPayload) (context.Context, error) {
 		// Get the token from payload
-		all := initPayload
-		fmt.Println("ALL OF EM BABY", all)
 		any := initPayload["authToken"]
 		token, ok := any.(string)
 		if !ok || token == "" {

--- a/pkg/okta/authentication_middleware.go
+++ b/pkg/okta/authentication_middleware.go
@@ -250,8 +250,6 @@ type MiddlewareFactory struct {
 func (f MiddlewareFactory) NewOktaWebSocketAuthenticationMiddleware(logger *zap.Logger) transport.WebsocketInitFunc {
 	return func(ctx context.Context, initPayload transport.InitPayload) (context.Context, error) {
 		// Get the token from payload
-		all := initPayload
-		fmt.Println("ALL OF EM BABY (OKTA)", all)
 		any := initPayload["authToken"]
 		token, ok := any.(string)
 		if !ok || token == "" {
@@ -261,12 +259,10 @@ func (f MiddlewareFactory) NewOktaWebSocketAuthenticationMiddleware(logger *zap.
 		// Parse auth header into JWT object
 		jwt, err := f.jwt(logger, token)
 		if err != nil {
-			fmt.Println("ERROR PARSING JWT", err)
-			// TODO How to error handle here?
+			logger.Warn("could not parse jwt from token", zap.Error(err))
 		}
 		ctx = appcontext.WithEnhancedJWT(ctx, *jwt)
 
-		// devCtx, err := devUserContext(ctx, token)
 		principal, err := f.newPrincipal(ctx)
 		if err != nil {
 			logger.Error("could not set context for okta auth", zap.Error(err))

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -292,29 +291,30 @@ func (s *Server) routes(
 	}
 
 	if ok, _ := strconv.ParseBool(os.Getenv("DEBUG_ROUTES")); ok {
+		s.logger.Debug("debugging routes")
 		// useful for debugging route issues
 		_ = s.router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
 			pathTemplate, err := route.GetPathTemplate()
 			if err == nil {
-				fmt.Println("ROUTE:", pathTemplate)
+				s.logger.Debug("ROUTE: ", zap.String("ROUTE", pathTemplate))
 			}
 			pathRegexp, err := route.GetPathRegexp()
 			if err == nil {
-				fmt.Println("Path regexp:", pathRegexp)
+				s.logger.Debug("Path regexp:", zap.String("Path regexp", pathRegexp))
 			}
 			queriesTemplates, err := route.GetQueriesTemplates()
 			if err == nil {
-				fmt.Println("Queries templates:", strings.Join(queriesTemplates, ","))
+				s.logger.Debug("Queries templates:", zap.String("Queries templates", strings.Join(queriesTemplates, ",")))
 			}
 			queriesRegexps, err := route.GetQueriesRegexp()
 			if err == nil {
-				fmt.Println("Queries regexps:", strings.Join(queriesRegexps, ","))
+				s.logger.Debug("Queries regexps:", zap.String("Queries regexps", strings.Join(queriesRegexps, ",")))
 			}
 			methods, err := route.GetMethods()
 			if err == nil {
-				fmt.Println("Methods:", strings.Join(methods, ","))
+				s.logger.Debug("Methods:", zap.String("Methods", strings.Join(methods, ",")))
 			}
-			fmt.Println()
+			s.logger.Debug("debugging routes end")
 			return nil
 		})
 	}

--- a/pkg/services/auth.go
+++ b/pkg/services/auth.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"fmt"
 
 	"go.uber.org/zap"
 
@@ -28,15 +27,9 @@ func HasAnyRole(ctx context.Context, roles []model.Role) (bool, error) {
 
 // HasRole authorizes a user as having a given role
 func HasRole(ctx context.Context, role model.Role) (bool, error) {
-	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
-	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
-	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
-	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
-	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
-	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
-	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
-	fmt.Println("APP CONTEXT PRINCIPAL", appcontext.Principal(ctx))
+
 	logger := appcontext.ZLogger(ctx)
+	logger.Info("app context principal", zap.Any("principal", appcontext.Principal(ctx)))
 	principal := appcontext.Principal(ctx)
 	switch role {
 	case model.RoleMintUser:


### PR DESCRIPTION

## Changes and Description

-This addresses some print statements that should be log statements
   - Print statement don't get a trace id, so it makes debugging from splunk difficult.
- Some other spots could use the logger in the future, but would need to have some restructuring to pass the logger around.  (For example, the pub sub doesn't have a reference to the logger)
 - Print statements are left in test code, as we run it with test logger that doesn't log any statements.


## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
