### PR TITLE
Use multi-arch images when building locally for migrate and mailcatcher, use alpine when building for ECR

### DIFF
--- a/.github/workflows/build_application_images.yml
+++ b/.github/workflows/build_application_images.yml
@@ -78,6 +78,8 @@ jobs:
           platforms: "linux/amd64"
           context: .
           cache-from: type=gha,scope=${{ env.GIT_REF_NAME }}-db_migrate
+          build-args: |
+            TAG=9.10-alpine
       - name: Announce failure
         if: ${{ failure() }}
         run: |

--- a/Dockerfile.db_migrations
+++ b/Dockerfile.db_migrations
@@ -1,4 +1,5 @@
-FROM flyway/flyway:9.10-alpine
+ARG TAG=
+FROM flyway/flyway:${TAG}
 
 COPY migrations/ /flyway/sql
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,9 @@ services:
 
   db_migrate:
     image: mint-db-migrate:latest
-    platform: linux/amd64
+    build:
+      args:
+        TAG: '9.10' # Multi arch tag, rather than '9.10-alpine'
     environment:
       - FLYWAY_USER=postgres
       - FLYWAY_PASSWORD=mysecretpassword
@@ -118,8 +120,7 @@ services:
       "
 
   email:
-    image: dockage/mailcatcher:0.7.1
-    platform: linux/amd64
+    image: dockage/mailcatcher:0.8.2
     ports:
       - "1085:1080"
       - "1030:1025"


### PR DESCRIPTION
# NOREF

## Changes and Description

- Modifies image tags used for mailcatcher to use 0.8.2, which is multi-arch (where the previous image was not)
- Modifies the Dockerfile for db migrations to support a build argument that allows modifying the tag used for the base Flyway image. This allows using the multi-arch image locally while also allowing the same dockerfile to build the alpine image to push to ECR.

The main goal for this PR was to reduce the frequency with which the DB Migrate container would fail to start locally. After some investigation, we're lead to believe that it's due to spinning up an amd64 image on arm computers (M1 Mac, for example). This isn't a guaranteed fix, but this is a good change to make even if it's not the fix for the hanging migrate cnotainers.
<!-- Put a description here! -->

## How to test this change

- `scripts/dev up`
- Ensure there are no warnings in the console about targeting the wrong platform when building
- Ensure the DB Migrate image starts and runs as expected
- Ensure mailcatcher starts and runs as expected

## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
