### PR TITLE
[NOREF] - Hidden columns(OpNeeds Table) race condition

### DIFF
--- a/src/views/ModelPlan/TaskList/ITSolutions/Home/__snapshots__/operationalNeedsTable.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Home/__snapshots__/operationalNeedsTable.test.tsx.snap
@@ -182,6 +182,39 @@ exports[`IT Solutions Home matches snapshot 1`] = `
                 </svg>
               </button>
             </th>
+            <th
+              aria-sort="none"
+              class="table-header"
+              colspan="1"
+              role="columnheader"
+              scope="col"
+              style="min-width: 138px; padding-bottom: .5rem; position: relative; padding-left: 0px; width: auto;"
+            >
+              <button
+                class="usa-button usa-button--unstyled"
+                type="button"
+              >
+                Actions
+                <svg
+                  class="usa-icon margin-left-05 position-absolute"
+                  data-testid="caret--sort"
+                  focusable="false"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0 0h24v24H0z"
+                    fill="none"
+                  />
+                  <path
+                    d="M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z"
+                  />
+                </svg>
+              </button>
+            </th>
           </tr>
         </thead>
         <tbody
@@ -214,6 +247,18 @@ exports[`IT Solutions Home matches snapshot 1`] = `
               >
                 Not answered
               </span>
+            </td>
+            <td
+              class=""
+              role="cell"
+              style="padding-left: 0px;"
+            >
+              <a
+                class="usa-link"
+                href="/models/ec2d1105-b722-4c99-94aa-5b76838d7a54/task-list/participants-and-providers/participants-options"
+              >
+                Answer question
+              </a>
             </td>
           </tr>
         </tbody>

--- a/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
@@ -105,7 +105,11 @@ const OperationalNeedsTable = ({
 
   const hasEditAccess: boolean = isCollaborator || isAssessment(groups, flags);
 
-  const hiddenTableColumns = hasEditAccess ? [] : ['Actions'];
+  const hiddenTableColumns = [...(hiddenColumns || [])];
+
+  if (!hasEditAccess) {
+    hiddenTableColumns.push('Actions');
+  }
 
   const needsColumns = useMemo<Column<any>[]>(() => {
     return [
@@ -324,9 +328,7 @@ const OperationalNeedsTable = ({
                 .filter(
                   column =>
                     // @ts-ignore
-                    !hiddenTableColumns?.includes(column.Header) &&
-                    // @ts-ignore
-                    !hiddenColumns?.includes(column.Header)
+                    !hiddenTableColumns?.includes(column.Header)
                 )
                 .map((column, index) => (
                   <th
@@ -364,9 +366,7 @@ const OperationalNeedsTable = ({
                   .filter(
                     cell =>
                       // @ts-ignore
-                      !hiddenTableColumns?.includes(cell.column.Header) &&
-                      // @ts-ignore
-                      !hiddenColumns?.includes(cell.column.Header)
+                      !hiddenTableColumns?.includes(cell.column.Header)
                   )
                   .map((cell, i) => {
                     if (i === 0) {

--- a/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Home/operationalNeedsTable.tsx
@@ -105,6 +105,8 @@ const OperationalNeedsTable = ({
 
   const hasEditAccess: boolean = isCollaborator || isAssessment(groups, flags);
 
+  const hiddenTableColumns = hasEditAccess ? [] : ['Actions'];
+
   const needsColumns = useMemo<Column<any>[]>(() => {
     return [
       {
@@ -266,8 +268,7 @@ const OperationalNeedsTable = ({
       autoResetPage: false,
       initialState: {
         sortBy: useMemo(() => [{ id: 'name', asc: true }], []),
-        pageIndex: 0,
-        hiddenColumns: hasEditAccess ? [] : ['Actions']
+        pageIndex: 0
       }
     },
     useFilters,
@@ -320,8 +321,13 @@ const OperationalNeedsTable = ({
           {headerGroups.map(headerGroup => (
             <tr {...headerGroup.getHeaderGroupProps()}>
               {headerGroup.headers
-                // @ts-ignore
-                .filter(column => !hiddenColumns?.includes(column.Header))
+                .filter(
+                  column =>
+                    // @ts-ignore
+                    !hiddenTableColumns?.includes(column.Header) &&
+                    // @ts-ignore
+                    !hiddenColumns?.includes(column.Header)
+                )
                 .map((column, index) => (
                   <th
                     {...column.getHeaderProps()}
@@ -355,10 +361,13 @@ const OperationalNeedsTable = ({
             return (
               <tr {...row.getRowProps()}>
                 {row.cells
-                  .filter(cell => {
-                    // @ts-ignore
-                    return !hiddenColumns?.includes(cell.column.Header);
-                  })
+                  .filter(
+                    cell =>
+                      // @ts-ignore
+                      !hiddenTableColumns?.includes(cell.column.Header) &&
+                      // @ts-ignore
+                      !hiddenColumns?.includes(cell.column.Header)
+                  )
                   .map((cell, i) => {
                     if (i === 0) {
                       return (

--- a/src/views/ModelPlan/TaskList/ITSolutions/util.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/util.tsx
@@ -105,7 +105,6 @@ export const returnActionLinks = (
   modelID: string,
   readOnly?: boolean
 ): JSX.Element => {
-  /* eslint no-underscore-dangle: 0 */
   const operationalNeedKey = operationalNeed.key || operationalNeed.needKey;
 
   const operationalNeedObj = operationalNeedMap[operationalNeedKey || 'NONE'];


### PR DESCRIPTION
# NOREF

## Changes and Description

- Modified how the initial state of Op Needs table is rendered to alleviate a race condition
- The initial state of the table was being set before async data was received to dictate what columns were hidden

<!-- Put a description here! -->

## How to test this change

Verify the 'Actions' column on op needs table isn't hidden because of a race condition

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
