### PR TITLE
[NOREF] Fix dockerfile copy command copying to wrong directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ FROM base AS dev
 
 FROM base AS build
 
-	COPY cmd/ pkg/ ./
+	COPY cmd ./cmd
+	COPY pkg ./pkg
 	RUN CGO_ENABLED=0 GOOS=linux go build -a -o bin/mint ./cmd/mint
 
 FROM scratch


### PR DESCRIPTION
# NOREF

## Changes and Description

- Modify dockerfile to correctly copy to pkg and cmd directories, not to root of workspace
- Fixes issue from https://github.com/CMSgov/mint-app/pull/707

## How to test this change

- Running `docker build -t local . --no-cache` locally should build the target that's built on the production build pipeline, which will validate this!

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
