### PR TITLE
[NOREF] - Fixed readonly header padding responsiveness

### DIFF
--- a/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Read Only Model Plan Summary matches snapshot 1`] = `
         className="usa-summary-box__text"
       >
         <div
-          className="grid-container padding-x-0"
+          className="grid-container"
           data-testid="gridContainer"
         >
           <div

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -103,6 +103,7 @@ const isSubpage = (
 const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   const { t: h } = useTranslation('generalReadOnly');
   const isMobile = useCheckResponsiveScreen('tablet', 'smaller');
+  const isTablet = useCheckResponsiveScreen('desktop', 'smaller');
 
   const history = useHistory();
 
@@ -303,7 +304,12 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
         className="padding-y-6 padding-x-2 border-0 bg-primary-lighter margin-top-0"
         data-testid="read-only-model-summary"
       >
-        <GridContainer className="padding-x-0">
+        <GridContainer
+          className={classnames({
+            'padding-x-0': isMobile,
+            'padding-x-2': isTablet
+          })}
+        >
           {!isHelpArticle && (
             <div className="display-flex flex-justify">
               <UswdsReactLink


### PR DESCRIPTION
# EASI-NOREF

## Changes and Description

- Fixed readonly header padding responsiveness

Padding was off/not aligned with body content on all screen sizes
![Screenshot 2023-07-14 at 10 26 45 AM](https://github.com/CMSgov/mint-app/assets/95709965/9a31db57-e563-4211-b823-00387bed09a7)

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
