### PR TITLE
[EASI-2561] Open discussion center reply from url

### DIFF
--- a/src/components/AskAQuestion/index.test.tsx
+++ b/src/components/AskAQuestion/index.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
+import { MemoryRouter, Route } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -79,11 +80,19 @@ describe('Ask a Question Component', () => {
 
   it('renders the discussion modal init with question', async () => {
     const { getByText, getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <Provider store={store}>
-          <AskAQuestion modelID={modelID} />
-        </Provider>
-      </MockedProvider>
+      <MemoryRouter
+        initialEntries={[
+          '/models/ce3405a0-3399-4e3a-88d7-3cfc613d2905/task-list/basics'
+        ]}
+      >
+        <Route path="/models/:modelID/task-list/basics">
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <Provider store={store}>
+              <AskAQuestion modelID={modelID} />
+            </Provider>
+          </MockedProvider>
+        </Route>
+      </MemoryRouter>
     );
 
     expect(getByTestId('ask-a-question')).toBeInTheDocument();

--- a/src/views/ModelPlan/Discussions/index.test.tsx
+++ b/src/views/ModelPlan/Discussions/index.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
+import { MemoryRouter, Route } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -90,11 +91,19 @@ describe('Discussion Component', () => {
 
   it('renders discussions and replies without errors', async () => {
     const { getByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <Provider store={store}>
-          <Discussions modelID={modelID} />
-        </Provider>
-      </MockedProvider>
+      <MemoryRouter
+        initialEntries={[
+          '/models/ce3405a0-3399-4e3a-88d7-3cfc613d2905/task-list'
+        ]}
+      >
+        <Route path="/models/:modelID/task-list">
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <Provider store={store}>
+              <Discussions modelID={modelID} />
+            </Provider>
+          </MockedProvider>
+        </Route>
+      </MemoryRouter>
     );
 
     await waitFor(() => {
@@ -109,11 +118,19 @@ describe('Discussion Component', () => {
 
   it('renders a question', async () => {
     const { getByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <Provider store={store}>
-          <Discussions modelID={modelID} />
-        </Provider>
-      </MockedProvider>
+      <MemoryRouter
+        initialEntries={[
+          '/models/ce3405a0-3399-4e3a-88d7-3cfc613d2905/task-list'
+        ]}
+      >
+        <Route path="/models/:modelID/task-list">
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <Provider store={store}>
+              <Discussions modelID={modelID} />
+            </Provider>
+          </MockedProvider>
+        </Route>
+      </MemoryRouter>
     );
 
     await waitFor(async () => {
@@ -135,5 +152,27 @@ describe('Discussion Component', () => {
     userEvent.type(feedbackField, 'Test feedback');
 
     expect(feedbackField).toHaveValue('Test feedback');
+  });
+
+  it('renders the reply form from email generated url param', async () => {
+    const { getByText } = render(
+      <MemoryRouter
+        initialEntries={[
+          '/models/ce3405a0-3399-4e3a-88d7-3cfc613d2905/task-list?discussionID=123'
+        ]}
+      >
+        <Route path="/models/:modelID/task-list">
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <Provider store={store}>
+              <Discussions modelID={modelID} discussionID="123" />
+            </Provider>
+          </MockedProvider>
+        </Route>
+      </MemoryRouter>
+    );
+
+    await waitFor(async () => {
+      expect(getByText(/This is a question./i)).toBeInTheDocument();
+    });
   });
 });

--- a/src/views/ModelPlan/TaskList/index.tsx
+++ b/src/views/ModelPlan/TaskList/index.tsx
@@ -3,11 +3,12 @@ import React, {
   Fragment,
   SetStateAction,
   useContext,
+  useEffect,
   useState
 } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { RootStateOrAny, useSelector } from 'react-redux';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import {
   Breadcrumb,
@@ -98,7 +99,13 @@ const taskListSectionMap: TaskListSectionMapType = {
 const TaskList = () => {
   const { t } = useTranslation('modelPlanTaskList');
   const { t: h } = useTranslation('draftModelPlan');
+
   const { modelID } = useParams<{ modelID: string }>();
+
+  // Get discussionID from generated email link
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const discussionID = params.get('discussionID');
 
   const flags = useFlags();
 
@@ -167,6 +174,10 @@ const TaskList = () => {
     discussions
   );
 
+  useEffect(() => {
+    if (discussionID) setIsDiscussionOpen(true);
+  }, [discussionID]);
+
   const getTaskListLockedStatus = (
     section: string
   ): LockSectionType | undefined => {
@@ -228,7 +239,7 @@ const TaskList = () => {
                   isOpen={isDiscussionOpen}
                   closeModal={() => setIsDiscussionOpen(false)}
                 >
-                  <Discussions modelID={modelID} />
+                  <Discussions modelID={modelID} discussionID={discussionID} />
                 </DiscussionModalWrapper>
               )}
 


### PR DESCRIPTION
# EASI-2561

## Changes and Description

- Added ability to open discussion center from URL
- Delete url param after replying
- Alert if discussion has already been replied

<!-- Put a description here! -->

## How to test this change

- Get the id of a discussion and plug in url param like so 
`http://localhost:3005/models/b7ed58a2-9610-4dff-a269-4f0127ecd07d/task-list?discussionID=234512535432134`
- Verify correct discussion is opened with form to reply
- Reply to it and try to reload window, should get alert that it has already been answered

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
