### PR TITLE
[EASI-3044] Increase activity timeout to 90 minutes

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Run buildx bake
-        uses: docker/bake-action@v3.1.0
+        uses: docker/bake-action@v3.0.1
         with:
           files: "docker-compose.yml,docker-compose.override.yml"
           targets: "${{ matrix.service_name }}"
@@ -195,7 +195,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Run buildx bake
-        uses: docker/bake-action@v3.1.0
+        uses: docker/bake-action@v3.0.1
         with:
           files: "docker-compose.yml,docker-compose.override.yml"
           load: true

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -43,6 +43,8 @@ jobs:
           password: ${{ secrets.CONTRIBSYS_REPO_PASSWORD }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.10.4
       - name: Run buildx bake
         uses: docker/bake-action@v3.0.1
         with:
@@ -194,6 +196,8 @@ jobs:
         run: sudo echo "127.0.0.1 minio" | sudo tee -a /etc/hosts
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.10.4
       - name: Run buildx bake
         uses: docker/bake-action@v3.0.1
         with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           version: v0.10.4
       - name: Run buildx bake
-        uses: docker/bake-action@v3.0.1
+        uses: docker/bake-action@v3.1.0
         with:
           files: "docker-compose.yml,docker-compose.override.yml"
           targets: "${{ matrix.service_name }}"
@@ -199,7 +199,7 @@ jobs:
         with:
           version: v0.10.4
       - name: Run buildx bake
-        uses: docker/bake-action@v3.0.1
+        uses: docker/bake-action@v3.1.0
         with:
           files: "docker-compose.yml,docker-compose.override.yml"
           load: true

--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -28,15 +28,28 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
 
   const [timeRemainingArr, setTimeRemainingArr] = useState([0, 'second']);
 
+  // Give the user 85 minutes of inactivity time before prompting the modal
   const activeDuration = Duration.fromObject({ minutes: 85 }).as(
     'milliseconds'
   );
+  // Give the user 5 minutes to respond to the modal before logging them out
   const modalDuration = Duration.fromObject({ minutes: 5 }).as('milliseconds');
 
-  // Since 5 minutes is used for the `promptTimeout` AND the `timeout`, you effectively have 10 minutes before you're logged out due to inactivity.
-  // 5 of those minutes will be uninterrupted, the other 5 will be when the prompt is up.
   const idleTimer = useIdleTimer({
-    events: ['mousedown', 'keydown'],
+    // Only events NOT included here are 'mousemove' and 'MSPointerMove', as simply moving the cursor across the screen isn't really "activity"
+    // compared to scrolling, switching tabs, typing, or clicking.
+    events: [
+      'keydown',
+      'wheel',
+      'DOMMouseScroll',
+      'mousewheel',
+      'mousedown',
+      'touchstart',
+      'touchmove',
+      'MSPointerDown',
+      'visibilitychange',
+      'focus'
+    ],
     onIdle: () => {
       if (!isLocalAuth && authState?.isAuthenticated) {
         oktaAuth.signOut();

--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -28,7 +28,10 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
 
   const [timeRemainingArr, setTimeRemainingArr] = useState([0, 'second']);
 
-  const fiveMinutes = Duration.fromObject({ minutes: 5 }).as('milliseconds');
+  const activeDuration = Duration.fromObject({ minutes: 85 }).as(
+    'milliseconds'
+  );
+  const modalDuration = Duration.fromObject({ minutes: 5 }).as('milliseconds');
 
   // Since 5 minutes is used for the `promptTimeout` AND the `timeout`, you effectively have 10 minutes before you're logged out due to inactivity.
   // 5 of those minutes will be uninterrupted, the other 5 will be when the prompt is up.
@@ -41,14 +44,14 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
     },
     onPrompt: () => {
       if (!isLocalAuth && authState?.isAuthenticated) {
-        setTimeRemainingArr(formatSessionTimeRemaining(fiveMinutes));
+        setTimeRemainingArr(formatSessionTimeRemaining(modalDuration));
       }
     },
-    promptTimeout: fiveMinutes,
+    promptTimeout: modalDuration,
     crossTab: true,
     syncTimers: 1000,
     debounce: 500,
-    timeout: fiveMinutes
+    timeout: activeDuration
   });
 
   const forceRenew = async () => {

--- a/src/views/TimeOutWrapper/index.tsx
+++ b/src/views/TimeOutWrapper/index.tsx
@@ -38,6 +38,7 @@ const TimeOutWrapper = ({ children }: TimeOutWrapperProps) => {
   const idleTimer = useIdleTimer({
     // Only events NOT included here are 'mousemove' and 'MSPointerMove', as simply moving the cursor across the screen isn't really "activity"
     // compared to scrolling, switching tabs, typing, or clicking.
+    // Events sourced from https://idletimer.dev/docs/api/use-idle-timer
     events: [
       'keydown',
       'wheel',


### PR DESCRIPTION
# EASI-3044

## Changes and Description

- Increase activity timeout to 90 minutes

## How to test this change

The best way to test this change locally is to modify the timeout variables in `TimeOutWrapper` to something more manageable, like

```typescript
  const activeDuration = Duration.fromObject({ minutes: 1 }).as('milliseconds');
  const modalDuration = Duration.fromObject({ minutes: 12 }).as('milliseconds');
```

then, **_log in with your EUA rather than local auth_**, as local auth negates the timeout modal, and ensure that aftert 1 minute of inactivity you get a modal that warns you that you have 12 minutes remaining.


Additionally, if you want to see the events that trigger activity, add the following property to `useIdleTimer`

```typescript
    onAction(event) {
      console.log('user triggered', event?.type);
    },
```
![image](https://github.com/CMSgov/mint-app/assets/15203744/0e180d77-b52b-4bc9-b4a1-743ec52387bc)


## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
