### PR TITLE
[NOREF] - Filter view view route restructure

### DIFF
--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -104,14 +104,8 @@ const AppRoutes = () => {
       {/* Model Routes */}
       <SecureRoute path="/models" exact component={ModelPlan} />
 
-      <Redirect
-        exact
-        from="/models/:modelID/read-only"
-        to="/models/:modelID/read-only/model-basics"
-      />
-
       <SecureRoute
-        path="/models/:modelID/read-only/:subinfo"
+        path="/models/:modelID/read-only/:subinfo?"
         exact
         component={ReadOnly}
       />

--- a/src/views/ModelPlan/ReadOnly/_components/FilterView/Banner/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterView/Banner/index.tsx
@@ -25,8 +25,6 @@ const FilterViewBanner = ({
 
   const history = useHistory();
 
-  const { pathname } = history.location;
-
   return (
     <div
       className="position-sticky z-100 top-0 bg-primary-darker text-white padding-105"
@@ -58,11 +56,7 @@ const FilterViewBanner = ({
                 type="button"
                 unstyled
                 className="text-white text-no-wrap"
-                onClick={() =>
-                  history.push(
-                    `${pathname}${pathname.length === 4 ? '/model-basics' : ''}`
-                  )
-                }
+                onClick={() => history.push(history.location.pathname)}
               >
                 {t('clearFilter')}
               </Button>

--- a/src/views/ModelPlan/ReadOnly/_components/FilterView/Banner/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterView/Banner/index.tsx
@@ -22,7 +22,11 @@ const FilterViewBanner = ({
   openFilterModal
 }: FilterViewBannerProps) => {
   const { t } = useTranslation('filterView');
+
   const history = useHistory();
+
+  const { pathname } = history.location;
+
   return (
     <div
       className="position-sticky z-100 top-0 bg-primary-darker text-white padding-105"
@@ -54,7 +58,11 @@ const FilterViewBanner = ({
                 type="button"
                 unstyled
                 className="text-white text-no-wrap"
-                onClick={() => history.push(`${history.location.pathname}`)}
+                onClick={() =>
+                  history.push(
+                    `${pathname}${pathname.length === 4 ? '/model-basics' : ''}`
+                  )
+                }
               >
                 {t('clearFilter')}
               </Button>

--- a/src/views/ModelPlan/ReadOnly/_components/FilterView/Modal/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterView/Modal/index.tsx
@@ -35,9 +35,7 @@ const FilterViewModal = ({
     const { pathname } = history.location;
 
     if (value === 'view-all') {
-      history.push(
-        `${pathname}${pathname.length === 4 ? '/model-basics' : ''}`
-      );
+      history.push(pathname);
     } else {
       history.push(`${pathname}?filter-view=${value}`);
     }

--- a/src/views/ModelPlan/ReadOnly/_components/FilterView/Modal/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterView/Modal/index.tsx
@@ -32,10 +32,14 @@ const FilterViewModal = ({
       window.scrollTo(0, 0);
     }, 0);
 
+    const { pathname } = history.location;
+
     if (value === 'view-all') {
-      history.push(`${history.location.pathname}`);
+      history.push(
+        `${pathname}${pathname.length === 4 ? '/model-basics' : ''}`
+      );
     } else {
-      history.push(`${history.location.pathname}?filter-view=${value}`);
+      history.push(`${pathname}?filter-view=${value}`);
     }
 
     closeModal();

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -128,6 +128,9 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   const [isDescriptionExpandable, setIsDescriptionExpandable] = useState(false);
   const [isFilterViewModalOpen, setIsFilterViewModalOpen] = useState(false);
 
+  // If no subinfo param exists, default to first subpage key
+  const defaultSection: typeof listOfSubpageKey[number] = listOfSubpageKey[0];
+
   // Enable the description toggle if it overflows
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
@@ -271,7 +274,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   }
 
   if (!subinfo && !isViewingFilteredGroup) {
-    history.replace(`${location.pathname}/model-basics`);
+    history.replace(`${location.pathname}/${defaultSection}`);
   }
 
   if (!isSubpage(subinfo, flags, isHelpArticle) && !isViewingFilteredGroup) {

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RootStateOrAny, useSelector } from 'react-redux';
-import { useLocation, useParams } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import {
   Alert,
@@ -29,7 +29,7 @@ import {
 } from 'queries/ReadOnly/types/GetModelSummary';
 import { ModelStatus, TeamRole } from 'types/graphql-global-types';
 import { isAssessment, isMAC } from 'utils/user';
-import NotFound, { NotFoundPartial } from 'views/NotFound';
+import NotFound from 'views/NotFound';
 
 import { UpdateFavoriteProps } from '../ModelPlanOverview';
 import TaskListStatus from '../TaskList/_components/TaskListStatus';
@@ -37,6 +37,7 @@ import TaskListStatus from '../TaskList/_components/TaskListStatus';
 import ContactInfo from './_components/ContactInfo';
 import FilterViewBanner from './_components/FilterView/Banner';
 import BodyContent from './_components/FilterView/BodyContent';
+import FilterGroupMap from './_components/FilterView/BodyContent/_filterGroupMapping';
 import FilterViewModal from './_components/FilterView/Modal';
 import { groupOptions } from './_components/FilterView/util';
 import MobileNav from './_components/MobileNav';
@@ -102,6 +103,8 @@ const isSubpage = (
 const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   const { t: h } = useTranslation('generalReadOnly');
   const isMobile = useCheckResponsiveScreen('tablet', 'smaller');
+
+  const history = useHistory();
 
   const flags = useFlags();
 
@@ -171,6 +174,10 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
     isCollaborator,
     crTdls
   } = data?.modelPlan || ({} as GetModelSummaryTypes);
+
+  if (filteredView && !Object.keys(FilterGroupMap).includes(filteredView)) {
+    return <NotFound />;
+  }
 
   const hasEditAccess: boolean =
     !isHelpArticle &&
@@ -260,10 +267,14 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   const subComponent = subComponents[subinfo];
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {
-    return <NotFoundPartial />;
+    return <NotFound />;
   }
 
-  if (!isSubpage(subinfo, flags, isHelpArticle)) {
+  if (!subinfo && !isViewingFilteredGroup) {
+    history.push(`${location.pathname}/model-basics`);
+  }
+
+  if (!isSubpage(subinfo, flags, isHelpArticle) && !isViewingFilteredGroup) {
     return <NotFound />;
   }
 

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -271,7 +271,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   }
 
   if (!subinfo && !isViewingFilteredGroup) {
-    history.push(`${location.pathname}/model-basics`);
+    history.replace(`${location.pathname}/model-basics`);
   }
 
   if (!isSubpage(subinfo, flags, isHelpArticle) && !isViewingFilteredGroup) {


### PR DESCRIPTION
# NOREF

## Changes and Description

- Fixed app crash when passing an unmapped filter query param
- Reworked readonly routing to all for filter views to be passed without a page subkey

This is in preparation for the BE to begin supplying filter view links to readonly without needing to specify a subpage

Ex: `${host}/models/${modelID}/read-only`
Ex: `${host}/models/${modelID}/read-only?filter-view=ccw`

Previous the routing didn't allow for filter views without a specified subpage (`model-basics`, etc)

<!-- Put a description here! -->

## How to test this change

Test out navigation to `${host}/models/${modelID}/read-only` without a subpage , should redirect to `model-basics`
Append a filter-view query param to `${host}/models/${modelID}/read-only` and verify it renders - `${host}/models/${modelID}/read-only?filter-view=ccw`
Try to type in an incorrect filter-view param - should reroute back to model basics

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
