### PR TITLE
[NOREF] - Job code contractor fix

### DIFF
--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -79,7 +79,7 @@ func devUserContext(ctx context.Context, authHeader string, store *storage.Store
 	// NOTE: We only allow nonprod job codes here. This is reflected in src/views/AuthenticationWrapper/DevLogin.tsx only pulling nonprod job codes
 	jcUser := swag.ContainsStrings(config.JobCodes, "MINT_USER_NONPROD")
 	jcAssessment := swag.ContainsStrings(config.JobCodes, "MINT_ASSESSMENT_NONPROD")
-	jcMAC := (swag.ContainsStrings(config.JobCodes, "MINT MAC Users") || swag.ContainsStrings(config.JobCodes, "MINT_CTR_FFS_NONPROD"))
+	jcMAC := (swag.ContainsStrings(config.JobCodes, "MINT MAC Users") || swag.ContainsStrings(config.JobCodes, "MINT_CTR_FFS_NONPROD") || swag.ContainsStrings(config.JobCodes, "MINT_CONTRACTOR_FFS"))
 
 	// Always set assessment users to have base user permissions
 	if jcAssessment {

--- a/pkg/local/authentication_middleware.go
+++ b/pkg/local/authentication_middleware.go
@@ -79,7 +79,7 @@ func devUserContext(ctx context.Context, authHeader string, store *storage.Store
 	// NOTE: We only allow nonprod job codes here. This is reflected in src/views/AuthenticationWrapper/DevLogin.tsx only pulling nonprod job codes
 	jcUser := swag.ContainsStrings(config.JobCodes, "MINT_USER_NONPROD")
 	jcAssessment := swag.ContainsStrings(config.JobCodes, "MINT_ASSESSMENT_NONPROD")
-	jcMAC := (swag.ContainsStrings(config.JobCodes, "MINT MAC Users") || swag.ContainsStrings(config.JobCodes, "MINT_CTR_FFS_NONPROD") || swag.ContainsStrings(config.JobCodes, "MINT_CONTRACTOR_FFS"))
+	jcMAC := (swag.ContainsStrings(config.JobCodes, "MINT MAC Users") || swag.ContainsStrings(config.JobCodes, "MINT_CONTRACTOR_FFS"))
 
 	// Always set assessment users to have base user permissions
 	if jcAssessment {


### PR DESCRIPTION
# NOREF

## Changes and Description

- The auth middleware was using the tester contractor code (`MINT_CTR_FFS_NONPROD`) for prod instead of `MINT_CONTRACTOR_FFS`

<!-- Put a description here! -->

## How to test this change
 
Not sure how to test this other than auth not breaking or having a user with only this role in Okta

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
