### PR TITLE
EASI-2876: pull from dockerhub and pin to 2.5.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,8 @@ services:
     restart: always
 
   opensearch:
-    image: public.ecr.aws/opensearchproject/opensearch:latest
+    # As of 5/2/2023 - Latest available version in AWS Opensearch Service: 2.5.0
+    image: opensearchproject/opensearch:2.5.0
     container_name: opensearch
     environment:
       - cluster.name=opensearch-cluster

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,8 @@ services:
       - "9400:9600" # Performance Analyzer
 
   opensearch-dashboards:
-    image: public.ecr.aws/opensearchproject/opensearch-dashboards:latest
+    # As of 5/2/2023 - Latest available version in AWS Opensearch Service: 2.5.0
+    image: opensearchproject/opensearch-dashboards:2.5.0
     container_name: opensearch-dashboards
     ports:
       - "5601:5601"


### PR DESCRIPTION
# EASI-2876

## Changes and Description

- Pulling Opensearch from Dockerhub after experiencing rate limiting issues pulling from ECR.
- Pinning to 2.5.0 to match current available versions in AWS Opensearch Service
```
Supported versions of OpenSearch and Elasticsearch
OpenSearch Service currently supports the following OpenSearch versions:

2.5, 2.3, 1.3, 1.2, 1.1, 1.0
```
[Current Versions- AWS Docs](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#choosing-version)

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
