### PR TITLE
[NOREF] Use groups for dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,20 +2,54 @@
 
 version: 2
 updates:
-
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1
+    groups:
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      other:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1
+    groups:
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      other:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1
+    groups:
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      other:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
# NOREF

## Changes and Description

- See https://github.com/CMSgov/easi-app/pull/2185
- Use dependabot groups ([docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)) to reduce the number of PRs that we need to dig through for each package manager.
- Groups minor/patch PRs in one group and major upgrades in another

## How to test this change

- Ensure that the dependabot config matches what would be expected based on the linked documentation

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
