### PR TITLE
[NOREF] - Fixed conditional when updating custom solution

### DIFF
--- a/src/i18n/en-US/draftModelPlan/itSolutions.ts
+++ b/src/i18n/en-US/draftModelPlan/itSolutions.ts
@@ -236,6 +236,7 @@ const itSolutions = {
     existingCmsDataAndProcess: 'Existing CMS data and process',
     interalStaff: 'Internal staff',
     otherNewProcess: 'Other'
-  }
+  },
+  otherNewProcess: 'Other new process'
 };
 export default itSolutions;

--- a/src/views/ModelPlan/TaskList/ITSolutions/AddCustomSolution/index.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/AddCustomSolution/index.tsx
@@ -158,7 +158,10 @@ const AddCustomSolution = () => {
             id: operationalSolutionID,
             changes: {
               needed: customOperationalSolution.needed,
-              nameOther: !selectedSolution ? nameOther : null,
+              nameOther:
+                selectedSolution === OperationalSolutionKey.OTHER_NEW_PROCESS
+                  ? nameOther
+                  : null,
               otherHeader: selectedSolution ? otherHeader : null,
               pocEmail,
               pocName

--- a/src/views/ModelPlan/TaskList/ITSolutions/AddCustomSolution/index.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/AddCustomSolution/index.tsx
@@ -137,14 +137,11 @@ const AddCustomSolution = () => {
         updateMutation = await createSolution({
           variables: {
             operationalNeedID,
-            solutionType:
-              selectedSolution !== OperationalSolutionKey.OTHER_NEW_PROCESS
-                ? selectedSolution
-                : null,
+            solutionType: selectedSolution || null,
             changes: {
               needed: true,
-              nameOther: nameOther ?? null,
-              otherHeader: otherHeader ?? null,
+              nameOther: !selectedSolution ? nameOther : null,
+              otherHeader: selectedSolution ? otherHeader : null,
               status: OpSolutionStatus.NOT_STARTED,
               pocEmail,
               pocName
@@ -158,10 +155,7 @@ const AddCustomSolution = () => {
             id: operationalSolutionID,
             changes: {
               needed: customOperationalSolution.needed,
-              nameOther:
-                selectedSolution === OperationalSolutionKey.OTHER_NEW_PROCESS
-                  ? nameOther
-                  : null,
+              nameOther: !selectedSolution ? nameOther : null,
               otherHeader: selectedSolution ? otherHeader : null,
               pocEmail,
               pocName
@@ -298,9 +292,7 @@ const AddCustomSolution = () => {
                             </h3>
                           )}
                           <Fieldset disabled={loading}>
-                            {selectedSolution ===
-                              OperationalSolutionKey.OTHER_NEW_PROCESS ||
-                            selectedSolution === null ? (
+                            {selectedSolution === null ? (
                               <FieldGroup
                                 scrollElement="nameOther"
                                 error={!!flatErrors.nameOther}
@@ -414,8 +406,6 @@ const AddCustomSolution = () => {
                                 className="margin-bottom-1"
                                 id="submit-custom-solution"
                                 disabled={
-                                  selectedSolution ===
-                                    OperationalSolutionKey.OTHER_NEW_PROCESS ||
                                   selectedSolution === null
                                     ? !values.nameOther
                                     : !values.otherHeader

--- a/src/views/ModelPlan/TaskList/ITSolutions/AddSolution/index.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/AddSolution/index.tsx
@@ -143,7 +143,6 @@ const AddSolution = () => {
     formikValues: OperationalSolutionFormType
   ) => {
     const { key } = formikValues;
-    console.log(formikValues);
 
     let updateMutation;
     try {

--- a/src/views/ModelPlan/TaskList/ITSolutions/AddSolution/index.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/AddSolution/index.tsx
@@ -143,6 +143,7 @@ const AddSolution = () => {
     formikValues: OperationalSolutionFormType
   ) => {
     const { key } = formikValues;
+    console.log(formikValues);
 
     let updateMutation;
     try {
@@ -360,9 +361,18 @@ const AddSolution = () => {
                                   id="add-custom-solution-button"
                                   className="usa-button usa-button--outline margin-top-3"
                                   onClick={() => {
-                                    history.push(
-                                      `/models/${modelID}/task-list/it-solutions/${operationalNeedID}/add-custom-solution?selectedSolution=${values.key}`
-                                    );
+                                    if (
+                                      values.key ===
+                                      OperationalSolutionKey.OTHER_NEW_PROCESS
+                                    ) {
+                                      history.push(
+                                        `/models/${modelID}/task-list/it-solutions/${operationalNeedID}/add-custom-solution`
+                                      );
+                                    } else {
+                                      history.push(
+                                        `/models/${modelID}/task-list/it-solutions/${operationalNeedID}/add-custom-solution?selectedSolution=${values.key}`
+                                      );
+                                    }
                                   }}
                                 >
                                   {t('addSolutionDetails')}

--- a/src/views/ModelPlan/TaskList/ITSolutions/_components/CheckboxCard/index.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/_components/CheckboxCard/index.tsx
@@ -79,11 +79,15 @@ const CheckboxCard = ({
     OperationalSolutionKey.CONTRACTOR,
     OperationalSolutionKey.CROSS_MODEL_CONTRACT,
     OperationalSolutionKey.EXISTING_CMS_DATA_AND_PROCESS,
-    OperationalSolutionKey.INTERNAL_STAFF
+    OperationalSolutionKey.INTERNAL_STAFF,
+    OperationalSolutionKey.OTHER_NEW_PROCESS
   ];
 
   const isDefaultSolutionOptions =
-    solution.name !== null && solution.pocEmail === null;
+    (solution.name !== null && solution.pocEmail === null) ||
+    (solution.name !== null && solution.isOther);
+
+  const solutionParam = solution.key ? `?selectedSolution=${solution.key}` : '';
 
   const renderCTALink = () => {
     if (isDefaultSolutionOptions && solution.isOther) {
@@ -97,13 +101,16 @@ const CheckboxCard = ({
                 solution.id !== '00000000-0000-0000-0000-000000000000'
                   ? solution.id
                   : ''
-              }?selectedSolution=${
-                solution.key || OperationalSolutionKey.OTHER_NEW_PROCESS
-              }`
+              }${solutionParam}`
             )
           }
         >
-          {solution.otherHeader ? t('updateTheseDetails') : t('addDetails')}
+          {!solution.pocName &&
+          !solution.pocEmail &&
+          !solution.otherHeader &&
+          solution.isOther
+            ? t('addDetails')
+            : t('updateTheseDetails')}
           <IconArrowForward className="margin-left-1" />
         </Button>
       );
@@ -116,11 +123,7 @@ const CheckboxCard = ({
           className="display-flex flex-align-center usa-button usa-button--unstyled margin-top-2 margin-bottom-0"
           onClick={() =>
             history.push(
-              `/models/${modelID}/task-list/it-solutions/${operationalNeedID}/add-custom-solution/${
-                solution.id
-              }?selectedSolution=${
-                solution.key || OperationalSolutionKey.OTHER_NEW_PROCESS
-              }`
+              `/models/${modelID}/task-list/it-solutions/${operationalNeedID}/add-custom-solution/${solution.id}${solutionParam}`
             )
           }
         >
@@ -181,7 +184,9 @@ const CheckboxCard = ({
                       {solution.otherHeader}
                     </h3>
                     <h5 className="text-normal margin-top-0 margin-bottom-2">
-                      {translateOperationalSolutionKey(solution.key)}
+                      {solution.key === OperationalSolutionKey.OTHER_NEW_PROCESS
+                        ? t('otherNewProcess')
+                        : translateOperationalSolutionKey(solution.key)}
                     </h5>
                   </>
                 ) : (


### PR DESCRIPTION
# NOREF

## Changes and Description

`UpdateOperationalSolution` payload had an incorrect conditional for passing `nameOther` .  It was expecting `selectedSolution` to be falsy, when that isn't the case here

- Fixed the conditonal to explicity check for `OTHER_NEW_PROCESS` to pass `nameOther` to the mutation payload

Had to fix areas where we were treating custom solutions with a key.  We now pass null keys when creating a brand new custom solution.  For the case where we have the `OTHER_NEW_PROCESS` solution as a default, we pass that key and it behaves like `treatAsOther`

Also added a translation key for render `OTHER_NEW_PROCESS` as 'Other new process' on the card once created.

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
