### PR TITLE
remove exclude for G602 as issue was resolved

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,4 @@
 linters-settings:
-  gosec:
-    # Currently excluding rule G602 due to issue slowing down execution
-    # https://github.com/securego/gosec/issues/1010
-    excludes:
-      - "G602"
   govet:
     check-shadowing: true
     settings:


### PR DESCRIPTION
# NOREF

## Changes and Description

- Removed configuration for gosec that excludes rule G602 as there was an issue. (https://github.com/securego/gosec/issues/1010)
That issue has now been resolved.

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
