### PR TITLE
[NOREF] - Removed styling from pdf link

### DIFF
--- a/src/components/ShareExport/__snapshots__/index.test.tsx.snap
+++ b/src/components/ShareExport/__snapshots__/index.test.tsx.snap
@@ -239,15 +239,24 @@ exports[`ShareExportModal matches the snapshot 1`] = `
                 class="line-height-mono-4"
               >
                 These are created in 
-                <a
-                  aria-label="Open AMS in a new tab"
-                  class="usa-link usa-link--external"
-                  href="https://ams.cmmi.cms.gov"
-                  rel="noopener noreferrer"
-                  target="_blank"
+                <span
+                  class="mint-no-print"
+                >
+                  <a
+                    aria-label="Open AMS in a new tab"
+                    class="usa-link usa-link--external"
+                    href="https://ams.cmmi.cms.gov"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    CMMI Analysis & Management System (AMS).
+                  </a>
+                </span>
+                <span
+                  class="mint-only-print-inline"
                 >
                   CMMI Analysis & Management System (AMS).
-                </a>
+                </span>
                  Skip these fields until your model has been added to AMS. Not all models will have demo codes.
               </p>
               <div

--- a/src/stylesheets/print.scss
+++ b/src/stylesheets/print.scss
@@ -2,10 +2,15 @@
   .page-break {
     display: none;
   }
+
 }
 
 @media screen {
   .mint-only-print {
+    display: none;
+  }
+
+  .mint-only-print-inline {
     display: none;
   }
 }
@@ -17,6 +22,10 @@
 
   .mint-only-print {
     display: block !important;
+  }
+
+  .mint-only-print-inline {
+    display: inline-block !important;
   }
 
   .page-break {

--- a/src/views/ModelPlan/ReadOnly/ModelBasics/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/ModelBasics/__snapshots__/index.test.tsx.snap
@@ -65,15 +65,24 @@ exports[`Read Only Model Plan Summary -- Model Basics matches snapshot 1`] = `
         class="line-height-mono-4"
       >
         These are created in 
-        <a
-          aria-label="Open AMS in a new tab"
-          class="usa-link usa-link--external"
-          href="https://ams.cmmi.cms.gov"
-          rel="noopener noreferrer"
-          target="_blank"
+        <span
+          class="mint-no-print"
+        >
+          <a
+            aria-label="Open AMS in a new tab"
+            class="usa-link usa-link--external"
+            href="https://ams.cmmi.cms.gov"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            CMMI Analysis & Management System (AMS).
+          </a>
+        </span>
+        <span
+          class="mint-only-print-inline"
         >
           CMMI Analysis & Management System (AMS).
-        </a>
+        </span>
          Skip these fields until your model has been added to AMS. Not all models will have demo codes.
       </p>
       <div

--- a/src/views/ModelPlan/ReadOnly/ModelBasics/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/ModelBasics/index.tsx
@@ -152,15 +152,22 @@ const ReadOnlyModelBasics = ({
 
           <p className="line-height-mono-4">
             {planBasicsMiscT('otherIdentifiersInfo1')}
-            <TrussLink
-              aria-label="Open AMS in a new tab"
-              href="https://ams.cmmi.cms.gov"
-              target="_blank"
-              rel="noopener noreferrer"
-              variant="external"
-            >
+
+            <span className="mint-no-print">
+              <TrussLink
+                aria-label="Open AMS in a new tab"
+                href="https://ams.cmmi.cms.gov"
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="external"
+              >
+                {planBasicsMiscT('otherIdentifiersInfo2')}
+              </TrussLink>
+            </span>
+
+            <span className="mint-only-print-inline">
               {planBasicsMiscT('otherIdentifiersInfo2')}
-            </TrussLink>
+            </span>
 
             {planBasicsMiscT('otherIdentifiersInfo3')}
           </p>

--- a/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
@@ -636,15 +636,24 @@ exports[`Read Only Model Plan Summary matches snapshot 1`] = `
                         className="line-height-mono-4"
                       >
                         These are created in 
-                        <a
-                          aria-label="Open AMS in a new tab"
-                          className="usa-link usa-link--external"
-                          href="https://ams.cmmi.cms.gov"
-                          rel="noopener noreferrer"
-                          target="_blank"
+                        <span
+                          className="mint-no-print"
+                        >
+                          <a
+                            aria-label="Open AMS in a new tab"
+                            className="usa-link usa-link--external"
+                            href="https://ams.cmmi.cms.gov"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                          >
+                            CMMI Analysis & Management System (AMS).
+                          </a>
+                        </span>
+                        <span
+                          className="mint-only-print-inline"
                         >
                           CMMI Analysis & Management System (AMS).
-                        </a>
+                        </span>
                          Skip these fields until your model has been added to AMS. Not all models will have demo codes.
                       </p>
                       <div


### PR DESCRIPTION
# NOREF

## Changes and Description

- Removed styling from pdf link in readonly basics

![Screenshot 2023-07-27 at 3 09 39 PM](https://github.com/CMSgov/mint-app/assets/95709965/001b265a-336f-45a0-9660-b9146d9fb281)

## How to test this change

Download a readonly pdf and verify blue link styling is gone

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
