### PR TITLE
[EASI-3098] Use default sender when sharing model plans

### DIFF
--- a/pkg/graph/resolvers/model_plan.go
+++ b/pkg/graph/resolvers/model_plan.go
@@ -289,6 +289,7 @@ func ModelPlanShare(
 	principal authentication.Principal,
 	emailService oddmail.EmailService,
 	emailTemplateService email.TemplateService,
+	addressBook email.AddressBook,
 	modelPlanID uuid.UUID,
 	viewFilter *models.ModelViewFilter,
 	receiverEmails []string,
@@ -306,9 +307,6 @@ func ModelPlanShare(
 
 	// Get client address
 	clientAddress := emailService.GetConfig().GetClientAddress()
-
-	// Get sender
-	sender := principal.Account().Email
 
 	// Get email template
 	emailTemplate, err := emailTemplateService.GetEmailTemplate(email.ModelPlanShareTemplateName)
@@ -380,7 +378,7 @@ func ModelPlanShare(
 	}
 
 	// Send email
-	err = emailService.Send(sender, receiverEmails, nil, emailSubject, "text/html", emailBody)
+	err = emailService.Send(addressBook.DefaultSender, receiverEmails, nil, emailSubject, "text/html", emailBody)
 	if err != nil {
 		return false, fmt.Errorf("failed to send email: %w", err)
 	}

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -475,6 +475,7 @@ func (r *mutationResolver) ShareModelPlan(ctx context.Context, modelPlanID uuid.
 		principal,
 		r.emailService,
 		r.emailTemplateService,
+		r.addressBook,
 		modelPlanID,
 		viewFilter,
 		receiverEmails,


### PR DESCRIPTION
# EASI-3098

## Changes and Description

- Use default sender (configured per-env through env vars) instead of trying to send emails from the user who made the GQL call.

## How to test this change

- `scripts/dev up`
- `scripts/dev db:seed`
- Share a model plan through the UI
- Ensure that mailcatcher shows it's coming from `no-reply-mint-localhost@cms.hhs.gov`

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
