### PR TITLE
[NOREF] - Landing UI tweaks

### DIFF
--- a/src/i18n/en-US/landing.ts
+++ b/src/i18n/en-US/landing.ts
@@ -5,7 +5,7 @@ const landing = {
   description:
     'The Model Innovation Tool provides a single source of truth for all upcoming CMMI models and demonstrations that breaks down silos, bringing transparency and awareness across CMS.',
   signIn: 'Sign in to get started',
-  bodyHeading: 'Product hightlights',
+  bodyHeading: 'Product highlights',
   bodyItem1: {
     heading: 'No more asking around',
     description:

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -33,10 +33,11 @@ export const getTimeElapsed = (discussionCreated: string) => {
       const floatTime = Math.abs(
         timePassed[time as keyof typeof getTimeElapsed]
       );
+
       // Only show parent most level of time, rather than all increments
       if (dateString === '') {
         dateString += `${floatTime} ${
-          timePassed[time as keyof typeof getTimeElapsed] >= 2
+          timePassed[time as keyof typeof getTimeElapsed] !== 1
             ? time
             : time.slice(0, -1) // If singular, remove last letter 's's from time string
         } `;

--- a/src/views/Landing/index.scss
+++ b/src/views/Landing/index.scss
@@ -6,7 +6,7 @@ $card-radius: 6px;
 
 .landing {
     word-break: break-word;
-
+    
     &__heading {
         font-size: 80px;
         font-weight: 400;
@@ -41,8 +41,7 @@ $card-radius: 6px;
         line-height: 23px;
         box-shadow: $card-shadow;
         width: 100%;
-        border-radius: $card-radius;
-        
+        border-radius: $card-radius; 
     }
 
     &__discussions {
@@ -63,13 +62,13 @@ $card-radius: 6px;
     }
 
     &__email-icon-contain {
-        width: 4rem;
-        height: 4rem;
+        width: 5rem;
+        height: 5rem;
         border-radius: .75rem;
         background: rgb(6,138,235);
         background: linear-gradient(180deg, rgba(6,138,235,1) 35%, rgba(1,98,166,1) 100%);
         margin-right: -2rem;
-        top: 15.5rem;
+        top: 14.5rem;
 
         @media screen and (max-width: $mobile) {
             top: 17rem;
@@ -78,8 +77,8 @@ $card-radius: 6px;
 
     &__email-icon {
         fill: white !important;
-        height: 2.75rem !important;
-        width: 2.75rem !important;
+        height: 3.5rem !important;
+        width: 3.5rem !important;
     }
 
     &__contain {

--- a/src/views/Landing/index.tsx
+++ b/src/views/Landing/index.tsx
@@ -53,7 +53,9 @@ export const LandingHeader = () => {
           </span>
         </h1>
 
-        <p className="landing__description">{t('description')}</p>
+        <p className="text-primary-lighter landing__description">
+          {t('description')}
+        </p>
 
         <UswdsReactLink
           className="usa-button bg-mint-cool-vivid text-white width-auto"
@@ -64,7 +66,7 @@ export const LandingHeader = () => {
         </UswdsReactLink>
 
         <NDABanner
-          className="bg-primary-darker text-white padding-x-0 border-top border-primary-dark margin-top-6"
+          className="bg-primary-darker text-white padding-x-0 border-top border-primary-dark margin-top-6 text-primary-lighter"
           landing
         />
       </GridContainer>
@@ -251,7 +253,7 @@ const SolutionTable = () => {
             </td>
             <td
               className={classNames(
-                'padding-1 padding-y-1 padding-left-0 text-top padding-top-2',
+                'padding-1 padding-y-2 padding-left-0 text-top padding-top-2',
                 {
                   'padding-right-0': index === 3
                 }
@@ -353,7 +355,7 @@ const EmailCard = () => {
         <div className="landing__email-icon-contain display-flex flex-align-center flex-justify-center position-absolute">
           <IconMail size={6} className="landing__email-icon" />
 
-          <div className="bg-red radius-top-pill radius-bottom-pill text-white padding-1 width-3 height-3 display-flex flex-align-center flex-justify-center position-absolute margin-left-8 margin-bottom-8">
+          <div className="bg-red radius-top-pill radius-bottom-pill text-white padding-1 width-3 height-3 display-flex flex-align-center flex-justify-center position-absolute margin-left-9 margin-bottom-9">
             1
           </div>
         </div>


### PR DESCRIPTION
# NOREF

## Changes and Description

Typos
Update “Product hightlights” to “Product highlights”
Update Jane Middleton timestamp from “3 hour ago” to “3 hours ago”
Styling
Increase the size of the email app icon? It looks a tad small currently
The alignment on the recruit participants row of the operational needs tracker looks a little wonky at some widths. It looks like it’s because it’s the only one not breaking to 2 lines all of the time (screenshot). Could we force a max width so it always wraps? Also open to your ideas if there's an easier way to fix that.
Can you update the color of the landing description and pre-decisional content to the primary lighter color? (#D9E8F6)

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
