### PR TITLE
Correct Duplicate Operational Solution

### DIFF
--- a/pkg/storage/SQL/operational_solution/and_possible_get_by_operational_need_id_LOADER.sql
+++ b/pkg/storage/SQL/operational_solution/and_possible_get_by_operational_need_id_LOADER.sql
@@ -26,7 +26,7 @@ possibleSolution AS (
         COALESCE(OpSol.is_other, pOpSol.treat_as_other) AS is_other,
         OpSol.other_header,
         COALESCE(OpSol.status, 'NOT_STARTED') AS status,
-        COALESCE(OpNd.created_by, '00000000-0000-0000-0000-000000000000') AS created_by, -- This is UUID.NIL, the same as the UNKNOWN_USER account in the DB
+        COALESCE(OpSol.created_by, '00000000-0000-0000-0000-000000000000') AS created_by, -- This is UUID.NIL, the same as the UNKNOWN_USER account in the DB
         COALESCE(OpSol.created_dts, CURRENT_TIMESTAMP) AS created_dts,
         OpSol.modified_by,
         OpSol.modified_dts,


### PR DESCRIPTION
# [EASI-2992](https://jiraent.cms.gov/browse/EASI-2992)


## Changes and Description

- Update the operational solutions dataloader to correctly select the created by field from the operational solution table.
  - This fixes a bug where you would see multiple solutions for an operational need under certain conditions.
  - To recreate the bug locally, all you have to do is make a model plan, answer a question to set a need as needed.
  - Log in as a different user, and select a default operational solution as the chosen solution. --> This would give two views of the solution, one with the incorrect created by, and one with the correct


<!-- Put a description here! -->

## How to test this change
1. Make a model Plan
2. Answer a question to set an operational need as needed
3. Log in as a different user
4. Select a default solution for that operational need.
5. Confirm that you don't see a duplicate solution.
6. 
## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [x] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [x] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
