### PR TITLE
[NOREF] Added trace ID to okta api calls

### DIFF
--- a/pkg/graph/schema.resolvers_test.go
+++ b/pkg/graph/schema.resolvers_test.go
@@ -144,7 +144,7 @@ func TestGraphQLTestSuite(t *testing.T) {
 	emailTemplateService, err := email.NewTemplateServiceImpl()
 	assert.NoError(t, err)
 
-	oktaClient, err := local.NewOktaAPIClient(logger)
+	oktaClient, err := local.NewOktaAPIClient()
 	assert.NoError(t, err)
 
 	directives := generated.DirectiveRoot{HasRole: func(ctx context.Context, obj interface{}, next graphql.Resolver, role model.Role) (res interface{}, err error) {

--- a/pkg/local/okta_api.go
+++ b/pkg/local/okta_api.go
@@ -7,19 +7,16 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/cmsgov/mint-app/pkg/appcontext"
 	"github.com/cmsgov/mint-app/pkg/models"
 )
 
 // client is a mock client for pkg/oktaapi
-type client struct {
-	logger *zap.Logger
-}
+type client struct{}
 
 // NewOktaAPIClient returns a mock Okta client
-func NewOktaAPIClient(logger *zap.Logger) (*client, error) {
-	return &client{
-		logger: logger,
-	}, nil
+func NewOktaAPIClient() (*client, error) {
+	return &client{}, nil
 }
 
 // getMockUserData returns a slice of *models.UserInfo that represents a response from the CEDAR LDAP server.
@@ -464,8 +461,9 @@ func getMockUserData() []*models.UserInfo {
 }
 
 // FetchUserInfo fetches a user's personal details
-func (c *client) FetchUserInfo(_ context.Context, username string) (*models.UserInfo, error) {
-	c.logger.Info("Mock FetchUserInfo from Okta API", zap.String("username", username))
+func (c *client) FetchUserInfo(ctx context.Context, username string) (*models.UserInfo, error) {
+	logger := appcontext.ZLogger(ctx)
+	logger.Info("Mock FetchUserInfo from Okta API", zap.String("username", username))
 	for _, mockUser := range getMockUserData() {
 		if mockUser.Username == username {
 			return mockUser, nil
@@ -475,8 +473,9 @@ func (c *client) FetchUserInfo(_ context.Context, username string) (*models.User
 }
 
 // SearchByName fetches a user's personal details by their common name
-func (c *client) SearchByName(_ context.Context, DisplayName string) ([]*models.UserInfo, error) {
-	c.logger.Info("Mock SearchByName from Okta API")
+func (c *client) SearchByName(ctx context.Context, DisplayName string) ([]*models.UserInfo, error) {
+	logger := appcontext.ZLogger(ctx)
+	logger.Info("Mock SearchByName from Okta API")
 
 	mockUserData := getMockUserData()
 	searchResults := []*models.UserInfo{}

--- a/pkg/oktaapi/client_wrapper.go
+++ b/pkg/oktaapi/client_wrapper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/okta/okta-sdk-golang/v2/okta/query"
 	"go.uber.org/zap"
 
+	"github.com/cmsgov/mint-app/pkg/appcontext"
 	"github.com/cmsgov/mint-app/pkg/models"
 )
 
@@ -17,11 +18,10 @@ import (
 // methods that the Client interface defines in ./client.go
 type clientWrapper struct {
 	oktaClient *okta.Client
-	logger     *zap.Logger
 }
 
 // NewClient creates a Client
-func NewClient(logger *zap.Logger, url string, token string) (Client, error) {
+func NewClient(url string, token string) (Client, error) {
 	// TODO Do we need the "Context" response from okta.NewClient??
 	_, oktaClient, oktaClientErr := okta.NewClient(context.TODO(), okta.WithOrgUrl(url), okta.WithToken(token))
 	if oktaClientErr != nil {
@@ -29,7 +29,6 @@ func NewClient(logger *zap.Logger, url string, token string) (Client, error) {
 	}
 	return &clientWrapper{
 		oktaClient: oktaClient,
-		logger:     logger,
 	}, nil
 }
 
@@ -43,21 +42,23 @@ type oktaUserResponse struct {
 	SourceType  string `json:"SourceType"`
 }
 
-func (cw *clientWrapper) parseOktaProfileResponse(profile *okta.UserProfile) (*oktaUserResponse, error) {
+func (cw *clientWrapper) parseOktaProfileResponse(ctx context.Context, profile *okta.UserProfile) (*oktaUserResponse, error) {
+	logger := appcontext.ZLogger(ctx)
+
 	// Create an okaUserProfile to return
 	parsedProfile := &oktaUserResponse{}
 
 	// Marshal the profile into a string so we can later unmarshal it into a struct
 	responseString, err := json.Marshal(profile)
 	if err != nil {
-		cw.logger.Error("error marshalling okta response", zap.Error(err))
+		logger.Error("error marshalling okta response", zap.Error(err))
 		return nil, err
 	}
 
 	// Unmarshal the string into the oktaUserProfile type
 	err = json.Unmarshal(responseString, parsedProfile)
 	if err != nil {
-		cw.logger.Error("error unmarshalling okta response", zap.Error(err))
+		logger.Error("error unmarshalling okta response", zap.Error(err))
 		return nil, err
 	}
 
@@ -75,13 +76,15 @@ func (o *oktaUserResponse) toUserInfo() *models.UserInfo {
 }
 
 func (cw *clientWrapper) FetchUserInfo(ctx context.Context, username string) (*models.UserInfo, error) {
+	logger := appcontext.ZLogger(ctx)
+
 	user, _, err := cw.oktaClient.User.GetUser(ctx, username)
 	if err != nil {
-		cw.logger.Error("Error fetching Okta user", zap.Error(err), zap.String("username", username))
+		logger.Error("Error fetching Okta user", zap.Error(err), zap.String("username", username))
 		return nil, err
 	}
 
-	profile, err := cw.parseOktaProfileResponse(user.Profile)
+	profile, err := cw.parseOktaProfileResponse(ctx, user.Profile)
 	if err != nil {
 		return nil, err
 	}
@@ -93,6 +96,8 @@ const euaSourceType = "EUA"
 const euaADSourceType = "EUA-AD"
 
 func (cw *clientWrapper) SearchByName(ctx context.Context, searchTerm string) ([]*models.UserInfo, error) {
+	logger := appcontext.ZLogger(ctx)
+
 	// profile.SourceType can be EUA, EUA-AD, or cmsidm
 	// the first 2 represent EUA users, the latter represents users created directly in IDM
 	// status eq "ACTIVE" or status eq "STAGED" ensures we only get users who have EUAs (Staged means they just haven't logged in yet)
@@ -106,13 +111,13 @@ func (cw *clientWrapper) SearchByName(ctx context.Context, searchTerm string) ([
 
 	searchedUsers, _, err := cw.oktaClient.User.ListUsers(ctx, search)
 	if err != nil {
-		cw.logger.Error("Error searching Okta users", zap.Error(err), zap.String("searchTerm", searchTerm))
+		logger.Error("Error searching Okta users", zap.Error(err), zap.String("searchTerm", searchTerm))
 		return nil, err
 	}
 
 	users := []*models.UserInfo{}
 	for _, user := range searchedUsers {
-		profile, err := cw.parseOktaProfileResponse(user.Profile)
+		profile, err := cw.parseOktaProfileResponse(ctx, user.Profile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -133,14 +133,14 @@ func (s *Server) routes(
 	var oktaClientErr error
 	if s.environment.Local() {
 		// Ensure Okta API Variables are set
-		oktaClient, oktaClientErr = local.NewOktaAPIClient(s.logger)
+		oktaClient, oktaClientErr = local.NewOktaAPIClient()
 		if oktaClientErr != nil {
 			s.logger.Fatal("failed to create okta api client", zap.Error(oktaClientErr))
 		}
 	} else {
 		// Ensure Okta API Variables are set
 		s.NewOktaAPIClientCheck()
-		oktaClient, oktaClientErr = oktaapi.NewClient(s.logger, s.Config.GetString(appconfig.OKTAApiURL), s.Config.GetString(appconfig.OKTAAPIToken))
+		oktaClient, oktaClientErr = oktaapi.NewClient(s.Config.GetString(appconfig.OKTAApiURL), s.Config.GetString(appconfig.OKTAAPIToken))
 		if oktaClientErr != nil {
 			s.logger.Fatal("failed to create okta api client", zap.Error(oktaClientErr))
 		}


### PR DESCRIPTION
# EASI-000

## Changes and Description

- Uses the `context` logger instead of the one instantiated in `routes.go` to ensure that each request to the Okta API has its own logger with the trace ID already applied to it.

## How to test this change

- scripts/dev up
- Make a new model plan
- Add a user, and perform a search by name
- Check the logs with `docker compose logs -f mint`
  - You should see logs that mock calls to the Okta API, and they should have a TraceID attached to them

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
