### PR TITLE
[NOREF] - Changed post login redirect from react-router to native browser redirect

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -88,9 +88,10 @@ const wsProtocol = protocol === 'https' ? 'wss' : 'ws'; // Use WSS when connecti
 const wsLink = new WebSocketLink(
   new SubscriptionClient(`${wsProtocol}://${gqlAddressWithoutProtocol}`, {
     reconnect: true,
-    connectionParams: {
+    lazy: true,
+    connectionParams: () => ({
       authToken: getAuthHeader(process.env.REACT_APP_GRAPHQL_ADDRESS as string)
-    }
+    })
   })
 );
 

--- a/src/views/AuthenticationWrapper/index.tsx
+++ b/src/views/AuthenticationWrapper/index.tsx
@@ -32,7 +32,9 @@ const AuthenticationWrapper = ({ children }: ParentComponentProps) => {
     _oktaAuth: OktaAuth,
     originalUri: string
   ) => {
-    history.replace(toRelativeUrl(originalUri || '/', window.location.origin));
+    window.location.replace(
+      toRelativeUrl(originalUri || '/', window.location.origin)
+    );
   };
 
   return isLocalAuthEnabled() &&

--- a/src/views/AuthenticationWrapper/index.tsx
+++ b/src/views/AuthenticationWrapper/index.tsx
@@ -32,9 +32,7 @@ const AuthenticationWrapper = ({ children }: ParentComponentProps) => {
     _oktaAuth: OktaAuth,
     originalUri: string
   ) => {
-    window.location.replace(
-      toRelativeUrl(originalUri || '/', window.location.origin)
-    );
+    history.replace(toRelativeUrl(originalUri || '/', window.location.origin));
   };
 
   return isLocalAuthEnabled() &&


### PR DESCRIPTION
# NOREF

## Changes and Description

MINT deployed and local env were experiencing issues with gql subscription authentication due to a missing okta storage token post login.  The app was using `react-router-dom` for post redirect, not allowing the app to ingest the auth token into its ws connections

This was carried over from EASI, so the same issue may exist there as well.

This resolves the issue, but we may want to dig further to see if it's possible to still use `react-router-dom` for a cleaner user experience

- Changed the `AuthenticationWrapper` redirect to use native browser redirect/hard refresh - post login

# UPDATE

- Reverted the  native browser redirect/hard refresh - post login
- Added a lazy config to ws connection to only attempt to init on first subscription
- Wrapped `authToken` in `connectionParams` function

This re-inits successfully the okta token in the ws connection without the need for a browser refresh

Reviewers may want to test both methods (via commit history).  I still see the initial ws connection fail with #2 but it successfully retries and connects on second attempt

<!-- Put a description here! -->

## How to test this change

- Log in with okta
- Navigate to a task list section form
- Copy url to clipboard
- Log out
- Paste url
- Sign in again
- Verify ws connection that auth token was passed

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
