### PR TITLE
[NOREF] - Restricted edit button to users who have access

### DIFF
--- a/src/components/ShareExport/__snapshots__/index.test.tsx.snap
+++ b/src/components/ShareExport/__snapshots__/index.test.tsx.snap
@@ -81,40 +81,7 @@ exports[`ShareExportModal matches the snapshot 1`] = `
                     </div>
                     <div
                       class="mint-no-print"
-                    >
-                      <div
-                        class="display-flex flex-align-center"
-                      >
-                        <div
-                          class="height-2 border-left-2px border-base-light margin-right-2 "
-                        />
-                        <div>
-                          <a
-                            class="usa-link display-flex flex-align-center"
-                            href="/models/f11eb129-2c80-4080-9440-439cbe1a286f/task-list"
-                          >
-                            <svg
-                              class="usa-icon margin-right-1"
-                              focusable="false"
-                              height="1em"
-                              role="img"
-                              viewBox="0 0 24 24"
-                              width="1em"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M0 0h24v24H0z"
-                                fill="none"
-                              />
-                              <path
-                                d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a.996.996 0 0 0 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
-                              />
-                            </svg>
-                            Edit Model Plan
-                          </a>
-                        </div>
-                      </div>
-                    </div>
+                    />
                   </div>
                 </div>
               </div>

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -346,6 +346,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
           statusLabel
           modifiedOrCreateLabel={!!modifiedDts}
           modifiedDts={modifiedDts ?? createdDts}
+          hasEditAccess={hasEditAccess}
         />
 
         {!isViewingFilteredGroup && (

--- a/src/views/ModelPlan/TaskList/_components/TaskListStatus/index.tsx
+++ b/src/views/ModelPlan/TaskList/_components/TaskListStatus/index.tsx
@@ -12,6 +12,7 @@ type TaskListStatusProps = {
   icon?: boolean;
   modelID: string;
   status: ModelStatus;
+  hasEditAccess?: boolean;
   statusLabel?: boolean;
   updateLabel?: boolean;
   modifiedDts?: string;
@@ -23,6 +24,7 @@ const TaskListStatus = ({
   icon,
   modelID,
   status,
+  hasEditAccess = false,
   statusLabel = false,
   updateLabel = false,
   modifiedDts,
@@ -66,18 +68,21 @@ const TaskListStatus = ({
         </Grid>
         {readOnly && (
           <div className="mint-no-print">
-            <div className="display-flex flex-align-center">
-              <div className="height-2 border-left-2px border-base-light margin-right-2 " />
-              <div>
-                <UswdsReactLink
-                  to={`/models/${modelID}/task-list`}
-                  className="display-flex flex-align-center"
-                >
-                  <IconEdit className="margin-right-1" />
-                  {t('edit')}
-                </UswdsReactLink>
+            {hasEditAccess && (
+              <div className="display-flex flex-align-center">
+                <div className="height-2 border-left-2px border-base-light margin-right-2 " />
+
+                <div>
+                  <UswdsReactLink
+                    to={`/models/${modelID}/task-list`}
+                    className="display-flex flex-align-center"
+                  >
+                    <IconEdit className="margin-right-1" />
+                    {t('edit')}
+                  </UswdsReactLink>
+                </div>
               </div>
-            </div>
+            )}
           </div>
         )}
       </Grid>


### PR DESCRIPTION
# NOREF

## Changes and Description

'Edit Model Plan' button was not hidden for users without access
 The button doesn't work due to security constraints, but the button should and is now hidden

<img width="491" alt="Screenshot 2023-07-26 at 3 45 55 PM" src="https://github.com/CMSgov/mint-app/assets/95709965/5c7f7b32-2cfe-4757-8814-0b3993f8fdbd">


## How to test this change

Login with Mac user or user who isnt a collaborator on a model plan
Navigate to readonly
Verify the 'Edit Model Plan' is hidden

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
