### PR TITLE
[EASI-3098] Use Model Status in Share Email

### DIFF
--- a/pkg/email/model_plan_share.go
+++ b/pkg/email/model_plan_share.go
@@ -2,8 +2,6 @@ package email
 
 import (
 	"time"
-
-	"github.com/cmsgov/mint-app/pkg/models"
 )
 
 // ModelPlanShareSubjectContent defines the parameters necessary for the corresponding email subject
@@ -17,7 +15,7 @@ type ModelPlanShareBodyContent struct {
 	OptionalMessage          *string
 	ModelName                string
 	ModelShortName           *string
-	ModelCategories          []models.ModelCategory
+	ModelCategories          []string
 	ModelStatus              string
 	ModelLastUpdated         time.Time
 	ModelLeads               []string

--- a/pkg/email/model_plan_share.go
+++ b/pkg/email/model_plan_share.go
@@ -18,7 +18,7 @@ type ModelPlanShareBodyContent struct {
 	ModelName                string
 	ModelShortName           *string
 	ModelCategories          []models.ModelCategory
-	ModelStatus              models.TaskStatus
+	ModelStatus              string
 	ModelLastUpdated         time.Time
 	ModelLeads               []string
 	ModelViewFilter          *string

--- a/pkg/email/templates/model_plan_share_body.html
+++ b/pkg/email/templates/model_plan_share_body.html
@@ -105,7 +105,7 @@
       <p>
           {{if .ModelCategories}}
               {{- range $index, $element := .ModelCategories -}}
-                  {{- if $index -}}, {{- end -}}
+                  {{ if $index }}, {{ end }}
                   {{$element}}
               {{- end -}}
           {{else}}

--- a/pkg/graph/resolvers/model_plan.go
+++ b/pkg/graph/resolvers/model_plan.go
@@ -348,6 +348,8 @@ func ModelPlanShare(
 		}
 	}
 
+	humanizedModelStatus := models.ModelStatusHumanized[modelPlan.Status]
+
 	var humanizedViewFilter *string
 	var lowercasedViewFilter *string
 	if viewFilter != nil {
@@ -363,9 +365,9 @@ func ModelPlanShare(
 		UserName:                 principal.Account().CommonName,
 		OptionalMessage:          optionalMessage,
 		ModelName:                modelPlan.ModelName,
-		ModelShortName:           modelPlan.Abbreviation, // TODO: Is this correct for the shortName?
+		ModelShortName:           modelPlan.Abbreviation,
 		ModelCategories:          modelPlanCategories,
-		ModelStatus:              planBasics.Status,
+		ModelStatus:              humanizedModelStatus,
 		ModelLastUpdated:         lastModified,
 		ModelLeads:               modelLeads,
 		ModelViewFilter:          lowercasedViewFilter,

--- a/pkg/graph/resolvers/model_plan.go
+++ b/pkg/graph/resolvers/model_plan.go
@@ -322,13 +322,14 @@ func ModelPlanShare(
 		return false, fmt.Errorf("failed to execute email subject: %w", err)
 	}
 
-	var modelPlanCategories []models.ModelCategory
+	var modelPlanCategoriesHumainzed []string
 	if planBasics.ModelCategory != nil {
-		modelPlanCategories = append(modelPlanCategories, *planBasics.ModelCategory)
+		modelPlanCategoriesHumainzed = append(modelPlanCategoriesHumainzed, models.ModelCategoryHumanized[*planBasics.ModelCategory])
 	}
 
 	for _, category := range planBasics.AdditionalModelCategories {
-		modelPlanCategories = append(modelPlanCategories, models.ModelCategory(category))
+		// Have to cast the additional category as a models.ModelCategory so we can fetch it from the models.ModelCategoryHumanized map
+		modelPlanCategoriesHumainzed = append(modelPlanCategoriesHumainzed, models.ModelCategoryHumanized[models.ModelCategory(category)])
 	}
 
 	lastModified := modelPlan.CreatedDts
@@ -366,7 +367,7 @@ func ModelPlanShare(
 		OptionalMessage:          optionalMessage,
 		ModelName:                modelPlan.ModelName,
 		ModelShortName:           modelPlan.Abbreviation,
-		ModelCategories:          modelPlanCategories,
+		ModelCategories:          modelPlanCategoriesHumainzed,
 		ModelStatus:              humanizedModelStatus,
 		ModelLastUpdated:         lastModified,
 		ModelLeads:               modelLeads,

--- a/pkg/models/model_plan.go
+++ b/pkg/models/model_plan.go
@@ -41,6 +41,17 @@ const (
 	MCToBeDetermined             ModelCategory = "TO_BE_DETERMINED"
 )
 
+// ModelCategoryHumanized maps ModelCategory to a human-readable string
+var ModelCategoryHumanized = map[ModelCategory]string{
+	MCAccountableCare:            "Accountable Care",
+	MCDiseaseSpecificAndEpisodic: "Disease-Specific & Episodic",
+	MCHealthPlan:                 "Health Plan",
+	MCPrescriptionDrug:           "Prescription Drug",
+	MCStateBased:                 "State-Based",
+	MCStatutory:                  "Statutory",
+	MCToBeDetermined:             "To be determined",
+}
+
 // ModelStatus represents the possible statuses of a Model Plan
 type ModelStatus string
 

--- a/pkg/models/model_plan.go
+++ b/pkg/models/model_plan.go
@@ -57,7 +57,26 @@ const (
 	ModelStatusAnnounced             ModelStatus = "ANNOUNCED"
 	ModelStatusActive                ModelStatus = "ACTIVE"
 	ModelStatusEnded                 ModelStatus = "ENDED"
+	ModelStatusPaused                ModelStatus = "PAUSED"
+	ModelStatusCanceled              ModelStatus = "CANCELED"
 )
+
+// ModelStatusHumanized maps ModelStatus to a human-readable string
+var ModelStatusHumanized = map[ModelStatus]string{
+	ModelStatusPlanDraft:             "Draft model plan",
+	ModelStatusPlanComplete:          "Model plan complete",
+	ModelStatusIcipComplete:          "ICIP complete",
+	ModelStatusInternalCmmiClearance: "Internal (CMMI) clearance",
+	ModelStatusCmsClearance:          "CMS clearance",
+	ModelStatusHhsClearance:          "HHS clearance",
+	ModelStatusOmbAsrfClearance:      "OMB/ASRF clearance",
+	ModelStatusCleared:               "Cleared",
+	ModelStatusAnnounced:             "Announced",
+	ModelStatusActive:                "Active",
+	ModelStatusEnded:                 "Ended",
+	ModelStatusPaused:                "Paused",
+	ModelStatusCanceled:              "Canceled",
+}
 
 // ModelViewFilter represents the possible filters for a model plan view
 type ModelViewFilter string


### PR DESCRIPTION
# EASI-3098

## Changes and Description

- Use `modelPlan.Status` instead of `planBasics.Status` when sending out email for sharing a model plan
- added humanized strings for model plan statuses

## How to test this change

- `scripts/dev db:seed`
- Modify some plans statuses
- Share those model plans in the UI
- View the emails in mailcatcher to ensure they appear as expected.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
