### PR TITLE
Existing Model Link Migration correction

### DIFF
--- a/migrations/V91__Resembles_Existing_Model_To_Link.sql
+++ b/migrations/V91__Resembles_Existing_Model_To_Link.sql
@@ -27,6 +27,7 @@ SELECT
     matchedLinks.existing_model_id,
     matchedLinks.current_model_plan_id,
     matchedLinks.created_by
-FROM matchedLinks;
+FROM matchedLinks
+WHERE (matchedLinks.current_model_plan_id IS NOT NULL OR matchedLinks.existing_model_id IS NOT NULL);
 
 ALTER TABLE plan_general_characteristics DROP COLUMN resembles_existing_model_which;


### PR DESCRIPTION

## Changes and Description

Deploying the migration V91 failed in impl because it tried to insert a record where for a text array entry for resembles which in general characteristics that didn't map to an `existing_model` or a `model_plan`. This is likely an artifact of data in IMPL from when we changed existing model ids. These unmatched links should be ignored.

- Add where clause to migration to make sure links are only added


<!-- Put a description here! -->

## How to test this change

1. Comment out migration v91
2. Bring up the app
3. Run the below SQL to add some data (with non-matching values for resembles_existing_model_which)
4. Manually run the migration in SQL and verify that it handles the non match condition
5. If you would like to verify that this was the root cause, do the above steps, but run the old migration without the where clause for step 4.

Seed data SQL
```SQL
INSERT INTO "public"."user_account"("id", "username", "is_euaid", "common_name", "locale", "email", "given_name", "family_name", "zone_info", "has_logged_in") VALUES('435205c4-1867-4723-816c-a12506084d6b', 'LOLD', 'TRUE', 'LOLD Doe', 'en_US', 'LOLD@local.cms.gov', 'LOLD', 'Doe', 'America/Los_Angeles', 'TRUE') RETURNING "id", "username", "is_euaid", "common_name", "locale", "email", "given_name", "family_name", "zone_info", "has_logged_in";

INSERT INTO "public"."model_plan"("id", "model_name", "archived", "status", "created_dts", "created_by") VALUES('812865d8-8fbe-4b68-a901-9dbab6f6b587', 'Steven''s Excellent Test Plan', 'FALSE', 'PLAN_DRAFT', '2023-04-26 15:20:20.202021+00', '435205c4-1867-4723-816c-a12506084d6b') RETURNING "id", "model_name", "archived", "status", "created_dts", "modified_dts", "created_by", "modified_by";
INSERT INTO "public"."model_plan"("id", "model_name", "archived", "status", "created_dts", "created_by") VALUES('2b39ed18-77be-429d-bf31-2a5ec769f2d5', 'Plan That resembles Plan That resembles Excellent', 'FALSE', 'PLAN_DRAFT', '2023-04-26 15:22:01.849617+00', '435205c4-1867-4723-816c-a12506084d6b') RETURNING "id", "model_name", "archived", "status", "created_dts", "modified_dts", "created_by", "modified_by";
INSERT INTO "public"."model_plan"("id", "model_name", "archived", "status", "created_dts", "created_by") VALUES('22b4e398-3086-42a8-9d82-4b1acdc3acdf', 'Plan That resembles itself', 'FALSE', 'PLAN_DRAFT', '2023-04-26 15:22:36.498181+00', '435205c4-1867-4723-816c-a12506084d6b') RETURNING "id", "model_name", "archived", "status", "created_dts", "modified_dts", "created_by", "modified_by";
INSERT INTO "public"."model_plan"("id", "model_name", "archived", "status", "created_dts", "created_by") VALUES('7e1ed916-b2b1-48c4-9880-d49e58622aad', 'Plan That resembles Excellent Test Plan', 'FALSE', 'PLAN_DRAFT', '2023-04-26 15:21:23.29975+00', '435205c4-1867-4723-816c-a12506084d6b') RETURNING "id", "model_name", "archived", "status", "created_dts", "modified_dts", "created_by", "modified_by";
INSERT INTO "public"."model_plan"("id", "model_name", "archived", "status", "created_dts", "created_by") VALUES('b7529e48-942c-49c2-ac1e-c1ee0c82bd6d', 'Plan That resembles everything!', 'FALSE', 'PLAN_DRAFT', '2023-04-26 15:23:18.478828+00', '435205c4-1867-4723-816c-a12506084d6b') RETURNING "id", "model_name", "archived", "status", "created_dts", "modified_dts", "created_by", "modified_by";



INSERT INTO "public"."plan_general_characteristics"("id", "model_plan_id", "resembles_existing_model", "resembles_existing_model_which", "created_dts", "modified_dts", "status", "created_by", "modified_by") VALUES('24a407ff-6111-44c1-a7a8-95d52da2526e', '2b39ed18-77be-429d-bf31-2a5ec769f2d5', 'TRUE', '{badData,7e1ed916-b2b1-48c4-9880-d49e58622aad}', '2023-04-26 15:22:01.863213+00', '2023-04-26 15:22:21.023303+00', 'IN_PROGRESS', '435205c4-1867-4723-816c-a12506084d6b', '435205c4-1867-4723-816c-a12506084d6b') RETURNING "id", "model_plan_id", "is_new_model", "existing_model", "resembles_existing_model", "resembles_existing_model_which", "resembles_existing_model_how", "resembles_existing_model_note", "has_components_or_tracks", "has_components_or_tracks_differ", "has_components_or_tracks_note", "alternative_payment_model_types", "alternative_payment_model_note", "key_characteristics", "key_characteristics_other", "key_characteristics_note", "collect_plan_bids", "collect_plan_bids_note", "manage_part_c_d_enrollment", "manage_part_c_d_enrollment_note", "plan_contract_updated", "plan_contract_updated_note", "care_coordination_involved", "care_coordination_involved_description", "care_coordination_involved_note", "additional_services_involved", "additional_services_involved_description", "additional_services_involved_note", "community_partners_involved", "community_partners_involved_description", "community_partners_involved_note", "geographies_targeted", "geographies_targeted_types", "geographies_targeted_types_other", "geographies_targeted_applied_to", "geographies_targeted_applied_to_other", "geographies_targeted_note", "participation_options", "participation_options_note", "agreement_types", "agreement_types_other", "multiple_patricipation_agreements_needed", "multiple_patricipation_agreements_needed_note", "rulemaking_required", "rulemaking_required_description", "rulemaking_required_note", "authority_allowances", "authority_allowances_other", "authority_allowances_note", "waivers_required", "waivers_required_types", "waivers_required_note", "created_dts", "modified_dts", "ready_for_review_dts", "ready_for_clearance_dts", "status", "ready_for_clearance_by", "ready_for_review_by", "created_by", "modified_by";
INSERT INTO "public"."plan_general_characteristics"("id", "model_plan_id", "is_new_model", "existing_model", "resembles_existing_model", "resembles_existing_model_which", "created_dts", "modified_dts", "status", "created_by", "modified_by") VALUES('3d1171ae-1582-4e05-aca0-5e40f2008810', '812865d8-8fbe-4b68-a901-9dbab6f6b587', 'FALSE', 'Medicaid Emergency Psychiatric Demonstration', 'TRUE', '{100095,100001,100066,100109,100062,100110,100092,100022}', '2023-04-26 15:20:20.25667+00', '2023-04-26 15:21:07.703835+00', 'IN_PROGRESS', '435205c4-1867-4723-816c-a12506084d6b', '435205c4-1867-4723-816c-a12506084d6b') RETURNING "id", "model_plan_id", "is_new_model", "existing_model", "resembles_existing_model", "resembles_existing_model_which", "resembles_existing_model_how", "resembles_existing_model_note", "has_components_or_tracks", "has_components_or_tracks_differ", "has_components_or_tracks_note", "alternative_payment_model_types", "alternative_payment_model_note", "key_characteristics", "key_characteristics_other", "key_characteristics_note", "collect_plan_bids", "collect_plan_bids_note", "manage_part_c_d_enrollment", "manage_part_c_d_enrollment_note", "plan_contract_updated", "plan_contract_updated_note", "care_coordination_involved", "care_coordination_involved_description", "care_coordination_involved_note", "additional_services_involved", "additional_services_involved_description", "additional_services_involved_note", "community_partners_involved", "community_partners_involved_description", "community_partners_involved_note", "geographies_targeted", "geographies_targeted_types", "geographies_targeted_types_other", "geographies_targeted_applied_to", "geographies_targeted_applied_to_other", "geographies_targeted_note", "participation_options", "participation_options_note", "agreement_types", "agreement_types_other", "multiple_patricipation_agreements_needed", "multiple_patricipation_agreements_needed_note", "rulemaking_required", "rulemaking_required_description", "rulemaking_required_note", "authority_allowances", "authority_allowances_other", "authority_allowances_note", "waivers_required", "waivers_required_types", "waivers_required_note", "created_dts", "modified_dts", "ready_for_review_dts", "ready_for_clearance_dts", "status", "ready_for_clearance_by", "ready_for_review_by", "created_by", "modified_by";
INSERT INTO "public"."plan_general_characteristics"("id", "model_plan_id", "resembles_existing_model", "resembles_existing_model_which", "created_dts", "modified_dts", "status", "created_by", "modified_by") VALUES('3d984b59-98d2-440f-ae46-be8664d7eae9', 'b7529e48-942c-49c2-ac1e-c1ee0c82bd6d', 'TRUE', '{100054,100109,100066,100001,100095,100088,200001,100104,100006,100007,100062,100008,100069,100089,100099,100110,100097,100108,100010,100044,100106,100011,200099,100012,100013,100072,100071,100064,100014,100015,100016,100091,100094,100100,100043,100092,100093,100017,100018,100051,100019,100002,100063,100047,100020,100073,100021,100022,100023,100042,100003,100004,100005,100009,100061,100105,100024,100059,100025,100056,100065,100096,100102,100026,100083,100027,100028,100029,7e1ed916-b2b1-48c4-9880-d49e58622aad,2b39ed18-77be-429d-bf31-2a5ec769f2d5,b7529e48-942c-49c2-ac1e-c1ee0c82bd6d,22b4e398-3086-42a8-9d82-4b1acdc3acdf,100098,100030,100101,100031,100037,812865d8-8fbe-4b68-a901-9dbab6f6b587,100040,100035,100046,100103,100076, hello}', '2023-04-26 15:23:18.505738+00', '2023-04-26 15:24:39.640771+00', 'IN_PROGRESS', '435205c4-1867-4723-816c-a12506084d6b', '435205c4-1867-4723-816c-a12506084d6b') RETURNING "id", "model_plan_id", "is_new_model", "existing_model", "resembles_existing_model", "resembles_existing_model_which", "resembles_existing_model_how", "resembles_existing_model_note", "has_components_or_tracks", "has_components_or_tracks_differ", "has_components_or_tracks_note", "alternative_payment_model_types", "alternative_payment_model_note", "key_characteristics", "key_characteristics_other", "key_characteristics_note", "collect_plan_bids", "collect_plan_bids_note", "manage_part_c_d_enrollment", "manage_part_c_d_enrollment_note", "plan_contract_updated", "plan_contract_updated_note", "care_coordination_involved", "care_coordination_involved_description", "care_coordination_involved_note", "additional_services_involved", "additional_services_involved_description", "additional_services_involved_note", "community_partners_involved", "community_partners_involved_description", "community_partners_involved_note", "geographies_targeted", "geographies_targeted_types", "geographies_targeted_types_other", "geographies_targeted_applied_to", "geographies_targeted_applied_to_other", "geographies_targeted_note", "participation_options", "participation_options_note", "agreement_types", "agreement_types_other", "multiple_patricipation_agreements_needed", "multiple_patricipation_agreements_needed_note", "rulemaking_required", "rulemaking_required_description", "rulemaking_required_note", "authority_allowances", "authority_allowances_other", "authority_allowances_note", "waivers_required", "waivers_required_types", "waivers_required_note", "created_dts", "modified_dts", "ready_for_review_dts", "ready_for_clearance_dts", "status", "ready_for_clearance_by", "ready_for_review_by", "created_by", "modified_by";
INSERT INTO "public"."plan_general_characteristics"("id", "model_plan_id", "resembles_existing_model", "resembles_existing_model_which", "created_dts", "modified_dts", "status", "created_by", "modified_by") VALUES('7c65bfb0-c43b-49f6-aad4-63448348184c', '22b4e398-3086-42a8-9d82-4b1acdc3acdf', 'TRUE', '{22b4e398-3086-42a8-9d82-4b1acdc3acdf}', '2023-04-26 15:22:36.517093+00', '2023-04-26 15:22:58.752972+00', 'IN_PROGRESS', '435205c4-1867-4723-816c-a12506084d6b', '435205c4-1867-4723-816c-a12506084d6b') RETURNING "id", "model_plan_id", "is_new_model", "existing_model", "resembles_existing_model", "resembles_existing_model_which", "resembles_existing_model_how", "resembles_existing_model_note", "has_components_or_tracks", "has_components_or_tracks_differ", "has_components_or_tracks_note", "alternative_payment_model_types", "alternative_payment_model_note", "key_characteristics", "key_characteristics_other", "key_characteristics_note", "collect_plan_bids", "collect_plan_bids_note", "manage_part_c_d_enrollment", "manage_part_c_d_enrollment_note", "plan_contract_updated", "plan_contract_updated_note", "care_coordination_involved", "care_coordination_involved_description", "care_coordination_involved_note", "additional_services_involved", "additional_services_involved_description", "additional_services_involved_note", "community_partners_involved", "community_partners_involved_description", "community_partners_involved_note", "geographies_targeted", "geographies_targeted_types", "geographies_targeted_types_other", "geographies_targeted_applied_to", "geographies_targeted_applied_to_other", "geographies_targeted_note", "participation_options", "participation_options_note", "agreement_types", "agreement_types_other", "multiple_patricipation_agreements_needed", "multiple_patricipation_agreements_needed_note", "rulemaking_required", "rulemaking_required_description", "rulemaking_required_note", "authority_allowances", "authority_allowances_other", "authority_allowances_note", "waivers_required", "waivers_required_types", "waivers_required_note", "created_dts", "modified_dts", "ready_for_review_dts", "ready_for_clearance_dts", "status", "ready_for_clearance_by", "ready_for_review_by", "created_by", "modified_by";
INSERT INTO "public"."plan_general_characteristics"("id", "model_plan_id", "resembles_existing_model", "resembles_existing_model_which", "created_dts", "modified_dts", "status", "created_by", "modified_by") VALUES('9f17a7d8-1654-445c-b72a-468505d8bc95', '7e1ed916-b2b1-48c4-9880-d49e58622aad', 'TRUE', '{812865d8-8fbe-4b68-a901-9dbab6f6b587}', '2023-04-26 15:21:23.311089+00', '2023-04-26 15:21:39.171466+00', 'IN_PROGRESS', '435205c4-1867-4723-816c-a12506084d6b', '435205c4-1867-4723-816c-a12506084d6b') RETURNING "id", "model_plan_id", "is_new_model", "existing_model", "resembles_existing_model", "resembles_existing_model_which", "resembles_existing_model_how", "resembles_existing_model_note", "has_components_or_tracks", "has_components_or_tracks_differ", "has_components_or_tracks_note", "alternative_payment_model_types", "alternative_payment_model_note", "key_characteristics", "key_characteristics_other", "key_characteristics_note", "collect_plan_bids", "collect_plan_bids_note", "manage_part_c_d_enrollment", "manage_part_c_d_enrollment_note", "plan_contract_updated", "plan_contract_updated_note", "care_coordination_involved", "care_coordination_involved_description", "care_coordination_involved_note", "additional_services_involved", "additional_services_involved_description", "additional_services_involved_note", "community_partners_involved", "community_partners_involved_description", "community_partners_involved_note", "geographies_targeted", "geographies_targeted_types", "geographies_targeted_types_other", "geographies_targeted_applied_to", "geographies_targeted_applied_to_other", "geographies_targeted_note", "participation_options", "participation_options_note", "agreement_types", "agreement_types_other", "multiple_patricipation_agreements_needed", "multiple_patricipation_agreements_needed_note", "rulemaking_required", "rulemaking_required_description", "rulemaking_required_note", "authority_allowances", "authority_allowances_other", "authority_allowances_note", "waivers_required", "waivers_required_types", "waivers_required_note", "created_dts", "modified_dts", "ready_for_review_dts", "ready_for_clearance_dts", "status", "ready_for_clearance_by", "ready_for_review_by", "created_by", "modified_by";

```

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
