### PR TITLE
[EASI-2968] Group Filter Box/Modal Select

### DIFF
--- a/src/components/Modal/index.scss
+++ b/src/components/Modal/index.scss
@@ -8,7 +8,7 @@
     left: 0;
     right: 0;
     background-color: rgba(0, 0, 0, 0.6);
-    z-index: 400;    
+    z-index: 400;
   }
 
   &__content {
@@ -46,7 +46,7 @@
   }
 
   &__body {
-    padding: 0 2rem 2rem;
+    padding: 0 2rem 1.5rem;
   }
 }
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -12,6 +12,7 @@ type ModalProps = {
   className?: string;
   scroll?: boolean;
   shouldCloseOnOverlayClick?: boolean;
+  modalHeading?: string;
   openModal?: () => void;
   closeModal: () => void;
 };
@@ -22,6 +23,7 @@ const Modal = ({
   className,
   scroll,
   shouldCloseOnOverlayClick = false,
+  modalHeading,
   openModal,
   closeModal
 }: ModalProps) => {
@@ -44,14 +46,24 @@ const Modal = ({
       shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
       appElement={document.getElementById('root')!}
     >
-      <button
-        type="button"
-        className="mint-modal__x-button"
-        aria-label="Close Modal"
-        onClick={closeModal}
+      <div
+        className={`mint-modal__top-section display-flex text-base ${
+          modalHeading ? 'border-bottom-1px border-base-lighter' : ''
+        }`}
       >
-        <IconClose />
-      </button>
+        <h4 className="margin-0 padding-left-4 padding-top-2">
+          {modalHeading}
+        </h4>
+        <button
+          type="button"
+          className="mint-modal__x-button text-base"
+          aria-label="Close Modal"
+          onClick={closeModal}
+        >
+          <IconClose />
+        </button>
+      </div>
+
       <div className="mint-modal__body">{children}</div>
     </ReactModal>
   );

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -15,6 +15,7 @@ import subtasks from './draftModelPlan/subtasks';
 import modelPlanOverview from './helpAndKnowledge/Articles/modelPlanOverview';
 import sampleModelPlan from './helpAndKnowledge/Articles/sampleModelPlan';
 import helpAndKnowledge from './helpAndKnowledge/helpAndKnowledge';
+import filterView from './readOnly/filterView';
 import generalReadOnly from './readOnly/generalReadOnly';
 import modelSummary from './readOnly/modelSummary';
 import readOnlyModelPlan from './readOnly/readOnlyModelPlan';
@@ -45,6 +46,7 @@ const enUS = {
   documents,
   draftModelPlan,
   error,
+  filterView,
   footer,
   general,
   generalCharacteristics,

--- a/src/i18n/en-US/readOnly/filterView.ts
+++ b/src/i18n/en-US/readOnly/filterView.ts
@@ -1,5 +1,13 @@
 const filterView = {
-  group: 'Gruop'
+  group: 'Group',
+  content: 'Filter down to the content your group cares the most about.',
+  alert: {
+    heading: 'Don’t see your group listed?',
+    content:
+      'Contact the MINT Team at <1>MINTTeam@cms.hhs.gov</1>, so we can learn more about your group.'
+  },
+  viewAll: 'View all content',
+  viewFiltered: 'View filtered content'
 };
 
 export default filterView;

--- a/src/i18n/en-US/readOnly/filterView.ts
+++ b/src/i18n/en-US/readOnly/filterView.ts
@@ -1,0 +1,5 @@
+const filterView = {
+  group: 'Gruop'
+};
+
+export default filterView;

--- a/src/i18n/en-US/readOnly/filterView.ts
+++ b/src/i18n/en-US/readOnly/filterView.ts
@@ -1,6 +1,7 @@
 const filterView = {
   group: 'Group',
   content: 'Filter down to the content your group cares the most about.',
+  selectAGroup: 'Select a group',
   alert: {
     heading: 'Don’t see your group listed?',
     content:

--- a/src/i18n/en-US/readOnly/generalReadOnly.ts
+++ b/src/i18n/en-US/readOnly/generalReadOnly.ts
@@ -15,6 +15,10 @@ const generalReadOnly = {
     modelLeads: 'Model lead(s)',
     sendAnEmail: 'Send an email',
     moreTeamMembers: 'More team members'
+  },
+  filterView: {
+    text: 'Are you part of a group that only cares about some of these fields?',
+    button: 'Filter view'
   }
 };
 

--- a/src/i18n/en-US/readOnly/generalReadOnly.ts
+++ b/src/i18n/en-US/readOnly/generalReadOnly.ts
@@ -17,8 +17,9 @@ const generalReadOnly = {
     moreTeamMembers: 'More team members'
   },
   filterView: {
-    text: 'Are you part of a group that only cares about some of these fields?',
-    button: 'Filter view'
+    question:
+      'Are you part of a group that only cares about some of these fields?',
+    text: 'Filter view'
   }
 };
 

--- a/src/types/flags.ts
+++ b/src/types/flags.ts
@@ -1,6 +1,7 @@
 export type Flags = {
   hideITLeadExperience: boolean;
   downgradeAssessmentTeam: boolean;
+  hideGroupView: boolean;
 };
 
 export type FlagsState = {

--- a/src/utils/user.test.ts
+++ b/src/utils/user.test.ts
@@ -40,7 +40,8 @@ describe('user', () => {
         expect(
           isAssessment(groups, {
             downgradeAssessmentTeam: true,
-            hideITLeadExperience: false
+            hideITLeadExperience: false,
+            hideGroupView: true
           })
         ).toBe(false);
       });

--- a/src/views/FlagsWrapper/index.tsx
+++ b/src/views/FlagsWrapper/index.tsx
@@ -34,7 +34,8 @@ const UserTargetingWrapper = ({ children }: WrapperProps) => {
           },
           flags: {
             hideITLeadExperience: true,
-            downgradeAssessmentTeam: false
+            downgradeAssessmentTeam: false,
+            hideGroupView: true
           }
         });
 

--- a/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
@@ -369,6 +369,22 @@ exports[`Read Only Model Plan Summary matches snapshot 1`] = `
               data-testid="read-only-side-nav__wrapper"
               id="read-only-side-nav__wrapper"
             >
+              <div
+                class="bg-base-lightest padding-2 margin-bottom-4"
+              >
+                <p
+                  class="margin-top-0 text-bold line-height-sans-5"
+                >
+                  Are you part of a group that only cares about some of these fields?
+                </p>
+                <button
+                  class="usa-button"
+                  data-testid="button"
+                  type="button"
+                >
+                  Filter view
+                </button>
+              </div>
               <ul
                 class="usa-sidenav"
                 data-testid="sidenav"

--- a/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,340 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Filter View Modal matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="filter-view-modal"
+  >
+    <div
+      class="filter-view__body padding-top-3 padding-bottom-4"
+    >
+      <h3
+        class="margin-y-0"
+      >
+        Group
+      </h3>
+      <p
+        class="margin-top-0 margin-bottom-3 font-body-sm text-base"
+      >
+        Filter down to the content your group cares the most about.
+      </p>
+      <form
+        class="usa-form maxw-none margin-bottom-5"
+        data-testid="form"
+      >
+        <label
+          class="usa-label margin-y-0 text-normal"
+          data-testid="label"
+          for="filter-group"
+        >
+          Select a group
+        </label>
+        <div
+          class="usa-combo-box"
+          data-enhanced="true"
+          data-testid="combo-box"
+        >
+          <select
+            aria-hidden="true"
+            class="usa-select usa-sr-only usa-combo-box__select"
+            data-testid="combo-box-select"
+            name="filter-group"
+            tabindex="-1"
+          >
+            <option
+              value="ccw"
+            >
+              Chronic Conditions Warehouse (CCW)
+            </option>
+            <option
+              value="cmmi"
+            >
+              CMMI Cost Estimate
+            </option>
+            <option
+              value="cbosc"
+            >
+              Consolidated Business Operations Support Center (CBOSC)
+            </option>
+            <option
+              value="dfsdm"
+            >
+              Division of Financial Services and Debt Management (DFSDM)
+            </option>
+            <option
+              value="ipc"
+            >
+              Innovation Payment Contractor (IPC)
+            </option>
+            <option
+              value="iddoc"
+            >
+              Innovative Design, Development, and Operations Contract (IDDOC)
+            </option>
+            <option
+              value="mdm"
+            >
+              Master Data Management (MDM)
+            </option>
+            <option
+              value="oact"
+            >
+              Office of the Actuary (OACT)
+            </option>
+            <option
+              value="pbg"
+            >
+              Provider Billing Group (PBG)
+            </option>
+          </select>
+          <input
+            aria-activedescendant=""
+            aria-autocomplete="list"
+            aria-describedby="filter-group--assistiveHint"
+            aria-expanded="false"
+            aria-owns="filter-group--list"
+            autocapitalize="off"
+            autocomplete="off"
+            class="usa-combo-box__input"
+            data-testid="combo-box-input"
+            id="filter-group"
+            role="combobox"
+            type="text"
+            value=""
+          />
+          <span
+            class="usa-combo-box__clear-input__wrapper"
+            tabindex="-1"
+          >
+            <button
+              aria-label="Clear the select contents"
+              class="usa-combo-box__clear-input"
+              data-testid="combo-box-clear-button"
+              hidden=""
+              type="button"
+            >
+               
+            </button>
+          </span>
+          <span
+            class="usa-combo-box__input-button-separator"
+          >
+             
+          </span>
+          <span
+            class="usa-combo-box__toggle-list__wrapper"
+            tabindex="-1"
+          >
+            <button
+              aria-label="Toggle the dropdown list"
+              class="usa-combo-box__toggle-list"
+              data-testid="combo-box-toggle"
+              tabindex="-1"
+              type="button"
+            >
+               
+            </button>
+          </span>
+          <ul
+            class="usa-combo-box__list"
+            data-testid="combo-box-option-list"
+            hidden=""
+            id="filter-group--list"
+            role="listbox"
+            tabindex="-1"
+          >
+            <li
+              aria-posinset="1"
+              aria-selected="false"
+              aria-setsize="9"
+              class="usa-combo-box__list-option"
+              data-testid="combo-box-option-ccw"
+              data-value="ccw"
+              id="filter-group--list--option-0"
+              role="option"
+              tabindex="-1"
+              value="ccw"
+            >
+              Chronic Conditions Warehouse (CCW)
+            </li>
+            <li
+              aria-posinset="2"
+              aria-selected="false"
+              aria-setsize="9"
+              class="usa-combo-box__list-option"
+              data-testid="combo-box-option-cmmi"
+              data-value="cmmi"
+              id="filter-group--list--option-1"
+              role="option"
+              tabindex="-1"
+              value="cmmi"
+            >
+              CMMI Cost Estimate
+            </li>
+            <li
+              aria-posinset="3"
+              aria-selected="false"
+              aria-setsize="9"
+              class="usa-combo-box__list-option"
+              data-testid="combo-box-option-cbosc"
+              data-value="cbosc"
+              id="filter-group--list--option-2"
+              role="option"
+              tabindex="-1"
+              value="cbosc"
+            >
+              Consolidated Business Operations Support Center (CBOSC)
+            </li>
+            <li
+              aria-posinset="4"
+              aria-selected="false"
+              aria-setsize="9"
+              class="usa-combo-box__list-option"
+              data-testid="combo-box-option-dfsdm"
+              data-value="dfsdm"
+              id="filter-group--list--option-3"
+              role="option"
+              tabindex="-1"
+              value="dfsdm"
+            >
+              Division of Financial Services and Debt Management (DFSDM)
+            </li>
+            <li
+              aria-posinset="5"
+              aria-selected="false"
+              aria-setsize="9"
+              class="usa-combo-box__list-option"
+              data-testid="combo-box-option-ipc"
+              data-value="ipc"
+              id="filter-group--list--option-4"
+              role="option"
+              tabindex="-1"
+              value="ipc"
+            >
+              Innovation Payment Contractor (IPC)
+            </li>
+            <li
+              aria-posinset="6"
+              aria-selected="false"
+              aria-setsize="9"
+              class="usa-combo-box__list-option"
+              data-testid="combo-box-option-iddoc"
+              data-value="iddoc"
+              id="filter-group--list--option-5"
+              role="option"
+              tabindex="-1"
+              value="iddoc"
+            >
+              Innovative Design, Development, and Operations Contract (IDDOC)
+            </li>
+            <li
+              aria-posinset="7"
+              aria-selected="false"
+              aria-setsize="9"
+              class="usa-combo-box__list-option"
+              data-testid="combo-box-option-mdm"
+              data-value="mdm"
+              id="filter-group--list--option-6"
+              role="option"
+              tabindex="-1"
+              value="mdm"
+            >
+              Master Data Management (MDM)
+            </li>
+            <li
+              aria-posinset="8"
+              aria-selected="false"
+              aria-setsize="9"
+              class="usa-combo-box__list-option"
+              data-testid="combo-box-option-oact"
+              data-value="oact"
+              id="filter-group--list--option-7"
+              role="option"
+              tabindex="-1"
+              value="oact"
+            >
+              Office of the Actuary (OACT)
+            </li>
+            <li
+              aria-posinset="9"
+              aria-selected="false"
+              aria-setsize="9"
+              class="usa-combo-box__list-option"
+              data-testid="combo-box-option-pbg"
+              data-value="pbg"
+              id="filter-group--list--option-8"
+              role="option"
+              tabindex="-1"
+              value="pbg"
+            >
+              Provider Billing Group (PBG)
+            </li>
+          </ul>
+          <div
+            class="usa-combo-box__status usa-sr-only"
+            role="status"
+          />
+          <span
+            class="usa-sr-only"
+            data-testid="combo-box-assistive-hint"
+            id="filter-group--assistiveHint"
+          >
+            When autocomplete results are available use up and down arrows to review
+           and enter to select. Touch device users, explore by touch or with swipe
+           gestures.
+          </span>
+        </div>
+      </form>
+      <div
+        class="usa-alert usa-alert--info usa-alert--no-icon"
+        data-testid="alert"
+      >
+        <div
+          class="usa-alert__body"
+        >
+          <p
+            class="usa-alert__text"
+          >
+            <span
+              class="margin-y-0 font-body-sm text-bold display-block"
+            >
+              Don’t see your group listed?
+            </span>
+            Contact the MINT Team at 
+            <a
+              class="usa-link"
+              href="mailto:MINTTeam@cms.hhs.gov"
+            >
+              MINTTeam@cms.hhs.gov
+            </a>
+            , so we can learn more about your group.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="filter-view__footer margin-x-neg-4 border-top-1px border-base-lighter"
+    >
+      <div
+        class="padding-x-4 padding-top-2 display-flex flex-justify"
+      >
+        <button
+          class="usa-button usa-button--unstyled"
+          data-testid="button"
+          type="button"
+        >
+          View all content
+        </button>
+        <button
+          class="usa-button margin-x-0"
+          data-testid="button"
+          disabled=""
+          type="button"
+        >
+          View filtered content
+        </button>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.test.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import FilterViewModal from './index';
+
+describe('Filter View Modal', () => {
+  it('renders without crashing', async () => {
+    const closeModal = jest.fn();
+    render(<FilterViewModal closeModal={closeModal} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-view-modal')).toBeInTheDocument();
+
+      const combobox = screen.getByTestId('combo-box-select');
+      userEvent.selectOptions(combobox, ['cmmi']);
+      expect(combobox).toHaveValue('cmmi');
+    });
+  });
+
+  it('matches snapshot', async () => {
+    const closeModal = jest.fn();
+    const { asFragment } = render(<FilterViewModal closeModal={closeModal} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-view-modal')).toBeInTheDocument();
+
+      const combobox = screen.getByTestId('combo-box-select');
+      userEvent.selectOptions(combobox, ['cmmi']);
+      expect(combobox).toHaveValue('cmmi');
+    });
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
@@ -42,7 +42,11 @@ const FilterViewModal = ({ closeModal }: FilterViewModalProps) => {
   ];
 
   const handleSubmit = (value: string) => {
-    history.push(`${history.location.pathname}?filter-view=${value}`);
+    if (value === 'view-all') {
+      history.push(`${history.location.pathname}`);
+    } else {
+      history.push(`${history.location.pathname}?filter-view=${value}`);
+    }
     closeModal();
   };
 

--- a/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import {
   Alert,
@@ -15,6 +15,8 @@ type FilterViewModalProps = {
 
 const FilterViewModal = ({ closeModal }: FilterViewModalProps) => {
   const { t } = useTranslation('filterView');
+
+  const [filteredGroup, setFilteredGroup] = useState('');
 
   const groupOptions = [
     { value: 'ccw', label: 'Chronic Conditions Warehouse (CCW)' },
@@ -44,17 +46,21 @@ const FilterViewModal = ({ closeModal }: FilterViewModalProps) => {
         <p className="margin-top-0 margin-bottom-3 font-body-sm text-base">
           {t('content')}
         </p>
-        <Form
-          className="maxw-none margin-bottom-5"
-          onSubmit={() => console.log('asdf')}
-        >
+        <Form className="maxw-none margin-bottom-5" onSubmit={() => {}}>
           <Label htmlFor="filter-group" className="margin-y-0 text-normal">
             {t('selectAGroup')}
           </Label>
           <ComboBox
             id="filter-group"
             name="filter-group"
-            onChange={() => console.log('asdf')}
+            onChange={value => {
+              if (value !== '' && value !== undefined) {
+                setFilteredGroup(value);
+              }
+              if (value === undefined) {
+                setFilteredGroup('');
+              }
+            }}
             options={groupOptions}
           />
         </Form>
@@ -77,7 +83,12 @@ const FilterViewModal = ({ closeModal }: FilterViewModalProps) => {
           <Button type="button" unstyled onClick={closeModal}>
             {t('viewAll')}
           </Button>
-          <Button type="button" disabled className="margin-x-0">
+          <Button
+            type="button"
+            disabled={filteredGroup === ''}
+            className="margin-x-0"
+            // onClick={() => console.log(filteredGroup)}
+          >
             {t('viewFiltered')}
           </Button>
         </div>

--- a/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
@@ -1,15 +1,44 @@
 import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { Alert, Button, Link } from '@trussworks/react-uswds';
+import {
+  Alert,
+  Button,
+  ComboBox,
+  Form,
+  Label,
+  Link
+} from '@trussworks/react-uswds';
 
 const FilterViewModal = () => {
   const { t } = useTranslation('filterView');
+
+  const groupOptions = [
+    { value: 'test', label: 'test' },
+    { value: 'Gary', label: 'Gary' }
+  ];
 
   return (
     <>
       <div className="filter-view__body padding-top-3 padding-bottom-4">
         <h3 className="margin-y-0">{t('group')}</h3>
-        <p className="margin-y-0 font-body-sm text-base">{t('content')}</p>
+        <p className="margin-top-0 margin-bottom-3 font-body-sm text-base">
+          {t('content')}
+        </p>
+        <Form
+          className="maxw-none margin-bottom-5"
+          onSubmit={() => console.log('asdf')}
+        >
+          <Label htmlFor="filter-group" className="margin-y-0 text-normal">
+            {t('selectAGroup')}
+          </Label>
+          <ComboBox
+            id="filter-group"
+            name="filter-group"
+            onChange={() => console.log('asdf')}
+            options={groupOptions}
+          />
+        </Form>
+
         <Alert noIcon type="info">
           <p className="margin-y-0 font-body-sm text-bold">
             {t('alert.heading')}

--- a/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
 import {
   Alert,
   Button,
@@ -11,14 +12,11 @@ import {
 
 type FilterViewModalProps = {
   closeModal: () => void;
-  setFilteredView: (value: string) => void;
 };
 
-const FilterViewModal = ({
-  closeModal,
-  setFilteredView
-}: FilterViewModalProps) => {
+const FilterViewModal = ({ closeModal }: FilterViewModalProps) => {
   const { t } = useTranslation('filterView');
+  const history = useHistory();
 
   const [filteredGroup, setFilteredGroup] = useState('');
 
@@ -44,7 +42,7 @@ const FilterViewModal = ({
   ];
 
   const handleSubmit = (value: string) => {
-    setFilteredView(value);
+    history.push(`${history.location.pathname}?filter-view=${value}`);
     closeModal();
   };
 

--- a/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
@@ -11,9 +11,13 @@ import {
 
 type FilterViewModalProps = {
   closeModal: () => void;
+  setFilteredView: (value: string) => void;
 };
 
-const FilterViewModal = ({ closeModal }: FilterViewModalProps) => {
+const FilterViewModal = ({
+  closeModal,
+  setFilteredView
+}: FilterViewModalProps) => {
   const { t } = useTranslation('filterView');
 
   const [filteredGroup, setFilteredGroup] = useState('');
@@ -38,6 +42,11 @@ const FilterViewModal = ({ closeModal }: FilterViewModalProps) => {
     { value: 'oact', label: 'Office of the Actuary (OACT)' },
     { value: 'pbg', label: 'Provider Billing Group (PBG)' }
   ];
+
+  const handleSubmit = (value: string) => {
+    setFilteredView(value);
+    closeModal();
+  };
 
   return (
     <>
@@ -80,14 +89,18 @@ const FilterViewModal = ({ closeModal }: FilterViewModalProps) => {
       </div>
       <div className="filter-view__footer margin-x-neg-4 border-top-1px border-base-lighter">
         <div className="padding-x-4 padding-top-2 display-flex flex-justify">
-          <Button type="button" unstyled onClick={closeModal}>
+          <Button
+            type="button"
+            unstyled
+            onClick={() => handleSubmit('view-all')}
+          >
             {t('viewAll')}
           </Button>
           <Button
             type="button"
             disabled={filteredGroup === ''}
             className="margin-x-0"
-            // onClick={() => console.log(filteredGroup)}
+            onClick={() => handleSubmit(filteredGroup)}
           >
             {t('viewFiltered')}
           </Button>

--- a/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
@@ -9,7 +9,11 @@ import {
   Link
 } from '@trussworks/react-uswds';
 
-const FilterViewModal = () => {
+type FilterViewModalProps = {
+  closeModal: () => void;
+};
+
+const FilterViewModal = ({ closeModal }: FilterViewModalProps) => {
   const { t } = useTranslation('filterView');
 
   const groupOptions = [
@@ -54,7 +58,7 @@ const FilterViewModal = () => {
       </div>
       <div className="filter-view__footer margin-x-neg-4 border-top-1px border-base-lighter">
         <div className="padding-x-4 padding-top-2 display-flex flex-justify">
-          <Button type="button" unstyled>
+          <Button type="button" unstyled onClick={closeModal}>
             {t('viewAll')}
           </Button>
           <Button type="button" disabled className="margin-x-0">

--- a/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
@@ -17,8 +17,24 @@ const FilterViewModal = ({ closeModal }: FilterViewModalProps) => {
   const { t } = useTranslation('filterView');
 
   const groupOptions = [
-    { value: 'test', label: 'test' },
-    { value: 'Gary', label: 'Gary' }
+    { value: 'ccw', label: 'Chronic Conditions Warehouse (CCW)' },
+    { value: 'cmmi', label: 'CMMI Cost Estimate' },
+    {
+      value: 'cbosc',
+      label: 'Consolidated Business Operations Support Center (CBOSC)'
+    },
+    {
+      value: 'dfsdm',
+      label: 'Division of Financial Services and Debt Management (DFSDM)'
+    },
+    { value: 'ipc', label: 'Innovation Payment Contractor (IPC)' },
+    {
+      value: 'iddoc',
+      label: 'Innovative Design, Development, and Operations Contract (IDDOC)'
+    },
+    { value: 'mdm', label: 'Master Data Management (MDM)' },
+    { value: 'oact', label: 'Office of the Actuary (OACT)' },
+    { value: 'pbg', label: 'Provider Billing Group (PBG)' }
   ];
 
   return (

--- a/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const FilterViewModal = () => {
+  return <div>FilterViewModal</div>;
+};
+
+export default FilterViewModal;

--- a/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
@@ -75,16 +75,14 @@ const FilterViewModal = ({
         </Form>
 
         <Alert noIcon type="info">
-          <p className="margin-y-0 font-body-sm text-bold">
+          <span className="margin-y-0 font-body-sm text-bold display-block">
             {t('alert.heading')}
-          </p>
-          <p className="margin-y-0 font-body-sm">
-            <Trans i18nKey="filterView:alert.content">
-              indexOne
-              <Link href="mailto:MINTTeam@cms.hhs.gov">helpTextEmail</Link>
-              indexTwo
-            </Trans>
-          </p>
+          </span>
+          <Trans i18nKey="filterView:alert.content">
+            indexOne
+            <Link href="mailto:MINTTeam@cms.hhs.gov">helpTextEmail</Link>
+            indexTwo
+          </Trans>
         </Alert>
       </div>
       <div className="filter-view__footer margin-x-neg-4 border-top-1px border-base-lighter">

--- a/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
@@ -51,7 +51,7 @@ const FilterViewModal = ({ closeModal }: FilterViewModalProps) => {
   };
 
   return (
-    <>
+    <div data-testid="filter-view-modal">
       <div className="filter-view__body padding-top-3 padding-bottom-4">
         <h3 className="margin-y-0">{t('group')}</h3>
         <p className="margin-top-0 margin-bottom-3 font-body-sm text-base">
@@ -106,7 +106,7 @@ const FilterViewModal = ({ closeModal }: FilterViewModalProps) => {
           </Button>
         </div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterViewModal/index.tsx
@@ -1,7 +1,40 @@
 import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { Alert, Button, Link } from '@trussworks/react-uswds';
 
 const FilterViewModal = () => {
-  return <div>FilterViewModal</div>;
+  const { t } = useTranslation('filterView');
+
+  return (
+    <>
+      <div className="filter-view__body padding-top-3 padding-bottom-4">
+        <h3 className="margin-y-0">{t('group')}</h3>
+        <p className="margin-y-0 font-body-sm text-base">{t('content')}</p>
+        <Alert noIcon type="info">
+          <p className="margin-y-0 font-body-sm text-bold">
+            {t('alert.heading')}
+          </p>
+          <p className="margin-y-0 font-body-sm">
+            <Trans i18nKey="filterView:alert.content">
+              indexOne
+              <Link href="mailto:MINTTeam@cms.hhs.gov">helpTextEmail</Link>
+              indexTwo
+            </Trans>
+          </p>
+        </Alert>
+      </div>
+      <div className="filter-view__footer margin-x-neg-4 border-top-1px border-base-lighter">
+        <div className="padding-x-4 padding-top-2 display-flex flex-justify">
+          <Button type="button" unstyled>
+            {t('viewAll')}
+          </Button>
+          <Button type="button" disabled className="margin-x-0">
+            {t('viewFiltered')}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
 };
 
 export default FilterViewModal;

--- a/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router-dom';
-import { SideNav as TrussSideNav } from '@trussworks/react-uswds';
+import { Button, SideNav as TrussSideNav } from '@trussworks/react-uswds';
 
 import { subComponentsProps } from '../..';
 
@@ -22,6 +22,7 @@ const SideNav = ({
 }: SideNavProps) => {
   const { t } = useTranslation('modelSummary');
   const { t: h } = useTranslation('helpAndKnowledge');
+  const { t: g } = useTranslation('generalReadOnly');
 
   const translationKey = solutionNavigation ? h : t;
 
@@ -55,6 +56,12 @@ const SideNav = ({
       id="read-only-side-nav__wrapper"
       data-testid="read-only-side-nav__wrapper"
     >
+      <div className="bg-base-lightest padding-2 margin-bottom-4">
+        <p className="margin-top-0 text-bold line-height-sans-5">
+          {g('filterView.text')}
+        </p>
+        <Button type="button">{g('filterView.button')}</Button>
+      </div>
       <TrussSideNav items={subNavigationLinks} />
     </div>
   );

--- a/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
@@ -60,10 +60,10 @@ const SideNav = ({
     >
       <div className="bg-base-lightest padding-2 margin-bottom-4">
         <p className="margin-top-0 text-bold line-height-sans-5">
-          {g('filterView.text')}
+          {g('filterView.question')}
         </p>
         <Button type="button" onClick={openFilterModal}>
-          {g('filterView.button')}
+          {g('filterView.text')}
         </Button>
       </div>
       <TrussSideNav items={subNavigationLinks} />

--- a/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router-dom';
 import { Button, SideNav as TrussSideNav } from '@trussworks/react-uswds';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import { subComponentsProps } from '../..';
 
@@ -53,19 +54,23 @@ const SideNav = ({
     )
   );
 
+  const flags = useFlags();
+
   return (
     <div
       id="read-only-side-nav__wrapper"
       data-testid="read-only-side-nav__wrapper"
     >
-      <div className="bg-base-lightest padding-2 margin-bottom-4">
-        <p className="margin-top-0 text-bold line-height-sans-5">
-          {g('filterView.question')}
-        </p>
-        <Button type="button" onClick={openFilterModal}>
-          {g('filterView.text')}
-        </Button>
-      </div>
+      {flags.hideGroupView && (
+        <div className="bg-base-lightest padding-2 margin-bottom-4">
+          <p className="margin-top-0 text-bold line-height-sans-5">
+            {g('filterView.question')}
+          </p>
+          <Button type="button" onClick={openFilterModal}>
+            {g('filterView.text')}
+          </Button>
+        </div>
+      )}
       <TrussSideNav items={subNavigationLinks} />
     </div>
   );

--- a/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
@@ -12,13 +12,15 @@ interface SideNavProps {
   isHelpArticle: boolean | undefined;
   solutionNavigation?: boolean;
   paramActive?: boolean;
+  openFilterModal?: () => void;
 }
 
 const SideNav = ({
   subComponents,
   isHelpArticle,
   solutionNavigation,
-  paramActive
+  paramActive,
+  openFilterModal
 }: SideNavProps) => {
   const { t } = useTranslation('modelSummary');
   const { t: h } = useTranslation('helpAndKnowledge');
@@ -60,7 +62,9 @@ const SideNav = ({
         <p className="margin-top-0 text-bold line-height-sans-5">
           {g('filterView.text')}
         </p>
-        <Button type="button">{g('filterView.button')}</Button>
+        <Button type="button" onClick={openFilterModal}>
+          {g('filterView.button')}
+        </Button>
       </div>
       <TrussSideNav items={subNavigationLinks} />
     </div>

--- a/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
@@ -61,7 +61,7 @@ const SideNav = ({
       id="read-only-side-nav__wrapper"
       data-testid="read-only-side-nav__wrapper"
     >
-      {flags.hideGroupView && (
+      {!flags.hideGroupView && (
         <div className="bg-base-lightest padding-2 margin-bottom-4">
           <p className="margin-top-0 text-bold line-height-sans-5">
             {g('filterView.question')}

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -306,7 +306,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
         shouldCloseOnOverlayClick
         modalHeading={h('filterView.text')}
       >
-        <FilterViewModal />
+        <FilterViewModal closeModal={() => setIsFilterViewModalOpen(false)} />
       </Modal>
       {hasEditAccess && <ModelSubNav modelID={modelID} link="task-list" />}
 

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -17,6 +17,7 @@ import { useFlags } from 'launchdarkly-react-client-sdk';
 import { FavoriteIcon } from 'components/FavoriteCard';
 import UswdsReactLink from 'components/LinkWrapper';
 import MainContent from 'components/MainContent';
+import Modal from 'components/Modal';
 import ModelSubNav from 'components/ModelSubNav';
 import PageHeading from 'components/PageHeading';
 import Alert from 'components/shared/Alert';
@@ -45,6 +46,7 @@ import { UpdateFavoriteProps } from '../ModelPlanOverview';
 import TaskListStatus from '../TaskList/_components/TaskListStatus';
 
 import ContactInfo from './_components/ContactInfo';
+import FilterViewModal from './_components/FilterViewModal';
 import MobileNav from './_components/MobileNav';
 import SideNav from './_components/Sidenav';
 import ReadOnlyGeneralCharacteristics from './GeneralCharacteristics/index';
@@ -298,6 +300,13 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
       className="model-plan-read-only"
       data-testid="model-plan-read-only"
     >
+      <Modal
+        isOpen={isFilterViewModalOpen}
+        closeModal={() => setIsFilterViewModalOpen(false)}
+        shouldCloseOnOverlayClick
+      >
+        <FilterViewModal />
+      </Modal>
       {hasEditAccess && <ModelSubNav modelID={modelID} link="task-list" />}
 
       <SummaryBox
@@ -483,6 +492,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
                 <SideNav
                   subComponents={subComponents}
                   isHelpArticle={isHelpArticle}
+                  openFilterModal={() => setIsFilterViewModalOpen(true)}
                 />
               </Grid>
             )}

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -123,13 +123,9 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   const { groups } = useSelector((state: RootStateOrAny) => state.auth);
 
   const descriptionRef = React.createRef<HTMLElement>();
-  const [
-    isDescriptionExpandable,
-    setIsDescriptionExpandable
-  ] = useState<boolean>(false);
-  const [descriptionExpanded, setDescriptionExpanded] = useState<boolean>(
-    false
-  );
+  const [isDescriptionExpandable, setIsDescriptionExpandable] = useState(false);
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
+  const [isFilterViewModalOpen, setIsFilterViewModalOpen] = useState(false);
 
   // Enable the description toggle if it overflows
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -128,6 +128,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   const [isDescriptionExpandable, setIsDescriptionExpandable] = useState(false);
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   const [isFilterViewModalOpen, setIsFilterViewModalOpen] = useState(false);
+  const [filteredView, setFilteredView] = useState('');
 
   // Enable the description toggle if it overflows
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -300,13 +301,17 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
       className="model-plan-read-only"
       data-testid="model-plan-read-only"
     >
+      <p>{filteredView}</p>
       <Modal
         isOpen={isFilterViewModalOpen}
         closeModal={() => setIsFilterViewModalOpen(false)}
         shouldCloseOnOverlayClick
         modalHeading={h('filterView.text')}
       >
-        <FilterViewModal closeModal={() => setIsFilterViewModalOpen(false)} />
+        <FilterViewModal
+          closeModal={() => setIsFilterViewModalOpen(false)}
+          setFilteredView={setFilteredView}
+        />
       </Modal>
       {hasEditAccess && <ModelSubNav modelID={modelID} link="task-list" />}
 

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -128,6 +128,8 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   const [isDescriptionExpandable, setIsDescriptionExpandable] = useState(false);
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   const [isFilterViewModalOpen, setIsFilterViewModalOpen] = useState(false);
+  // Temporary disable unused variable, since it will be convered in another ticket
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [filteredView, setFilteredView] = useState('');
 
   // Enable the description toggle if it overflows
@@ -301,7 +303,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
       className="model-plan-read-only"
       data-testid="model-plan-read-only"
     >
-      <p>{filteredView}</p>
+      {/* <p>{filteredView}</p> */}
       <Modal
         isOpen={isFilterViewModalOpen}
         closeModal={() => setIsFilterViewModalOpen(false)}

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -129,10 +129,6 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   const [isFilterViewModalOpen, setIsFilterViewModalOpen] = useState(false);
 
-  // Temporary disable unused variable, since it will be convered in another ticket
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [filteredView, setFilteredView] = useState('');
-
   // Enable the description toggle if it overflows
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
@@ -310,10 +306,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
         shouldCloseOnOverlayClick
         modalHeading={h('filterView.text')}
       >
-        <FilterViewModal
-          closeModal={() => setIsFilterViewModalOpen(false)}
-          setFilteredView={setFilteredView}
-        />
+        <FilterViewModal closeModal={() => setIsFilterViewModalOpen(false)} />
       </Modal>
       {hasEditAccess && <ModelSubNav modelID={modelID} link="task-list" />}
 

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -304,6 +304,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
         isOpen={isFilterViewModalOpen}
         closeModal={() => setIsFilterViewModalOpen(false)}
         shouldCloseOnOverlayClick
+        modalHeading={h('filterView.text')}
       >
         <FilterViewModal />
       </Modal>

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -304,7 +304,6 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
       className="model-plan-read-only"
       data-testid="model-plan-read-only"
     >
-      {/* <p>{filteredView}</p> */}
       <Modal
         isOpen={isFilterViewModalOpen}
         closeModal={() => setIsFilterViewModalOpen(false)}

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -128,6 +128,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   const [isDescriptionExpandable, setIsDescriptionExpandable] = useState(false);
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   const [isFilterViewModalOpen, setIsFilterViewModalOpen] = useState(false);
+
   // Temporary disable unused variable, since it will be convered in another ticket
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [filteredView, setFilteredView] = useState('');


### PR DESCRIPTION
# EASI-2968

## Changes and Description

- Add `FilterVIewModal` component
- Add filter "box" to `SideNav` nav and wrapped in a flag
- Add new `hideGroupView` flag
- Add Group View specific copy
- Adjusted `Modal` component to be more flexible




<!-- Put a description here! -->

## How to test this change

### This PR is only to render the filter box in sidenav and modal. Rendering filtered data view is another ticket

1. Navigate to a Read only page for any model plan
2. See sidenav does not have "Filter box" 
3. Go to LaunchDarkly and add yourself to the flag
4. Now, see new filter "box" in the side nav
6. Click button to pop up modal
7. Select a group in the dropdown and hit `View filtered content` button
8. Check to see query parameter has been updated to have the value of the group you've selected
9. Go through the modal again, but this time click `View all content` 
10. check to see query parameter is cleared

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
