### PR TITLE
[NOREF] - Discussion text and alert fixes

### DIFF
--- a/src/components/ITSolutionsWarning/__snapshots__/index.test.tsx.snap
+++ b/src/components/ITSolutionsWarning/__snapshots__/index.test.tsx.snap
@@ -11,7 +11,8 @@ exports[`The ITSolutionsWarning component matches snapshot 1`] = `
     >
       <p
         class="usa-alert__text"
-      >
+      />
+      <div>
         Changing your answer to this question may also affect your selections in the IT solutions and implementation status tracker.  
         <button
           class="usa-button usa-button usa-button--unstyled"
@@ -21,7 +22,8 @@ exports[`The ITSolutionsWarning component matches snapshot 1`] = `
         >
           Go to IT solutions tracker.
         </button>
-      </p>
+      </div>
+      <p />
     </div>
   </div>
 </DocumentFragment>

--- a/src/components/shared/Alert/__snapshots__/index.test.tsx.snap
+++ b/src/components/shared/Alert/__snapshots__/index.test.tsx.snap
@@ -16,19 +16,21 @@ exports[`The Alert component matches snapshot 1`] = `
       </h4>
       <p
         class="usa-alert__text"
-      >
+      />
+      <div>
         This is information
-        <button
-          aria-label="Close Button"
-          class="usa-button usa-button usa-button--unstyled text-no-underline text-black flex-align-end"
-          data-testid="button"
-          role="button"
-          tabindex="0"
-          type="button"
-        >
-          ✕
-        </button>
-      </p>
+      </div>
+      <button
+        aria-label="Close Button"
+        class="usa-button usa-button usa-button--unstyled text-no-underline text-black flex-align-end"
+        data-testid="button"
+        role="button"
+        tabindex="0"
+        type="button"
+      >
+        ✕
+      </button>
+      <p />
     </div>
   </div>
 </DocumentFragment>

--- a/src/components/shared/Alert/index.tsx
+++ b/src/components/shared/Alert/index.tsx
@@ -2,7 +2,7 @@
 Wrapper for Truss' <Alert> component to allow for manually closing the component
 */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Alert as TrussAlert, Button } from '@trussworks/react-uswds';
 import classnames from 'classnames';
 
@@ -17,6 +17,7 @@ type AlertProps = {
   noIcon?: boolean;
   inline?: boolean;
   isClosable?: boolean;
+  closeAlert?: (closed: boolean) => void;
 } & JSX.IntrinsicElements['div'];
 
 export const Alert = ({
@@ -29,6 +30,7 @@ export const Alert = ({
   inline,
   // Default to closable button if type = success or error
   isClosable = type === 'success' || type === 'error',
+  closeAlert,
   ...props
 }: AlertProps & React.HTMLAttributes<HTMLDivElement>): React.ReactElement => {
   const classes = classnames(
@@ -42,6 +44,11 @@ export const Alert = ({
 
   const [isClosed, setClosed] = useState<boolean>(false);
 
+  // closeAlert is a state setter passed down to conditionally render alert component from parent
+  useEffect(() => {
+    if (closeAlert && isClosed) closeAlert(false);
+  }, [isClosed, closeAlert]);
+
   return (
     <>
       {!isClosed && (
@@ -53,7 +60,7 @@ export const Alert = ({
           className={classes}
           {...props}
         >
-          {children}
+          <div>{children}</div>
           {isClosable && (
             <Button
               type="button"

--- a/src/views/ModelPlan/Collaborators/AddCollaborator/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/Collaborators/AddCollaborator/__snapshots__/index.test.tsx.snap
@@ -202,13 +202,15 @@ exports[`Adding a collaborator page matches snapshot 1`] = `
             >
               <p
                 class="usa-alert__text"
-              >
+              />
+              <div>
                 <span
                   class="mandatory-fields-alert__text"
                 >
                   This team member will be able to view and edit anything about a model plan. Please make sure this individual should be able to do this before you proceed.
                 </span>
-              </p>
+              </div>
+              <p />
             </div>
           </div>
           <div

--- a/src/views/ModelPlan/Collaborators/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/Collaborators/__snapshots__/index.test.tsx.snap
@@ -85,6 +85,8 @@ exports[`Collaborator/Team Member page w/table matches snapshot 1`] = `
               <p
                 class="usa-alert__text"
               />
+              <div />
+              <p />
             </div>
           </div>
           <div

--- a/src/views/ModelPlan/Discussions/SingleDiscussion.tsx
+++ b/src/views/ModelPlan/Discussions/SingleDiscussion.tsx
@@ -64,7 +64,9 @@ const SingleDiscussion = ({
           'mint-discussions__not-connected': !connected
         })}
       >
-        <p className="margin-y-0 padding-y-1">{discussion.content}</p>
+        <p className="margin-y-0 padding-y-1 text-pre-wrap">
+          {discussion.content}
+        </p>
         <div className="display-flex margin-bottom-2">
           {/* Rendered a link to answer a question if there are no replies/answers only for Collaborator and Assessment Users */}
           {hasEditAccess && answerQuestion && (

--- a/src/views/ModelPlan/Discussions/index.tsx
+++ b/src/views/ModelPlan/Discussions/index.tsx
@@ -140,6 +140,9 @@ const Discussions = ({
   // State and setter used for containing the related question when replying
   const [reply, setReply] = useState<DiscussionType | ReplyType | null>(null);
 
+  // State used to manage alert rendering
+  const [alertClosed, closeAlert] = useState<boolean>(false);
+
   const validationSchema = Yup.object().shape({
     content: Yup.string().trim().required(`Please enter a ${discussionType}`)
   });
@@ -279,10 +282,14 @@ const Discussions = ({
             : t('answerDescription')}
         </p>
 
-        {/* General error message for mutations that expires after 3 seconds */}
-        {discussionStatusMessage && (
+        {/* General error message for mutations that expires after 45 seconds */}
+        {discussionStatusMessage && !alertClosed && (
           <Expire delay={45000} callback={setDiscussionStatusMessage}>
-            <Alert className="margin-bottom-4" type={discussionStatus}>
+            <Alert
+              className="margin-bottom-4"
+              type={discussionStatus}
+              closeAlert={closeAlert}
+            >
               {discussionStatusMessage}
             </Alert>
           </Expire>
@@ -513,10 +520,14 @@ const Discussions = ({
           </div>
         )}
 
-        {/* General error message for mutations that expires after 3 seconds */}
-        {discussionStatusMessage && (
+        {/* General error message for mutations that expires after 45 seconds */}
+        {discussionStatusMessage && !alertClosed && (
           <Expire delay={45000} callback={setDiscussionStatusMessage}>
-            <Alert type={discussionStatus} className="margin-bottom-4">
+            <Alert
+              type={discussionStatus}
+              className="margin-bottom-4"
+              closeAlert={closeAlert}
+            >
               {discussionStatusMessage}
             </Alert>
           </Expire>

--- a/src/views/ModelPlan/Documents/AddDocument/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/Documents/AddDocument/__snapshots__/index.test.tsx.snap
@@ -384,13 +384,15 @@ exports[`Model Plan Add Documents page matches snapshot 1`] = `
                   >
                     <p
                       class="usa-alert__text"
-                    >
+                    />
+                    <div>
                       <span
                         class="mandatory-fields-alert__text"
                       >
                         To keep CMS safe, documents are scanned for viruses after uploading. If something goes wrong, we’ll let you know
                       </span>
-                    </p>
+                    </div>
+                    <p />
                   </div>
                 </div>
                 <button

--- a/src/views/ModelPlan/NewPlan/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/NewPlan/__snapshots__/index.test.tsx.snap
@@ -60,13 +60,15 @@ exports[`New Model Plan page matches snapshot 1`] = `
           >
             <p
               class="usa-alert__text"
-            >
+            />
+            <div>
               <span
                 class="mandatory-fields-alert__text"
               >
                 This is not a permanent name. If needed, you may update it later.
               </span>
-            </p>
+            </div>
+            <p />
           </div>
         </div>
         <form

--- a/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
@@ -341,9 +341,11 @@ exports[`Read Only Model Plan Summary matches snapshot 1`] = `
         >
           <p
             class="usa-alert__text"
-          >
+          />
+          <div>
             Information outlined in this Model Plan can change drastically until it’s been cleared.
-          </p>
+          </div>
+          <p />
         </div>
       </div>
     </div>

--- a/src/views/ModelPlan/TaskList/Basics/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/Basics/__snapshots__/index.test.tsx.snap
@@ -105,13 +105,15 @@ exports[`Model Plan Documents page matches snapshot 1`] = `
           >
             <p
               class="usa-alert__text"
-            >
+            />
+            <div>
               <span
                 class="mandatory-fields-alert__text"
               >
                 All fields are mandatory
               </span>
-            </p>
+            </div>
+            <p />
           </div>
         </div>
         <div

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/KeyCharacteristics/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/KeyCharacteristics/__snapshots__/index.test.tsx.snap
@@ -115,13 +115,15 @@ exports[`Model Plan Characteristics matches snapshot 1`] = `
         >
           <p
             class="usa-alert__text"
-          >
+          />
+          <div>
             <span
               class="mandatory-fields-alert__text"
             >
               In order to be considered by the Quality Payment Program (QPP), and to be MIPS or Advanced APM, you will need to collect TINs and NPIs for providers.
             </span>
-          </p>
+          </div>
+          <p />
         </div>
       </div>
       <fieldset

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/TargetsAndOptions/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/TargetsAndOptions/__snapshots__/index.test.tsx.snap
@@ -451,7 +451,8 @@ exports[`Model Plan Characteristics matches snapshot 1`] = `
         >
           <p
             class="usa-alert__text"
-          >
+          />
+          <div>
             Changing your answer to this question may also affect your selections in the IT solutions and implementation status tracker.  
             <button
               class="usa-button usa-button usa-button--unstyled"
@@ -461,7 +462,8 @@ exports[`Model Plan Characteristics matches snapshot 1`] = `
             >
               Go to IT solutions tracker.
             </button>
-          </p>
+          </div>
+          <p />
         </div>
       </div>
       <p

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/CCWAndQuality/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/CCWAndQuality/__snapshots__/index.test.tsx.snap
@@ -369,7 +369,8 @@ exports[`Model Plan Ops Eval and Learning CCW and Qualtiy matches snapshot 1`] =
         >
           <p
             class="usa-alert__text"
-          >
+          />
+          <div>
             Changing your answer to this question may also affect your selections in the IT solutions and implementation status tracker.  
             <button
               class="usa-button usa-button usa-button--unstyled"
@@ -379,7 +380,8 @@ exports[`Model Plan Ops Eval and Learning CCW and Qualtiy matches snapshot 1`] =
             >
               Go to IT solutions tracker.
             </button>
-          </p>
+          </div>
+          <p />
         </div>
       </div>
       <fieldset

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCTesting/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCTesting/__snapshots__/index.test.tsx.snap
@@ -109,13 +109,15 @@ exports[`Model Plan Ops Eval and Learning IDDOC matches snapshot 1`] = `
       >
         <p
           class="usa-alert__text"
-        >
+        />
+        <div>
           <span
             class="mandatory-fields-alert__text"
           >
             SSM request to begin analysis at least 1 year before implementation
           </span>
-        </p>
+        </div>
+        <p />
       </div>
     </div>
     <div

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Learning/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Learning/__snapshots__/index.test.tsx.snap
@@ -115,7 +115,8 @@ exports[`Model Plan Ops Eval and Learning - Learning matches snapshot 1`] = `
         >
           <p
             class="usa-alert__text"
-          >
+          />
+          <div>
             Changing your answer to this question may also affect your selections in the IT solutions and implementation status tracker.  
             <button
               class="usa-button usa-button usa-button--unstyled"
@@ -125,7 +126,8 @@ exports[`Model Plan Ops Eval and Learning - Learning matches snapshot 1`] = `
             >
               Go to IT solutions tracker.
             </button>
-          </p>
+          </div>
+          <p />
         </div>
       </div>
       <div

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Performance/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Performance/__snapshots__/index.test.tsx.snap
@@ -534,9 +534,11 @@ exports[`Model Plan Ops Eval and Learning Performance matches snapshot 1`] = `
         >
           <p
             class="usa-alert__text"
-          >
+          />
+          <div>
             If yes to any of the following, please check with the Legal Vertical on what needs to be in a Participation Agreement and/or regulatory text around your model’s appeal process steps and time frames.
-          </p>
+          </div>
+          <p />
         </div>
       </div>
       <label

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/Coordination/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/Coordination/__snapshots__/index.test.tsx.snap
@@ -284,7 +284,8 @@ exports[`Model Plan Coordination matches snapshot 1`] = `
         >
           <p
             class="usa-alert__text"
-          >
+          />
+          <div>
             Changing your answer to this question may also affect your selections in the IT solutions and implementation status tracker.  
             <button
               class="usa-button usa-button usa-button--unstyled"
@@ -294,7 +295,8 @@ exports[`Model Plan Coordination matches snapshot 1`] = `
             >
               Go to IT solutions tracker.
             </button>
-          </p>
+          </div>
+          <p />
         </div>
       </div>
       <p

--- a/src/views/ModelPlan/TaskList/Payment/AnticipateDependencies/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/Payment/AnticipateDependencies/__snapshots__/index.test.tsx.snap
@@ -358,9 +358,11 @@ exports[`Model Plan -- Anticipate Dependencies matches snapshot 1`] = `
             >
               <p
                 class="usa-alert__text"
-              >
+              />
+              <div>
                 Make sure your contractor is aware of the Electronic File Transfer process if they’re connected to the Baltimore Data Center (BDC).
-              </p>
+              </div>
+              <p />
             </div>
           </div>
           <div

--- a/src/views/NDA/__snapshots__/index.test.tsx.snap
+++ b/src/views/NDA/__snapshots__/index.test.tsx.snap
@@ -37,9 +37,11 @@ exports[`NDA Page matches snapshot 1`] = `
             >
               <p
                 class="usa-alert__text"
-              >
+              />
+              <div>
                 Accepted on 07/30/2022
-              </p>
+              </div>
+              <p />
             </div>
           </div>
           <a


### PR DESCRIPTION
# NOREF

## Changes and Description

- Added text pre-wrap to discussion text for spacing preservation
- Added callback to alert for consecutive rendering of alerts to properly close and reopen (noticeable in the recent discussion readdonly PR)
- Added a div around alert children to properly use flex with multi- line children text and the close button

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
