### PR TITLE
[EASI-3008] - Added usernames to discussions,replies and model plan CSV

### DIFF
--- a/src/components/ShareExport/__snapshots__/index.test.tsx.snap
+++ b/src/components/ShareExport/__snapshots__/index.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`ShareExportModal matches the snapshot 1`] = `
                       <p
                         class="margin-y-0 text-normal"
                       >
-                        Last updated on 08/27/2022
+                        Last updated on 08/26/2022
                       </p>
                     </div>
                     <div
@@ -6286,7 +6286,7 @@ exports[`ShareExportModal matches the snapshot 2`] = `
                       <p
                         class="margin-y-0 text-normal"
                       >
-                        Last updated on 08/27/2022
+                        Last updated on 08/26/2022
                       </p>
                     </div>
                     <div

--- a/src/data/mock/readonly.ts
+++ b/src/data/mock/readonly.ts
@@ -572,7 +572,7 @@ const summaryData: GetModelSummaryTypes = {
   modelName: 'Testing Model Summary',
   abbreviation: 'TMS',
   createdDts: '2022-08-23T04:00:00Z',
-  modifiedDts: '2022-08-27T04:00:00Z',
+  modifiedDts: '2022-08-26T012:00:00Z',
   status: ModelStatus.PLAN_DRAFT,
   basics: {
     __typename: 'PlanBasics',

--- a/src/data/mock/readonly.ts
+++ b/src/data/mock/readonly.ts
@@ -571,13 +571,13 @@ const summaryData: GetModelSummaryTypes = {
   isFavorite: false,
   modelName: 'Testing Model Summary',
   abbreviation: 'TMS',
-  createdDts: '2022-08-23T04:12:00Z',
-  modifiedDts: '2022-08-27T04:12:00Z',
+  createdDts: '2022-08-23T04:00:00Z',
+  modifiedDts: '2022-08-27T04:00:00Z',
   status: ModelStatus.PLAN_DRAFT,
   basics: {
     __typename: 'PlanBasics',
     goal: 'This is the goal',
-    performancePeriodStarts: '2022-08-20T04:12:00Z'
+    performancePeriodStarts: '2022-08-20T04:00:00Z'
   },
   generalCharacteristics: {
     __typename: 'PlanGeneralCharacteristics',

--- a/src/data/mock/readonly.ts
+++ b/src/data/mock/readonly.ts
@@ -571,13 +571,13 @@ const summaryData: GetModelSummaryTypes = {
   isFavorite: false,
   modelName: 'Testing Model Summary',
   abbreviation: 'TMS',
-  createdDts: '2022-08-23T04:00:00Z',
-  modifiedDts: '2022-08-27T04:00:00Z',
+  createdDts: '2022-08-23T04:12:00Z',
+  modifiedDts: '2022-08-27T04:12:00Z',
   status: ModelStatus.PLAN_DRAFT,
   basics: {
     __typename: 'PlanBasics',
     goal: 'This is the goal',
-    performancePeriodStarts: '2022-08-20T04:00:00Z'
+    performancePeriodStarts: '2022-08-20T04:12:00Z'
   },
   generalCharacteristics: {
     __typename: 'PlanGeneralCharacteristics',

--- a/src/queries/GetAllModelData.ts
+++ b/src/queries/GetAllModelData.ts
@@ -9,7 +9,9 @@ export default gql`
       nameHistory(sort: DESC)
       abbreviation
       archived
-      createdBy
+      createdByUserAccount {
+        commonName
+      }
       createdDts
       modifiedBy
       modifiedDts
@@ -40,10 +42,6 @@ export default gql`
         phasedInNote
         readyForReviewBy
         readyForReviewDts
-        createdBy
-        createdDts
-        modifiedBy
-        modifiedDts
         status
       }
       beneficiaries {
@@ -76,14 +74,18 @@ export default gql`
       discussions {
         id
         content
-        createdBy
+        createdByUserAccount {
+          commonName
+        }
         createdDts
         status
         replies {
           id
           discussionID
           content
-          createdBy
+          createdByUserAccount {
+            commonName
+          }
           createdDts
           resolution
         }

--- a/src/queries/GetAllSingleModelPlan.ts
+++ b/src/queries/GetAllSingleModelPlan.ts
@@ -8,7 +8,9 @@ export default gql`
       nameHistory(sort: DESC)
       abbreviation
       archived
-      createdBy
+      createdByUserAccount {
+        commonName
+      }
       createdDts
       modifiedBy
       modifiedDts
@@ -40,10 +42,6 @@ export default gql`
         phasedInNote
         readyForReviewBy
         readyForReviewDts
-        createdBy
-        createdDts
-        modifiedBy
-        modifiedDts
         status
       }
       generalCharacteristics {
@@ -357,14 +355,18 @@ export default gql`
       discussions {
         id
         content
-        createdBy
+        createdByUserAccount {
+          commonName
+        }
         createdDts
         status
         replies {
           id
           discussionID
           content
-          createdBy
+          createdByUserAccount {
+            commonName
+          }
           createdDts
           resolution
         }

--- a/src/queries/types/GetAllModelData.ts
+++ b/src/queries/types/GetAllModelData.ts
@@ -9,6 +9,11 @@ import { ModelCategory, CMSCenter, CMMIGroup, ModelType, TaskStatus, Beneficiari
 // GraphQL query operation: GetAllModelData
 // ====================================================
 
+export interface GetAllModelData_modelPlanCollection_createdByUserAccount {
+  __typename: "UserAccount";
+  commonName: string;
+}
+
 export interface GetAllModelData_modelPlanCollection_basics {
   __typename: "PlanBasics";
   id: UUID;
@@ -37,10 +42,6 @@ export interface GetAllModelData_modelPlanCollection_basics {
   phasedInNote: string | null;
   readyForReviewBy: UUID | null;
   readyForReviewDts: Time | null;
-  createdBy: UUID;
-  createdDts: Time;
-  modifiedBy: UUID | null;
-  modifiedDts: Time | null;
   status: TaskStatus;
 }
 
@@ -73,12 +74,22 @@ export interface GetAllModelData_modelPlanCollection_beneficiaries {
   beneficiarySelectionMethod: SelectionMethodType[];
 }
 
+export interface GetAllModelData_modelPlanCollection_discussions_createdByUserAccount {
+  __typename: "UserAccount";
+  commonName: string;
+}
+
+export interface GetAllModelData_modelPlanCollection_discussions_replies_createdByUserAccount {
+  __typename: "UserAccount";
+  commonName: string;
+}
+
 export interface GetAllModelData_modelPlanCollection_discussions_replies {
   __typename: "DiscussionReply";
   id: UUID;
   discussionID: UUID;
   content: string | null;
-  createdBy: UUID;
+  createdByUserAccount: GetAllModelData_modelPlanCollection_discussions_replies_createdByUserAccount;
   createdDts: Time;
   resolution: boolean | null;
 }
@@ -87,7 +98,7 @@ export interface GetAllModelData_modelPlanCollection_discussions {
   __typename: "PlanDiscussion";
   id: UUID;
   content: string | null;
-  createdBy: UUID;
+  createdByUserAccount: GetAllModelData_modelPlanCollection_discussions_createdByUserAccount;
   createdDts: Time;
   status: DiscussionStatus;
   replies: GetAllModelData_modelPlanCollection_discussions_replies[];
@@ -394,7 +405,7 @@ export interface GetAllModelData_modelPlanCollection {
   nameHistory: string[];
   abbreviation: string | null;
   archived: boolean;
-  createdBy: UUID;
+  createdByUserAccount: GetAllModelData_modelPlanCollection_createdByUserAccount;
   createdDts: Time;
   modifiedBy: UUID | null;
   modifiedDts: Time | null;

--- a/src/queries/types/GetAllSingleModelData.ts
+++ b/src/queries/types/GetAllSingleModelData.ts
@@ -9,6 +9,11 @@ import { ModelStatus, ModelCategory, CMSCenter, CMMIGroup, ModelType, TaskStatus
 // GraphQL query operation: GetAllSingleModelData
 // ====================================================
 
+export interface GetAllSingleModelData_modelPlan_createdByUserAccount {
+  __typename: "UserAccount";
+  commonName: string;
+}
+
 export interface GetAllSingleModelData_modelPlan_basics {
   __typename: "PlanBasics";
   id: UUID;
@@ -37,10 +42,6 @@ export interface GetAllSingleModelData_modelPlan_basics {
   phasedInNote: string | null;
   readyForReviewBy: UUID | null;
   readyForReviewDts: Time | null;
-  createdBy: UUID;
-  createdDts: Time;
-  modifiedBy: UUID | null;
-  modifiedDts: Time | null;
   status: TaskStatus;
 }
 
@@ -367,12 +368,22 @@ export interface GetAllSingleModelData_modelPlan_collaborators {
   createdDts: Time;
 }
 
+export interface GetAllSingleModelData_modelPlan_discussions_createdByUserAccount {
+  __typename: "UserAccount";
+  commonName: string;
+}
+
+export interface GetAllSingleModelData_modelPlan_discussions_replies_createdByUserAccount {
+  __typename: "UserAccount";
+  commonName: string;
+}
+
 export interface GetAllSingleModelData_modelPlan_discussions_replies {
   __typename: "DiscussionReply";
   id: UUID;
   discussionID: UUID;
   content: string | null;
-  createdBy: UUID;
+  createdByUserAccount: GetAllSingleModelData_modelPlan_discussions_replies_createdByUserAccount;
   createdDts: Time;
   resolution: boolean | null;
 }
@@ -381,7 +392,7 @@ export interface GetAllSingleModelData_modelPlan_discussions {
   __typename: "PlanDiscussion";
   id: UUID;
   content: string | null;
-  createdBy: UUID;
+  createdByUserAccount: GetAllSingleModelData_modelPlan_discussions_createdByUserAccount;
   createdDts: Time;
   status: DiscussionStatus;
   replies: GetAllSingleModelData_modelPlan_discussions_replies[];
@@ -394,7 +405,7 @@ export interface GetAllSingleModelData_modelPlan {
   nameHistory: string[];
   abbreviation: string | null;
   archived: boolean;
-  createdBy: UUID;
+  createdByUserAccount: GetAllSingleModelData_modelPlan_createdByUserAccount;
   createdDts: Time;
   modifiedBy: UUID | null;
   modifiedDts: Time | null;

--- a/src/utils/export/CsvData.ts
+++ b/src/utils/export/CsvData.ts
@@ -21,7 +21,7 @@ const csvFields = [
   },
   {
     label: 'Created By',
-    value: 'createdBy'
+    value: 'createdByUserAccount.commonName'
   },
   {
     label: 'Created At',
@@ -360,14 +360,14 @@ const csvFields = [
 
   // Discussions
   'discussions.content',
-  'discussions.createdBy',
+  'discussions.createdByUserAccount.commonName',
   'discussions.createdDts',
   'discussions.status',
 
   // Discussion Replies
   'discussions.replies.discussionID',
   'discussions.replies.content',
-  'discussions.replies.createdBy',
+  'discussions.replies.createdByUserAccount.commonName',
   'discussions.replies.createdDts',
   'discussions.replies.resolution'
 ];

--- a/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`Read Only Model Plan Summary matches snapshot 1`] = `
                   <p
                     class="margin-y-0 text-normal"
                   >
-                    Last updated on 08/27/2022
+                    Last updated on 08/26/2022
                   </p>
                 </div>
                 <div


### PR DESCRIPTION
# EASI-3008

## Changes and Description

- Added human readable user names where users are referenced in CSV model plan
  - Discussions, replies, and model plan
- Updated unit tests/snapshots
  -  Changed mocked data where time was set at midnight to be more consistent

<!-- Put a description here! -->

CSV headers will be addressed in another ticket

## How to test this change

Download a model plan csv
Verify that user's names are rendered

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
