### PR TITLE
[NOREF] Upgrade SQLFluff to v2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,9 +109,9 @@ repos:
         entry: git-secrets --pre_commit_hook
 
   - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 1.2.1
+    rev: 2.0.7
     hooks:
       - id: sqlfluff-fix
-        exclude: ^scripts/data/
+        exclude: ^migrations/
       - id: sqlfluff-lint
-        exclude: ^scripts/data/
+        exclude: ^migrations/

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -4,28 +4,24 @@
 dialect = postgres
 ignore = parsing
 
-# Ignoring L014 because it seems to want to uppercase column names if there are capitalized enums defined before the table (like in V11__Add_Plan_General_Characteristics)
-# Ignoring L016 because we break line-length requirements in a few places with comments
-# Ignoring L031 so we can use table aliases
-# Ignoreing L034 becase we like to order SQL statements similarly across files
-exclude_rules = L014, L016, L031, L034
+# Ignoring capitalisation.identifiers because it seems to want to uppercase column names if there are capitalized enums defined before the table (like in V11__Add_Plan_General_Characteristics)
+# Ignoring layout.long_lines because we break line-length requirements in a few places with comments
+# Ignoring aliasing.forbid so we can use table aliases
+# Ignoring structure.column_order becase we like to order SQL statements similarly across files
+exclude_rules = capitalisation.identifiers, layout.long_lines, aliasing.forbid, structure.column_order, layout.spacing
 
-[sqlfluff:rules:L010]
-# Inconsistent capitalisation of keywords.
-# https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L010
+[sqlfluff:rules:capitalisation.keywords]
+# https://docs.sqlfluff.com/en/stable/rules.html#rule-capitalisation.keywords
 capitalisation_policy = upper
 
-[sqlfluff:rules:L031]
-# Avoid table aliases in from clauses and join conditions.
-# https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.Rule_L031
+[sqlfluff:rules:aliasing.forbid]
+# https://docs.sqlfluff.com/en/stable/rules.html#rule-aliasing.forbid
 force_enable = False
 
-[sqlfluff:rules:L040]
-# Inconsistent capitalisation of boolean/null literal.
-# https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L040
+[sqlfluff:rules:capitalisation.literals]
+# https://docs.sqlfluff.com/en/stable/rules.html#rule-capitalisation.literals
 capitalisation_policy = upper
 
-[sqlfluff:rules:L063]
-# Inconsistent capitalisation of datatypes.
-# https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L063
+[sqlfluff:rules:capitalisation.types]
+# https://docs.sqlfluff.com/en/stable/rules.html#rule-capitalisation.types
 extended_capitalisation_policy = upper

--- a/config/logstash/ingest_change_table.sql
+++ b/config/logstash/ingest_change_table.sql
@@ -14,7 +14,7 @@ SELECT
     CAST(ROW_TO_JSON(user_account.*) AS TEXT) AS modified_by,
 
     -- Creates a GUID from the table_id and primary_key
-    CONCAT(audit.change.table_id::TEXT, '_', audit.change.primary_key::TEXT) AS guid
+    CONCAT(CAST(audit.change.table_id AS TEXT), '_', CAST(audit.change.primary_key AS TEXT)) AS guid
 
 FROM audit.change
 LEFT JOIN user_account ON audit.change.modified_by = user_account.id

--- a/pkg/storage/SQL/access_control/check_if_collaborator.sql
+++ b/pkg/storage/SQL/access_control/check_if_collaborator.sql
@@ -1,6 +1,7 @@
 SELECT EXISTS(
-        SELECT 1
-        FROM plan_collaborator
-        WHERE model_plan_id = :model_plan_id
-            AND user_id = :user_id
-    ) AS isCollaborator
+    SELECT 1
+    FROM plan_collaborator
+    WHERE
+        model_plan_id = :model_plan_id
+        AND user_id = :user_id
+) AS isCollaborator

--- a/pkg/storage/SQL/access_control/check_if_collaborator_by_operational_need_id.sql
+++ b/pkg/storage/SQL/access_control/check_if_collaborator_by_operational_need_id.sql
@@ -2,6 +2,7 @@ SELECT EXISTS(
     SELECT 1
     FROM PLAN_COLLABORATOR
     INNER JOIN OPERATIONAL_NEED AS need ON need.model_plan_id = PLAN_COLLABORATOR.model_plan_id
-    WHERE need.id = :need_id
+    WHERE
+        need.id = :need_id
         AND PLAN_COLLABORATOR.user_id = :user_id
 ) AS isCollaborator

--- a/pkg/storage/SQL/access_control/check_if_collaborator_by_solution_id.sql
+++ b/pkg/storage/SQL/access_control/check_if_collaborator_by_solution_id.sql
@@ -3,6 +3,7 @@ SELECT EXISTS(
     FROM PLAN_COLLABORATOR
     INNER JOIN OPERATIONAL_NEED AS need ON need.model_plan_id = PLAN_COLLABORATOR.model_plan_id
     INNER JOIN OPERATIONAL_SOLUTION AS solution ON need.id = solution.operational_need_id
-    WHERE solution.id = :solution_id
+    WHERE
+        solution.id = :solution_id
         AND PLAN_COLLABORATOR.user_id = :user_id
 ) AS isCollaborator

--- a/pkg/storage/SQL/access_control/check_if_collaborator_discussion_id.sql
+++ b/pkg/storage/SQL/access_control/check_if_collaborator_discussion_id.sql
@@ -2,6 +2,7 @@ SELECT EXISTS(
     SELECT 1
     FROM PLAN_COLLABORATOR
     INNER JOIN PLAN_DISCUSSION ON PLAN_COLLABORATOR.model_plan_id = PLAN_DISCUSSION.model_plan_id
-    WHERE PLAN_DISCUSSION.id = :discussion_id
+    WHERE
+        PLAN_DISCUSSION.id = :discussion_id
         AND PLAN_COLLABORATOR.user_id = :user_id
 ) AS isCollaborator

--- a/pkg/storage/SQL/analyzed_audit/get_by_model_plan_id_and_date.sql
+++ b/pkg/storage/SQL/analyzed_audit/get_by_model_plan_id_and_date.sql
@@ -9,6 +9,7 @@ SELECT
     modified_by,
     modified_dts
 FROM analyzed_audit
-WHERE model_plan_id = :model_plan_id
+WHERE
+    model_plan_id = :model_plan_id
     AND date = :date
 ORDER BY model_name ASC

--- a/pkg/storage/SQL/analyzed_audit/get_collection_by_model_plan_ids_and_date.sql
+++ b/pkg/storage/SQL/analyzed_audit/get_collection_by_model_plan_ids_and_date.sql
@@ -9,6 +9,7 @@ SELECT
     modified_by,
     modified_dts
 FROM analyzed_audit
-WHERE model_plan_id = ANY(:model_plan_ids)
+WHERE
+    model_plan_id = ANY(:model_plan_ids)
     AND date = :date
 ORDER BY model_name ASC

--- a/pkg/storage/SQL/audit_change/collection_by_id_and_table_and_field.sql
+++ b/pkg/storage/SQL/audit_change/collection_by_id_and_table_and_field.sql
@@ -9,5 +9,6 @@ SELECT
     audit.change.modified_dts
 FROM audit.change
 INNER JOIN audit.table_config ON audit.table_config.id = audit.change.table_id
-WHERE audit.table_config.name = :table_name AND audit.change.primary_key = :primary_key
+WHERE
+    audit.table_config.name = :table_name AND audit.change.primary_key = :primary_key
     AND audit.change.fields -> :field_name IS NOT NULL

--- a/pkg/storage/SQL/audit_change/collection_by_primary_key_or_foreign_keyand_date.sql
+++ b/pkg/storage/SQL/audit_change/collection_by_primary_key_or_foreign_keyand_date.sql
@@ -9,5 +9,6 @@ SELECT
     audit.change.modified_dts
 FROM audit.change
 INNER JOIN audit.table_config ON audit.table_config.id = audit.change.table_id
-WHERE (audit.change.foreign_key = :foreign_key OR audit.change.primary_key = :primary_key)
+WHERE
+    (audit.change.foreign_key = :foreign_key OR audit.change.primary_key = :primary_key)
     AND audit.change.modified_dts >= :start_date AND audit.change.modified_dts < :end_date

--- a/pkg/storage/SQL/discussion_reply/update.sql
+++ b/pkg/storage/SQL/discussion_reply/update.sql
@@ -1,5 +1,6 @@
 UPDATE discussion_reply
-SET discussion_id = :discussion_id,
+SET
+    discussion_id = :discussion_id,
     content = :content,
     resolution = :resolution,
     modified_by = :modified_by,

--- a/pkg/storage/SQL/nda_agreement/update.sql
+++ b/pkg/storage/SQL/nda_agreement/update.sql
@@ -1,5 +1,6 @@
 UPDATE nda_agreement
-SET agreed = :agreed,
+SET
+    agreed = :agreed,
     agreed_dts = :agreed_dts,
     modified_by = :modified_by,
     modified_dts = CURRENT_TIMESTAMP

--- a/pkg/storage/SQL/operational_need/insert_all_possible.sql
+++ b/pkg/storage/SQL/operational_need/insert_all_possible.sql
@@ -1,31 +1,31 @@
 WITH retVal AS (
-INSERT INTO operational_need(
+    INSERT INTO operational_need(
+        id,
+        model_plan_id,
+        need_type,
+        created_by,
+        created_dts
+    )
+    (
+        SELECT
+            gen_random_uuid() AS id,
+            :model_plan_id AS model_plan_id,
+            id,
+            :created_by AS created_by,
+            current_timestamp AS created_dts
+        FROM possible_operational_need
+    )
+
+    RETURNING
     id,
     model_plan_id,
     need_type,
+    name_other,
+    needed,
     created_by,
-    created_dts
-)
-
-
-SELECT
-    gen_random_uuid() AS id,
-    :model_plan_id AS model_plan_id,
-    id,
-    :created_by AS created_by,
-    CURRENT_TIMESTAMP AS created_dts
-
-    FROM possible_operational_need
-RETURNING
-id,
-model_plan_id,
-need_type,
-name_other,
-needed,
-created_by,
-created_dts,
-modified_by,
-modified_dts
+    created_dts,
+    modified_by,
+    modified_dts
 )
 
 SELECT

--- a/pkg/storage/SQL/operational_need/insert_or_update.sql
+++ b/pkg/storage/SQL/operational_need/insert_or_update.sql
@@ -1,35 +1,37 @@
-WITH retVal AS (INSERT INTO operational_need(
+WITH retVal AS (
+    INSERT INTO operational_need(
+        id,
+        model_plan_id,
+        need_type,
+        needed,
+        created_by,
+        created_dts
+    )
+    (
+        SELECT
+            :id AS id, -- could do gen_random_uuid()
+            :model_plan_id AS model_plan_id,
+            (SELECT possible_operational_need.id FROM possible_operational_need WHERE possible_operational_need.need_key = :need_key) AS need_type,
+            :needed AS needed,
+            :created_by AS created_by,
+            CURRENT_TIMESTAMP AS created_dts
+    )
+
+    ON CONFLICT(model_plan_id, need_type) DO UPDATE -- If there is already a record for this, 
+    SET
+    needed = EXCLUDED.needed,
+    modified_by = :modified_by,
+    modified_dts = CURRENT_TIMESTAMP
+    RETURNING
     id,
     model_plan_id,
     need_type,
+    name_other,
     needed,
     created_by,
-    created_dts
-)
-SELECT
-    :id AS id, -- could do gen_random_uuid()
-    :model_plan_id AS model_plan_id,
-    (SELECT possible_operational_need.id FROM possible_operational_need WHERE possible_operational_need.need_key = :need_key) AS need_type,
-    :needed AS needed,
-    :created_by AS created_by,
-    CURRENT_TIMESTAMP AS created_dts
-
-ON CONFLICT(model_plan_id, need_type) DO -- If there is already a record for this, 
-UPDATE
-SET
-needed = EXCLUDED.needed,
-modified_by = :modified_by,
-modified_dts = CURRENT_TIMESTAMP
-RETURNING
-id,
-model_plan_id,
-need_type,
-name_other,
-needed,
-created_by,
-created_dts,
-modified_by,
-modified_dts
+    created_dts,
+    modified_by,
+    modified_dts
 )
 
 

--- a/pkg/storage/SQL/operational_need/update_by_id.sql
+++ b/pkg/storage/SQL/operational_need/update_by_id.sql
@@ -8,14 +8,14 @@ WITH retVal AS (
         modified_dts = CURRENT_TIMESTAMP
     WHERE operational_need.id = :id
     RETURNING id,
-        model_plan_id,
-        need_type,
-        name_other,
-        needed,
-        created_by,
-        created_dts,
-        modified_by,
-        modified_dts
+    model_plan_id,
+    need_type,
+    name_other,
+    needed,
+    created_by,
+    created_dts,
+    modified_by,
+    modified_dts
 )
 
 SELECT

--- a/pkg/storage/SQL/operational_solution/insert.sql
+++ b/pkg/storage/SQL/operational_solution/insert.sql
@@ -1,5 +1,36 @@
 WITH retVal AS (
-INSERT INTO operational_solution(
+    INSERT INTO operational_solution(
+        id,
+        operational_need_id,
+        solution_type,
+        needed,
+        name_other,
+        poc_name,
+        poc_email,
+        must_start_dts,
+        must_finish_dts,
+        is_other,
+        other_header,
+        status,
+        created_by
+    )
+    (
+        SELECT
+            :id AS id,
+            :operational_need_id AS operational_need_id,
+            (SELECT possible_operational_solution.id FROM possible_operational_solution WHERE possible_operational_solution.sol_key = :sol_key) AS solution_type,
+            :needed AS needed,
+            :name_other AS name_other,
+            :poc_name AS poc_name,
+            :poc_email AS poc_email,
+            :must_start_dts AS must_start_dts,
+            :must_finish_dts AS must_finish_dts,
+            COALESCE((SELECT possible_operational_solution.treat_as_other FROM possible_operational_solution WHERE possible_operational_solution.sol_key = :sol_key), TRUE) AS is_other, -- IF NULL, then custom
+            :other_header AS other_header,
+            :status AS status,
+            :created_by AS created_by
+    )
+    RETURNING
     id,
     operational_need_id,
     solution_type,
@@ -12,39 +43,10 @@ INSERT INTO operational_solution(
     is_other,
     other_header,
     status,
-    created_by
-)
-SELECT
-    :id AS id,
-    :operational_need_id AS operational_need_id,
-    (SELECT possible_operational_solution.id FROM possible_operational_solution WHERE possible_operational_solution.sol_key = :sol_key) AS solution_type,
-    :needed AS needed,
-    :name_other AS name_other,
-    :poc_name AS poc_name,
-    :poc_email AS poc_email,
-    :must_start_dts AS must_start_dts,
-    :must_finish_dts AS must_finish_dts,
-    COALESCE((SELECT possible_operational_solution.treat_as_other FROM possible_operational_solution WHERE possible_operational_solution.sol_key = :sol_key), TRUE) AS is_other, -- IF NULL, then custom
-    :other_header AS other_header,
-    :status AS status,
-    :created_by AS created_by
-RETURNING
-id,
-operational_need_id,
-solution_type,
-needed,
-name_other,
-poc_name,
-poc_email,
-must_start_dts,
-must_finish_dts,
-is_other,
-other_header,
-status,
-created_by,
-created_dts,
-modified_by,
-modified_dts
+    created_by,
+    created_dts,
+    modified_by,
+    modified_dts
 )
 
 SELECT

--- a/pkg/storage/SQL/operational_solution/update_by_id.sql
+++ b/pkg/storage/SQL/operational_solution/update_by_id.sql
@@ -1,6 +1,7 @@
 WITH retVal AS (
     UPDATE operational_solution
-    SET solution_type = :solution_type,
+    SET
+        solution_type = :solution_type,
         name_other = :name_other,
         needed = :needed,
         poc_name = :poc_name,
@@ -13,21 +14,21 @@ WITH retVal AS (
         modified_dts = CURRENT_TIMESTAMP
     WHERE operational_solution.id = :id
     RETURNING id,
-        operational_need_id,
-        solution_type,
-        needed,
-        name_other,
-        poc_name,
-        poc_email,
-        must_start_dts,
-        must_finish_dts,
-        is_other,
-        other_header,
-        status,
-        created_by,
-        created_dts,
-        modified_by,
-        modified_dts
+    operational_need_id,
+    solution_type,
+    needed,
+    name_other,
+    poc_name,
+    poc_email,
+    must_start_dts,
+    must_finish_dts,
+    is_other,
+    other_header,
+    status,
+    created_by,
+    created_dts,
+    modified_by,
+    modified_dts
 )
 
 SELECT

--- a/pkg/storage/SQL/plan_document_solution_link/delete_by_ids.sql
+++ b/pkg/storage/SQL/plan_document_solution_link/delete_by_ids.sql
@@ -6,5 +6,6 @@ WITH PlanDocumentSolutionLinkDelete AS ( --noqa
 
 DELETE FROM plan_document_solution_link
 USING PlanDocumentSolutionLinkDelete
-WHERE plan_document_solution_link.solution_id = PlanDocumentSolutionLinkDelete.SolutionID
-      AND plan_document_solution_link.document_id = PlanDocumentSolutionLinkDelete.DocumentID
+WHERE
+    plan_document_solution_link.solution_id = PlanDocumentSolutionLinkDelete.SolutionID
+    AND plan_document_solution_link.document_id = PlanDocumentSolutionLinkDelete.DocumentID

--- a/pkg/storage/SQL/plan_favorite/create.sql
+++ b/pkg/storage/SQL/plan_favorite/create.sql
@@ -1,27 +1,27 @@
 WITH addedFavorite AS (
-INSERT INTO plan_favorite(
+    INSERT INTO plan_favorite(
+        id,
+        model_plan_id,
+        user_id,
+        created_by,
+        modified_by
+    )
+    VALUES (
+        :id,
+        :model_plan_id,
+        :user_id,
+        :created_by,
+        :modified_by
+    )
+    ON CONFLICT (model_plan_id, user_id) DO NOTHING
+    RETURNING
     id,
     model_plan_id,
     user_id,
     created_by,
-    modified_by
-)
-VALUES (
-    :id,
-    :model_plan_id,
-    :user_id,
-    :created_by,
-    :modified_by
-)
-ON CONFLICT (model_plan_id, user_id) DO NOTHING
-RETURNING
-id,
-model_plan_id,
-user_id,
-created_by,
-created_dts,
-modified_by,
-modified_dts
+    created_dts,
+    modified_by,
+    modified_dts
 
 )
 

--- a/pkg/storage/SQL/plan_ops_eval_and_learning/update.sql
+++ b/pkg/storage/SQL/plan_ops_eval_and_learning/update.sql
@@ -1,5 +1,6 @@
 UPDATE plan_ops_eval_and_learning
-SET agency_or_state_help = :agency_or_state_help,
+SET
+    agency_or_state_help = :agency_or_state_help,
     agency_or_state_help_other = :agency_or_state_help_other,
     agency_or_state_help_note = :agency_or_state_help_note,
     stakeholders = :stakeholders,


### PR DESCRIPTION
# NOREF

## Changes and Description

This change attempts to do 2 things

- Upgrade SQLFluff to v2 using [this upgrade guide](https://docs.sqlfluff.com/en/stable/releasenotes.html#upgrading-from-1-x-to-2-0)
- No longer lint the [migrations/](./migrations/) folder. I foresee the following benefits
  - Allow us to more readily make changes to our SQLFluff config, as linting the migrations folder means we can't really lint any existing migrations (or else flyway will throw a fit about the SHA having changed)
  - Speed up the linting of our SQL by reducing the lint process to only our other .sql files (right now it takes upwards of 5 minutes on CI to run our entire lint process)

If anyone can think of a way to lint NEW migrations, but not existing ones, I'm all ears, but this was the best thing I could come up with in the short term

## How to test this change

- Check out the branch
- Run `scripts/dev lint`

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
