### PR TITLE
[NOREF] Remove branch naming check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
-      - id: no-commit-to-branch
-        args: [
-          '--pattern', '^(?!((main)|(feature\/EASI-\d{1,5})|((EASI-\d{1,5}|NOREF|dependabot)\/[a-zA-Z0-9\-\._/]+))$).*',
-          '--branch', '' # Adding this to remove the default protection on `main` so that CI checks can pass
-        ]
-        name: Enforce branch naming patterns
-        description: Enforces branch naming policy. Allowed branch patterns are 'EASI-#', 'EASI-#/*', 'feature/EASI-#', 'NOREF/*', and 'dependabot/*'. A feature branch like feature/EASI-2020 would have branches like EASI-2020/frontend and EASI-2020/backend merge into it.
       - id: check-yaml
         name: Check YAML formatting
       - id: detect-private-key


### PR DESCRIPTION
# NOREF

## Changes and Description

- Remove branch naming check in favor of using GitHub rules

![image](https://github.com/CMSgov/mint-app/assets/15203744/405ad963-e0b5-4236-9a7d-4f4dc2a2dba4)


## How to test this change

- Try to create a branch in GitHub that doesn't match our expected naming patterns!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
