### PR TITLE
[EASI-3022] Allow MAC users to favorite plans

### DIFF
--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -8175,7 +8175,7 @@ agreeToNDA(agree: Boolean! = true): NDAInfo!
 @hasAnyRole(roles: [MINT_USER, MINT_MAC])
 
 addPlanFavorite(modelPlanID: UUID!): PlanFavorite!
-@hasRole(role: MINT_USER)
+@hasAnyRole(roles: [MINT_USER, MINT_MAC])
 
 deletePlanFavorite(modelPlanID: UUID!): PlanFavorite!
 @hasRole(role: MINT_USER)
@@ -19113,14 +19113,14 @@ func (ec *executionContext) _Mutation_addPlanFavorite(ctx context.Context, field
 			return ec.resolvers.Mutation().AddPlanFavorite(rctx, fc.Args["modelPlanID"].(uuid.UUID))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
-			role, err := ec.unmarshalNRole2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRole(ctx, "MINT_USER")
+			roles, err := ec.unmarshalNRole2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐRoleᚄ(ctx, []interface{}{"MINT_USER", "MINT_MAC"})
 			if err != nil {
 				return nil, err
 			}
-			if ec.directives.HasRole == nil {
-				return nil, errors.New("directive hasRole is not implemented")
+			if ec.directives.HasAnyRole == nil {
+				return nil, errors.New("directive hasAnyRole is not implemented")
 			}
-			return ec.directives.HasRole(ctx, nil, directive0, role)
+			return ec.directives.HasAnyRole(ctx, nil, directive0, roles)
 		}
 
 		tmp, err := directive1(rctx)

--- a/pkg/graph/schema.graphql
+++ b/pkg/graph/schema.graphql
@@ -1581,7 +1581,7 @@ agreeToNDA(agree: Boolean! = true): NDAInfo!
 @hasAnyRole(roles: [MINT_USER, MINT_MAC])
 
 addPlanFavorite(modelPlanID: UUID!): PlanFavorite!
-@hasRole(role: MINT_USER)
+@hasAnyRole(roles: [MINT_USER, MINT_MAC])
 
 deletePlanFavorite(modelPlanID: UUID!): PlanFavorite!
 @hasRole(role: MINT_USER)

--- a/src/views/ModelPlan/ModelPlanOverview/index.tsx
+++ b/src/views/ModelPlan/ModelPlanOverview/index.tsx
@@ -109,7 +109,7 @@ const ModelPlan = () => {
           >
             {t('allModelsLink')}
           </Button>
-          {!isMAC && (
+          {!macUser && (
             <SummaryBox
               heading=""
               className="bg-base-lightest border-0 radius-0 padding-2 padding-bottom-3 margin-top-3 "
@@ -128,20 +128,18 @@ const ModelPlan = () => {
           )}
         </Grid>
 
-        {!macUser && (
-          <Grid
-            desktop={{ col: 12 }}
-            className="padding-bottom-2 margin-bottom-4 border-bottom border-base-light"
-          >
-            <div className="margin-bottom-1 font-heading-xl text-bold">
-              {t('following.heading')}
-            </div>
-            <p className="line-height-body-5 text-light margin-bottom-05 margin-top-0 margin-bottom-3">
-              {t('following.subheading')}
-            </p>
-            {loading ? <PageLoading /> : Favorites}
-          </Grid>
-        )}
+        <Grid
+          desktop={{ col: 12 }}
+          className="padding-bottom-2 margin-bottom-4 border-bottom border-base-light"
+        >
+          <div className="margin-bottom-1 font-heading-xl text-bold">
+            {t('following.heading')}
+          </div>
+          <p className="line-height-body-5 text-light margin-bottom-05 margin-top-0 margin-bottom-3">
+            {t('following.subheading')}
+          </p>
+          {loading ? <PageLoading /> : Favorites}
+        </Grid>
 
         <Grid>
           <div
@@ -156,11 +154,7 @@ const ModelPlan = () => {
           {loading && <PageLoading />}
           {error && <Alert type="error">{h('fetchError')}</Alert>}
           {!loading && !error && (
-            <Table
-              data={modelPlans}
-              updateFavorite={handleUpdateFavorite}
-              hiddenColumns={macUser ? [0] : []}
-            />
+            <Table data={modelPlans} updateFavorite={handleUpdateFavorite} />
           )}
         </Grid>
       </GridContainer>

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -351,13 +351,11 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
                 {h('back')}
               </UswdsReactLink>
 
-              {!isMAC(groups) && (
-                <FavoriteIcon
-                  isFavorite={isFavorite}
-                  modelPlanID={id}
-                  updateFavorite={handleUpdateFavorite}
-                />
-              )}
+              <FavoriteIcon
+                isFavorite={isFavorite}
+                modelPlanID={id}
+                updateFavorite={handleUpdateFavorite}
+              />
             </div>
           )}
 


### PR DESCRIPTION
# EASI-3022

## Changes and Description

- Modify BE to allow plan favoriting by all users
- Modify FE to show hidden fields for MAC users

![image](https://github.com/CMSgov/mint-app/assets/15203744/61f65f16-6ae9-425c-8cc5-289f39109566)

## How to test this change

- Start app
- Seed DB
- Login as a MAC user (from 1Password)
- Ensure plan favoriting works

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
