### PR TITLE
Easi 2592/mint assessment permissions overhaul

### DIFF
--- a/pkg/graph/resolvers/search_change_table.go
+++ b/pkg/graph/resolvers/search_change_table.go
@@ -33,6 +33,7 @@ const (
 )
 
 // Embed the template files
+//
 //go:embed searchquerytemplates/free_text.tmpl
 var freeTextSearchTmpl string
 

--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -73,11 +73,20 @@ func devUserContext(ctx context.Context, authHeader string, store *storage.Store
 	if parseErr := json.Unmarshal([]byte(devUserConfigJSON), &config); parseErr != nil {
 		return nil, errors.New("could not parse local auth JSON")
 	}
+	var jcUser bool
+	jcAssessment := swag.ContainsStrings(config.JobCodes, "MINT_ASSESSMENT_NONPROD")
+	if jcAssessment { //Assessment users automatically are granted the base user permissions
+		jcUser = true
+	} else {
+		jcUser = swag.ContainsStrings(config.JobCodes, "MINT_USER_NONPROD")
+	}
+	jcMAC := swag.ContainsStrings(config.JobCodes, "MINT MAC Users")
+
 	princ := &authentication.ApplicationPrincipal{
 		Username:          strings.ToUpper(config.EUA),
-		JobCodeUSER:       swag.ContainsStrings(config.JobCodes, "MINT_USER_NONPROD"),
-		JobCodeASSESSMENT: swag.ContainsStrings(config.JobCodes, "MINT_ASSESSMENT_NONPROD"),
-		JobCodeMAC:        swag.ContainsStrings(config.JobCodes, "MINT MAC Users"),
+		JobCodeUSER:       jcUser,
+		JobCodeASSESSMENT: jcAssessment,
+		JobCodeMAC:        jcMAC,
 	}
 
 	userAccount, err := userhelpers.GetOrCreateUserAccount(ctx, store, princ.ID(), true, princ.JobCodeMAC, userhelpers.GetOktaAccountInfoWrapperFunction(userhelpers.GetUserInfoFromOktaLocal))

--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -73,14 +73,15 @@ func devUserContext(ctx context.Context, authHeader string, store *storage.Store
 	if parseErr := json.Unmarshal([]byte(devUserConfigJSON), &config); parseErr != nil {
 		return nil, errors.New("could not parse local auth JSON")
 	}
-	var jcUser bool
+	// Pull job codes from config
+	jcUser := swag.ContainsStrings(config.JobCodes, "MINT_USER_NONPROD")
 	jcAssessment := swag.ContainsStrings(config.JobCodes, "MINT_ASSESSMENT_NONPROD")
-	if jcAssessment { //Assessment users automatically are granted the base user permissions
-		jcUser = true
-	} else {
-		jcUser = swag.ContainsStrings(config.JobCodes, "MINT_USER_NONPROD")
-	}
 	jcMAC := swag.ContainsStrings(config.JobCodes, "MINT MAC Users")
+
+	// Always set assessment users to have base user permissions
+	if jcAssessment {
+		jcUser = true
+	}
 
 	princ := &authentication.ApplicationPrincipal{
 		Username:          strings.ToUpper(config.EUA),

--- a/pkg/okta/authentication_middleware.go
+++ b/pkg/okta/authentication_middleware.go
@@ -134,8 +134,13 @@ func (f MiddlewareFactory) newPrincipal(ctx context.Context) (*authentication.Ap
 	}
 
 	// Get job codes out of the JWT
-	jcUser := jwtGroupsContainsJobCode(enhanced.JWT, f.jobCodes.GetUserJobCode())
+	var jcUser bool
 	jcAssessment := jwtGroupsContainsJobCode(enhanced.JWT, f.jobCodes.GetAssessmentJobCode())
+	if jcAssessment { //Assessment users automatically are granted the base user permissions
+		jcUser = true
+	} else {
+		jcUser = jwtGroupsContainsJobCode(enhanced.JWT, f.jobCodes.GetUserJobCode())
+	}
 	jcMAC := jwtGroupsContainsJobCode(enhanced.JWT, f.jobCodes.GetMACUserJobCode())
 
 	// Create a LaunchDarkly user

--- a/pkg/okta/authentication_middleware_test.go
+++ b/pkg/okta/authentication_middleware_test.go
@@ -68,7 +68,7 @@ func (tjv TestJwtVerifier) VerifyAccessToken(jwt string) (*jwtverifier.Jwt, erro
 	return tjv.verify(jwt)
 }
 
-func (s *AuthenticationMiddlewareTestSuite) buidMiddleWareFactory(verify func(jwt string) (*jwtverifier.Jwt, error)) *MiddlewareFactory {
+func (s *AuthenticationMiddlewareTestSuite) buildMiddleWareFactory(verify func(jwt string) (*jwtverifier.Jwt, error)) *MiddlewareFactory {
 	verifier := TestJwtVerifier{
 		verify: verify,
 	}
@@ -93,7 +93,7 @@ func (s *AuthenticationMiddlewareTestSuite) buidMiddleWareFactory(verify func(jw
 }
 
 func (s *AuthenticationMiddlewareTestSuite) buildMiddleware(verify func(jwt string) (*jwtverifier.Jwt, error)) func(http.Handler) http.Handler {
-	factory := s.buidMiddleWareFactory(verify)
+	factory := s.buildMiddleWareFactory(verify)
 	return factory.NewAuthenticationMiddleware
 }
 
@@ -165,7 +165,7 @@ func (s *AuthenticationMiddlewareTestSuite) TestAuthorizeMiddleware() {
 }
 func (s *AuthenticationMiddlewareTestSuite) TestNewPrincipal() {
 	s.Run("Assessment has user permissions", func() {
-		faktory := s.buidMiddleWareFactory(func(jwt string) (*jwtverifier.Jwt, error) {
+		faktory := s.buildMiddleWareFactory(func(jwt string) (*jwtverifier.Jwt, error) {
 			return nil, errors.New("invalid token")
 		})
 		jwt := validJwt()
@@ -184,7 +184,7 @@ func (s *AuthenticationMiddlewareTestSuite) TestNewPrincipal() {
 	})
 
 	s.Run("User only have USER assessment permissions", func() {
-		faktory := s.buidMiddleWareFactory(func(jwt string) (*jwtverifier.Jwt, error) {
+		faktory := s.buildMiddleWareFactory(func(jwt string) (*jwtverifier.Jwt, error) {
 			return nil, errors.New("invalid token")
 		})
 		jwt := validJwt()
@@ -202,7 +202,7 @@ func (s *AuthenticationMiddlewareTestSuite) TestNewPrincipal() {
 		s.False(princ.JobCodeMAC)
 	})
 	s.Run("MAC users only have MAC permissions", func() {
-		faktory := s.buidMiddleWareFactory(func(jwt string) (*jwtverifier.Jwt, error) {
+		faktory := s.buildMiddleWareFactory(func(jwt string) (*jwtverifier.Jwt, error) {
 			return nil, errors.New("invalid token")
 		})
 		jwt := validJwt()

--- a/pkg/okta/authentication_middleware_test.go
+++ b/pkg/okta/authentication_middleware_test.go
@@ -68,7 +68,7 @@ func (tjv TestJwtVerifier) VerifyAccessToken(jwt string) (*jwtverifier.Jwt, erro
 	return tjv.verify(jwt)
 }
 
-func (s *AuthenticationMiddlewareTestSuite) buildMiddleware(verify func(jwt string) (*jwtverifier.Jwt, error)) func(http.Handler) http.Handler {
+func (s *AuthenticationMiddlewareTestSuite) buidMiddleWareFactory(verify func(jwt string) (*jwtverifier.Jwt, error)) *MiddlewareFactory {
 	verifier := TestJwtVerifier{
 		verify: verify,
 	}
@@ -81,7 +81,6 @@ func (s *AuthenticationMiddlewareTestSuite) buildMiddleware(verify func(jwt stri
 	}
 	ldClient, err := ld.MakeCustomClient("fake", ldConfig, 0)
 	s.NoError(err)
-
 	factory := NewMiddlewareFactory(
 		handlers.NewHandlerBase(s.logger),
 		verifier,
@@ -89,6 +88,12 @@ func (s *AuthenticationMiddlewareTestSuite) buildMiddleware(verify func(jwt stri
 		true,
 		ldClient,
 	)
+	return factory
+
+}
+
+func (s *AuthenticationMiddlewareTestSuite) buildMiddleware(verify func(jwt string) (*jwtverifier.Jwt, error)) func(http.Handler) http.Handler {
+	factory := s.buidMiddleWareFactory(verify)
 	return factory.NewAuthenticationMiddleware
 }
 
@@ -157,6 +162,63 @@ func (s *AuthenticationMiddlewareTestSuite) TestAuthorizeMiddleware() {
 		s.True(handlerRun)
 	})
 
+}
+func (s *AuthenticationMiddlewareTestSuite) TestNewPrincipal() {
+	s.Run("Assessment has user permissions", func() {
+		faktory := s.buidMiddleWareFactory(func(jwt string) (*jwtverifier.Jwt, error) {
+			return nil, errors.New("invalid token")
+		})
+		jwt := validJwt()
+		jwt.Claims["mint-groups"] = []interface{}{"MINT_ASSESSMENT_NONPROD"}
+
+		eJwt := authentication.EnhancedJwt{
+			JWT:       jwt,
+			AuthToken: "Bearer isNotABear",
+		}
+		ctx := appcontext.WithEnhancedJWT(context.Background(), eJwt)
+		princ, err := faktory.newPrincipal(ctx)
+		s.NoError(err)
+		s.True(princ.JobCodeUSER)
+		s.True(princ.JobCodeASSESSMENT)
+		s.False(princ.JobCodeMAC)
+	})
+
+	s.Run("User only have USER assessment permissions", func() {
+		faktory := s.buidMiddleWareFactory(func(jwt string) (*jwtverifier.Jwt, error) {
+			return nil, errors.New("invalid token")
+		})
+		jwt := validJwt()
+		jwt.Claims["mint-groups"] = []interface{}{"MINT_USER_NONPROD"}
+
+		eJwt := authentication.EnhancedJwt{
+			JWT:       jwt,
+			AuthToken: "Bearer isNotABear",
+		}
+		ctx := appcontext.WithEnhancedJWT(context.Background(), eJwt)
+		princ, err := faktory.newPrincipal(ctx)
+		s.NoError(err)
+		s.True(princ.JobCodeUSER)
+		s.False(princ.JobCodeASSESSMENT)
+		s.False(princ.JobCodeMAC)
+	})
+	s.Run("MAC users only have MAC permissions", func() {
+		faktory := s.buidMiddleWareFactory(func(jwt string) (*jwtverifier.Jwt, error) {
+			return nil, errors.New("invalid token")
+		})
+		jwt := validJwt()
+		jwt.Claims["mint-groups"] = []interface{}{"MINT MAC Users"}
+
+		eJwt := authentication.EnhancedJwt{
+			JWT:       jwt,
+			AuthToken: "Bearer isNotABear",
+		}
+		ctx := appcontext.WithEnhancedJWT(context.Background(), eJwt)
+		princ, err := faktory.newPrincipal(ctx)
+		s.NoError(err)
+		s.False(princ.JobCodeUSER)
+		s.False(princ.JobCodeASSESSMENT)
+		s.True(princ.JobCodeMAC)
+	})
 }
 
 func TestJobCodes(t *testing.T) {


### PR DESCRIPTION
# EASI-2592

## Changes and Description

- Assessment User now gets granted normal user role
- Unit tests to assert this new logic.
- I looked through the front end code to see if there needs to be changes there, It looks like this covers all the needs.
- 

## How to test this change
1. Log into the app / Run postman queries with only the ASSESSMENT Job code
2. Confirm that you can hit endpoints that require the mint user job code (like modelPlan)
3. Verify Unit test coverage matches as expected
4.  Verify that there aren't missed areas on the frontend that need code changes to work with this paradigm.

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [x] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [x] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
