### PR TITLE
[EASI-3091] Bug fix -- Question should only show up if "Reductions to beneficiary cost-sharing" is selected

### DIFF
--- a/src/views/ModelPlan/ReadOnly/Payments/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/Payments/__snapshots__/index.test.tsx.snap
@@ -343,27 +343,7 @@ exports[`Read Only Model Plan Summary -- Payment matches snapshot 1`] = `
     </div>
     <div
       class=""
-    >
-      <div
-        class="desktop:grid-col-12"
-        data-testid="grid"
-      >
-        <div
-          class="read-only-section read-only-section--would-the-waiver-only-apply-for-part-of-the-payment margin-bottom-3"
-        >
-          <p
-            class="text-bold margin-y-0 font-body-sm line-height-sans-4 text-pre-line"
-          >
-            Would the waiver only apply for part of the payment?
-          </p>
-          <p
-            class="margin-y-0 font-body-md line-height-sans-4 text-pre-line"
-          >
-            Yes
-          </p>
-        </div>
-      </div>
-    </div>
+    />
     <div
       class=""
     />

--- a/src/views/ModelPlan/ReadOnly/Payments/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/Payments/index.tsx
@@ -429,7 +429,7 @@ const ReadOnlyPayments = ({
               }
             />
           )}
-        {(isCostSharing && waiveBeneficiaryCostSharingForAnyServices) ||
+        {isCostSharing &&
           checkGroupMap(
             isViewingFilteredView,
             filteredQuestions,


### PR DESCRIPTION
# EASI-3091

## Changes and Description

- Address rogue question popping up (https://oddball.slack.com/archives/C059QQA3HK5/p1689018937456579?thread_ts=1688750264.802819&cid=C059QQA3HK5)
- Change 2

<!-- Put a description here! -->

## How to test this change
1. This should only show if "Reductions to beneficiary cost-sharing" is selected under claims-based payment types (first question on page 2). 


<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
