### PR TITLE
NOREF add MINT Contractor role in anticipation of job role change

### DIFF
--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -77,7 +77,7 @@ func devUserContext(ctx context.Context, authHeader string, store *storage.Store
 	// Pull job codes from config
 	jcUser := swag.ContainsStrings(config.JobCodes, "MINT_USER_NONPROD")
 	jcAssessment := swag.ContainsStrings(config.JobCodes, "MINT_ASSESSMENT_NONPROD")
-	jcMAC := (swag.ContainsStrings(config.JobCodes, "MINT MAC Users") || swag.ContainsStrings(config.JobCodes, "MINT Medicare Administrative Contractor"))
+	jcMAC := (swag.ContainsStrings(config.JobCodes, "MINT MAC Users") || swag.ContainsStrings(config.JobCodes, "MINT Contractor"))
 
 	// Always set assessment users to have base user permissions
 	if jcAssessment {

--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -77,7 +77,7 @@ func devUserContext(ctx context.Context, authHeader string, store *storage.Store
 	// Pull job codes from config
 	jcUser := swag.ContainsStrings(config.JobCodes, "MINT_USER_NONPROD")
 	jcAssessment := swag.ContainsStrings(config.JobCodes, "MINT_ASSESSMENT_NONPROD")
-	jcMAC := (swag.ContainsStrings(config.JobCodes, "MINT MAC Users") || swag.ContainsStrings(config.JobCodes, "MINT Contractor"))
+	jcMAC := (swag.ContainsStrings(config.JobCodes, "MINT MAC Users") || swag.ContainsStrings(config.JobCodes, "MINT Medicare Administrative Contractor"))
 
 	// Always set assessment users to have base user permissions
 	if jcAssessment {

--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -77,7 +77,7 @@ func devUserContext(ctx context.Context, authHeader string, store *storage.Store
 	// Pull job codes from config
 	jcUser := swag.ContainsStrings(config.JobCodes, "MINT_USER_NONPROD")
 	jcAssessment := swag.ContainsStrings(config.JobCodes, "MINT_ASSESSMENT_NONPROD")
-	jcMAC := swag.ContainsStrings(config.JobCodes, "MINT MAC Users")
+	jcMAC := (swag.ContainsStrings(config.JobCodes, "MINT MAC Users") || swag.ContainsStrings(config.JobCodes, "MINT Contractor"))
 
 	// Always set assessment users to have base user permissions
 	if jcAssessment {

--- a/pkg/okta/authentication_middleware.go
+++ b/pkg/okta/authentication_middleware.go
@@ -32,7 +32,7 @@ const (
 	JobCodeProdMACUser    = "MINT MAC Users"
 
 	// This represents the rename to the MAC user job code. Future work will likely rename the job code config, but for now will allow either
-	JobCodeMINTContractor = "MINT Medicare Administrative Contractor"
+	JobCodeMINTContractor = "MINT Contractor"
 )
 
 // JobCodesConfig contains a set of environment context-sensitive job codes
@@ -93,7 +93,7 @@ func (j *JobCodesConfig) GetMACUserJobCode() string {
 	return j.macUser
 }
 
-// GetMINTContractorJobCode returns this JobCodesConfig's MINT Medicare Administrative Contractor job code
+// GetMINTContractorJobCode returns this JobCodesConfig's MINT Contractor job code
 func (j *JobCodesConfig) GetMINTContractorJobCode() string {
 	return j.mintContractor
 }

--- a/pkg/okta/authentication_middleware.go
+++ b/pkg/okta/authentication_middleware.go
@@ -30,13 +30,17 @@ const (
 	JobCodeProdUser       = "MINT_USER"
 	JobCodeProdAssessment = "MINT_ASSESSMENT"
 	JobCodeProdMACUser    = "MINT MAC Users"
+
+	// This represents the rename to the MAC user job code. Future work will likely rename the job code config, but for now will allow either
+	JobCodeMINTContractor = "MINT Contractor"
 )
 
 // JobCodesConfig contains a set of environment context-sensitive job codes
 type JobCodesConfig struct {
-	user       string
-	assessment string
-	macUser    string
+	user           string
+	assessment     string
+	macUser        string
+	mintContractor string
 }
 
 // NewJobCodesConfig is a constructor to generate a JobCodesConfig
@@ -44,11 +48,13 @@ func NewJobCodesConfig(
 	user string,
 	assessment string,
 	macUser string,
+	mintContractor string,
 ) *JobCodesConfig {
 	return &JobCodesConfig{
-		user:       user,
-		assessment: assessment,
-		macUser:    macUser,
+		user:           user,
+		assessment:     assessment,
+		macUser:        macUser,
+		mintContractor: mintContractor,
 	}
 }
 
@@ -58,6 +64,7 @@ func NewProductionJobCodesConfig() *JobCodesConfig {
 		JobCodeProdUser,
 		JobCodeProdAssessment,
 		JobCodeProdMACUser,
+		JobCodeMINTContractor,
 	)
 }
 
@@ -67,6 +74,7 @@ func NewTestJobCodesConfig() *JobCodesConfig {
 		JobCodeTestUser,
 		JobCodeTestAssessment,
 		JobCodeTestMACUser,
+		JobCodeMINTContractor,
 	)
 }
 
@@ -83,6 +91,11 @@ func (j *JobCodesConfig) GetAssessmentJobCode() string {
 // GetMACUserJobCode returns this JobCodesConfig's MAC user job code
 func (j *JobCodesConfig) GetMACUserJobCode() string {
 	return j.macUser
+}
+
+// GetMINTContractorJobCode returns this JobCodesConfig's MINT Contractor job code
+func (j *JobCodesConfig) GetMINTContractorJobCode() string {
+	return j.mintContractor
 }
 
 func (f MiddlewareFactory) jwt(logger *zap.Logger, authHeader string) (*authentication.EnhancedJwt, error) {
@@ -141,7 +154,9 @@ func (f MiddlewareFactory) newPrincipal(ctx context.Context) (*authentication.Ap
 	} else {
 		jcUser = jwtGroupsContainsJobCode(enhanced.JWT, f.jobCodes.GetUserJobCode())
 	}
-	jcMAC := jwtGroupsContainsJobCode(enhanced.JWT, f.jobCodes.GetMACUserJobCode())
+
+	//TODO: this should be updated once job codes are updated to only check for the MINTContractor job code.
+	jcMAC := (jwtGroupsContainsJobCode(enhanced.JWT, f.jobCodes.GetMACUserJobCode()) || jwtGroupsContainsJobCode(enhanced.JWT, f.jobCodes.GetMINTContractorJobCode()))
 
 	// Create a LaunchDarkly user
 	// NOTE: This is copied pkg flags.Principal(). That function couldn't be used here because it

--- a/pkg/okta/authentication_middleware.go
+++ b/pkg/okta/authentication_middleware.go
@@ -32,7 +32,7 @@ const (
 	JobCodeProdMACUser    = "MINT MAC Users"
 
 	// This represents the rename to the MAC user job code. Future work will likely rename the job code config, but for now will allow either
-	JobCodeMINTContractor = "MINT Contractor"
+	JobCodeMINTContractor = "MINT Medicare Administrative Contractor"
 )
 
 // JobCodesConfig contains a set of environment context-sensitive job codes
@@ -93,7 +93,7 @@ func (j *JobCodesConfig) GetMACUserJobCode() string {
 	return j.macUser
 }
 
-// GetMINTContractorJobCode returns this JobCodesConfig's MINT Contractor job code
+// GetMINTContractorJobCode returns this JobCodesConfig's MINT Medicare Administrative Contractor job code
 func (j *JobCodesConfig) GetMINTContractorJobCode() string {
 	return j.mintContractor
 }

--- a/src/constants/jobCodes.ts
+++ b/src/constants/jobCodes.ts
@@ -3,7 +3,7 @@ export const BASIC = 'MINT_USER';
 export const ASSESSMENT_NONPROD = 'MINT_ASSESSMENT_NONPROD';
 export const ASSESSMENT = 'MINT_ASSESSMENT';
 export const MAC = 'MINT MAC Users';
-export const MINT_CONTRACTOR = 'MINT Medicare Administrative Contractor';
+export const MINT_CONTRACTOR = 'MINT Contractor';
 
 export const NONPROD_JOB_CODES = [
   BASIC_NONPROD,

--- a/src/constants/jobCodes.ts
+++ b/src/constants/jobCodes.ts
@@ -3,7 +3,7 @@ export const BASIC = 'MINT_USER';
 export const ASSESSMENT_NONPROD = 'MINT_ASSESSMENT_NONPROD';
 export const ASSESSMENT = 'MINT_ASSESSMENT';
 export const MAC = 'MINT MAC Users';
-export const MINT_CONTRACTOR = 'MINT Contractor';
+export const MINT_CONTRACTOR = 'MINT Medicare Administrative Contractor';
 
 export const NONPROD_JOB_CODES = [
   BASIC_NONPROD,

--- a/src/constants/jobCodes.ts
+++ b/src/constants/jobCodes.ts
@@ -3,15 +3,22 @@ export const BASIC = 'MINT_USER';
 export const ASSESSMENT_NONPROD = 'MINT_ASSESSMENT_NONPROD';
 export const ASSESSMENT = 'MINT_ASSESSMENT';
 export const MAC = 'MINT MAC Users';
+export const MINT_CONTRACTOR = 'MINT Contractor';
 
-export const NONPROD_JOB_CODES = [BASIC_NONPROD, ASSESSMENT_NONPROD, MAC];
+export const NONPROD_JOB_CODES = [
+  BASIC_NONPROD,
+  ASSESSMENT_NONPROD,
+  MAC,
+  MINT_CONTRACTOR
+];
 
 export const JOB_CODES = [
   BASIC,
   ASSESSMENT,
   BASIC_NONPROD,
   ASSESSMENT_NONPROD,
-  MAC
+  MAC,
+  MINT_CONTRACTOR
 ];
 
 export default JOB_CODES;

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -3,7 +3,8 @@ import {
   ASSESSMENT_NONPROD,
   BASIC,
   BASIC_NONPROD,
-  MAC
+  MAC,
+  MINT_CONTRACTOR
 } from 'constants/jobCodes';
 import { Flags } from 'types/flags';
 
@@ -27,7 +28,7 @@ export const isBasicUser = (groups: Array<String> = []) => {
 };
 
 export const isMAC = (groups: Array<String> = []) => {
-  if (groups.includes(MAC)) {
+  if (groups.includes(MAC) || groups.includes(MINT_CONTRACTOR)) {
     return true;
   }
 


### PR DESCRIPTION
## Context

It was determined that the job code `MINT MAC Users` should be a broader named job code `MINT Contractor`. To avoid any service interruption, the code is updated to allow all job code checking logic by using either the legacy job code, or the new job code. When the new job code is released, we will remove the references to the legacy job code.
## Changes and Description

- Introduce MINT Contractor job codes

   - Update JobCodeMAC on the backend to return true for either `MINT Contractor` or for `MINT MAC users`
   - Update isMac user on frontend to return true for either `MINT Contractor` or for `MINT MAC users`

<!-- Put a description here! -->

## How to test this change
1. Log in with the new job code. Confirm you can accept the NDA (which requires at least a MAC user job code)
2. Repeat the above with the legacy job code, and ensure that you can still accept the NDA.

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
