### PR TITLE
Rename logger fields so they dont conflict with SPLUNK

### DIFF
--- a/pkg/server/logger.go
+++ b/pkg/server/logger.go
@@ -24,11 +24,11 @@ func loggerMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
 		fields := []zap.Field{
 			zap.String("accepted-language", r.Header.Get("accepted-language")),
 			zap.Int64("content-length", r.ContentLength),
-			zap.String("host", r.Host),
+			zap.String("app-host", r.Host),
 			zap.String("method", r.Method),
 			zap.String("protocol-version", r.Proto),
 			zap.String("referer", r.Header.Get("referer")),
-			zap.String("source", r.RemoteAddr),
+			zap.String("request-source", r.RemoteAddr),
 			zap.String("url", r.URL.String()),
 			zap.String("user-agent", r.UserAgent()),
 		}


### PR DESCRIPTION
## Changes and Description

-  (source and host) fields are created during ingestion by SPLUNK, and are defined in our logger.go configuration.
   - this made it so you couldn't search on those fields without getting incorrect results
- These fields are renamed so we can query them individually in SPLUNK.



## How to test this change
Run the App, or just see that CI tests passed.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
