### PR TITLE
Easi 3349/send feedback email be

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -29,6 +29,7 @@ export EMAIL_SENDER=no-reply-mint-localhost@cms.hhs.gov
 export GRT_EMAIL=success@simulator.amazonses.com
 export ACCESSIBILITY_TEAM_EMAIL=success@simulator.amazonses.com
 export MINT_TEAM_EMAIL=MINTTeam@cms.hhs.gov
+export DEV_TEAM_EMAIL=devs@cms.hhs.gov
 export DATE_CHANGED_RECIPIENT_EMAILS=one@test.gov,two@test.gov
 
 # AWS variables

--- a/MINT.postman_collection.json
+++ b/MINT.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e68452c4-426e-415f-ac15-5e441ed4dcf3",
+		"_postman_id": "f8c48fb4-c317-409d-92c7-694ee6bfbd69",
 		"name": "MINT",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "20320964"
@@ -1132,6 +1132,43 @@
 							"graphql": {
 								"query": "query searchOktaUsers ($searchTerm: String!) {\n    searchOktaUsers (searchTerm: $searchTerm) {\n        firstName\n        lastName\n        displayName\n        email\n        username\n    }\n}",
 								"variables": "{\n  \"searchTerm\": \"\"\n}"
+							}
+						},
+						"url": {
+							"raw": "{{url}}",
+							"host": [
+								"{{url}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "SendFeedback",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"let responseData = pm.response.json().data.sendFeedbackEmail",
+									"",
+									"pm.test(\"Feedback Email was sent\", function (){",
+									"    pm.expect(responseData).to.equal(true)",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "graphql",
+							"graphql": {
+								"query": "mutation sendFeedbackEmail{\n  \n  sendFeedbackEmail(input:{\n      isAnonymousSubmission: false\n      allowContact: true\n      cmsRole: \"Ultimate COR\"\n      mintUsedFor: [VIEW_MODEL, EDIT_MODEL]\n      mintUsedForOther: \"Looking cool\"\n      systemEasyToUse: AGREE\n      systemEasyToUseOther: \"HMM I guess it's great!\"\n      howCanWeImprove: \"a virtual assistant that pops up and sings to you\"\n      })\n}",
+								"variables": ""
 							}
 						},
 						"url": {

--- a/docker-compose.backend.yml
+++ b/docker-compose.backend.yml
@@ -92,6 +92,7 @@ services:
       - EMAIL_HOST
       - EMAIL_PORT
       - MINT_TEAM_EMAIL
+      - DEV_TEAM_EMAIL
       - DATE_CHANGED_RECIPIENT_EMAILS
       - EMAIL_SENDER
       - EMAIL_ENABLED

--- a/pkg/appconfig/config.go
+++ b/pkg/appconfig/config.go
@@ -139,6 +139,9 @@ const AccessibilityTeamEmailKey = "ACCESSIBILITY_TEAM_EMAIL"
 // MINTTeamEmailKey is the key for the receiving email for the MINT team
 const MINTTeamEmailKey = "MINT_TEAM_EMAIL"
 
+// DevTeamEmailKey is the key for getting the email sender
+const DevTeamEmailKey = "DEV_TEAM_EMAIL"
+
 // DateChangedRecipientEmailsKey is the key for the receiving email addresses for
 // the model plan date changed email notification
 const DateChangedRecipientEmailsKey = "DATE_CHANGED_RECIPIENT_EMAILS"

--- a/pkg/email/address_book.go
+++ b/pkg/email/address_book.go
@@ -8,6 +8,9 @@ type AddressBook struct {
 	// MINTTeamEmail is the email address of the MINT team
 	MINTTeamEmail string
 
+	// DevTeamEmail is the email address of the MINT development team
+	DevTeamEmail string
+
 	// ModelPlanDateChangedRecipients is the list of email addresses that should
 	// receive notifications when one or more model plan dates are changed
 	ModelPlanDateChangedRecipients []string

--- a/pkg/email/send_feedback.go
+++ b/pkg/email/send_feedback.go
@@ -8,7 +8,7 @@ type SendFeedbackBodyContent struct {
 	IsAnonymousSubmission bool
 	ReporterName          string
 	ReporterEmail         string
-	AllowContact          bool
+	AllowContact          string
 	CMSRole               string
 	MINTUsedFor           []string
 	SystemEasyToUse       string

--- a/pkg/email/send_feedback.go
+++ b/pkg/email/send_feedback.go
@@ -1,0 +1,17 @@
+package email
+
+// SendFeedbackSubjectContent defines the parameters necessary for the corresponding email subject
+type SendFeedbackSubjectContent struct{}
+
+// SendFeedbackBodyContent defines the parameters necessary for the corresponding email body
+type SendFeedbackBodyContent struct {
+	IsAnonymousSubmission bool
+	ReporterName          string
+	ReporterEmail         string
+	AllowContact          bool
+	CMSRole               string
+	MINTUsedFor           []string
+	SystemEasyToUse       string
+	HowSatisfied          string
+	HowCanWeImprove       string
+}

--- a/pkg/email/template_service_impl.go
+++ b/pkg/email/template_service_impl.go
@@ -70,6 +70,15 @@ var modelPlanShareSubjectTemplate string
 //go:embed templates/model_plan_share_body.html
 var modelPlanShareBodyTemplate string
 
+// SendFeedbackTemplateName is the template name definition of the send feedback email template
+const SendFeedbackTemplateName string = "send_feedback"
+
+//go:embed templates/send_feedback_body.html
+var sendFeedbackBodyTemplate string
+
+//go:embed templates/send_feedback_subject.html
+var sendFeedbackSubjectTemplate string
+
 // TemplateServiceImpl is an implementation-specific structure loading all resources necessary for server execution
 type TemplateServiceImpl struct {
 	templateCache  *emailTemplates.TemplateCache
@@ -127,6 +136,10 @@ func (t *TemplateServiceImpl) Load() error {
 		return err
 	}
 
+	err = t.loadEmailTemplate(SendFeedbackTemplateName, sendFeedbackSubjectTemplate, sendFeedbackBodyTemplate)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/email/templates/send_feedback_body.html
+++ b/pkg/email/templates/send_feedback_body.html
@@ -1,0 +1,139 @@
+<!DOCTYPE  html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <title>Content</title>
+  <style type="text/css">
+    /* CSS Reset */
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    /* General */
+    body {
+      padding-left: 5px;
+      text-align: left;
+    }
+
+    /* Headings */
+    h1 {
+      font-size: 39pt;
+      font-weight: bold;
+      font-style: normal;
+      color: #1A1A1A;
+      font-family: Arial, sans-serif;
+      text-decoration: none;
+    }
+
+    h2 {
+      font-size: 24pt;
+      font-weight: bold;
+      font-style: normal;
+      color: #1B1B1B;
+      font-family: Arial, sans-serif;
+      text-decoration: none;
+    }
+
+    h3 {
+      font-size: 15.5pt;
+      font-weight: bold;
+      font-style: normal;
+      color: #1A1A1A;
+      font-family: Arial, sans-serif;
+      text-decoration: none;
+      line-height: 1.4;
+    }
+
+    /* Subtitle */
+    .subtitle {
+      font-size: 15.5pt;
+      font-weight: normal;
+      font-style: normal;
+      color: #707579;
+      font-family: Arial, sans-serif;
+      text-decoration: none;
+    }
+
+    /* Paragraph */
+    p {
+      font-size: 15.5pt;
+      font-weight: normal;
+      font-style: normal;
+      color: #1A1A1A;
+      font-family: Arial, sans-serif;
+      text-decoration: none;
+      line-height: 1.4;
+    }
+
+    /* Links */
+    a {
+      font-size: 15.5pt;
+      font-weight: normal;
+      font-style: normal;
+      color: #005BA0;
+      font-family: Arial, sans-serif;
+      text-decoration: none;
+    }
+  </style>
+</head>
+
+<body>
+    <h1 style="padding-top: 3pt;">MINT</h1>
+    <p class="subtitle" style="padding-top: 11pt;">The Model Innovation Tool</p>
+    <br/>
+    <h2 style="padding-top: 18pt">Feedback</h2>
+    <br />
+    <h3 style="padding-top: 14pt;">Reporter</h3>
+    {{if .IsAnonymousSubmission }}
+      <p>Anonymous</p>
+    {{else}}
+      <p>{{.ReporterName}}</p>
+      <a href="mailto:{{.ReporterEmail}}">{{.ReporterEmail}}</a>
+      <br />
+      <br />
+      {{if .AllowContact}}
+        <p>{{.AllowContact}}</p>
+      {{else}}
+        <i>User didn't specify if they could be contacted</i>
+      {{end}}
+    {{end}}
+    <br />
+    <br />
+    <hr />
+    <h3 style="padding-top: 14pt;">What is your role?</h3>
+    {{ if .CMSRole}}
+      <p>{{.CMSRole}}</p>
+    {{else}}
+      <i>Left Blank</i>
+    {{end}}
+    <h3 style="padding-top: 14pt;">What have you used MINT for?</h3>
+    {{ if .MINTUsedFor}}
+    <!-- TODO: implement UL for each list item -->
+      <p>{{.MINTUsedFor}}</p> 
+    {{else}}
+      <i>Left Blank</i>
+    {{end}}
+    <h3 style="padding-top: 14pt;">The system is easy to use.</h3>
+    {{ if .SystemEasyToUse}}
+      <p>{{.SystemEasyToUse}}</p>
+    {{else}}
+      <i>Left Blank</i>
+    {{end}}
+    <h3 style="padding-top: 14pt;">Overall, how satisfied are you with MINT</h3>
+    {{ if .HowSatisfied}}
+      <p>{{.HowSatisfied}}</p>
+    {{else}}
+      <i>Left Blank</i>
+    {{end}}
+    <h3 style="padding-top: 14pt;">How can we improve MINT</h3>
+    {{ if .HowCanWeImprove}}
+      <p>{{.HowCanWeImprove}}</p>
+    {{else}}
+      <i>Left Blank</i>
+    {{end}}
+    
+    </body>
+    </html>

--- a/pkg/email/templates/send_feedback_body.html
+++ b/pkg/email/templates/send_feedback_body.html
@@ -111,8 +111,11 @@
     {{end}}
     <h3 style="padding-top: 14pt;">What have you used MINT for?</h3>
     {{ if .MINTUsedFor}}
-    <!-- TODO: implement UL for each list item -->
-      <p>{{.MINTUsedFor}}</p> 
+    <ul>
+    {{range $use := .MINTUsedFor}}
+    <li>{{$use}}</li>
+    {{end}}
+    </ul>
     {{else}}
       <i>Left Blank</i>
     {{end}}

--- a/pkg/email/templates/send_feedback_body.html
+++ b/pkg/email/templates/send_feedback_body.html
@@ -77,6 +77,28 @@
       font-family: Arial, sans-serif;
       text-decoration: none;
     }
+    /* Lists */
+    ul,
+    li {
+      color: #1B1B1B;
+      font-family: Helvetica, Arial, sans-serif;
+      font-weight: normal;
+      padding: 0;
+      margin: 0;
+      Margin: 0;
+      text-align: left;
+      line-height: 1.3;
+    }
+    li {
+        font-weight: 400;
+        text-decoration: none;
+        font-size: 16px;
+        line-height: 25px;
+        letter-spacing: -0.01em;
+      }
+    ul {
+      padding: 10px 0 0 25px ;
+     }
   </style>
 </head>
 
@@ -113,7 +135,9 @@
     {{ if .MINTUsedFor}}
     <ul>
     {{range $use := .MINTUsedFor}}
-    <li>{{$use}}</li>
+    <li>
+      {{$use}}
+    </li>
     {{end}}
     </ul>
     {{else}}

--- a/pkg/email/templates/send_feedback_subject.html
+++ b/pkg/email/templates/send_feedback_subject.html
@@ -1,0 +1,1 @@
+MINT Feedback

--- a/pkg/graph/resolvers/send_feedback_email.go
+++ b/pkg/graph/resolvers/send_feedback_email.go
@@ -1,0 +1,83 @@
+package resolvers
+
+import (
+	"github.com/cmsgov/mint-app/pkg/email"
+	"github.com/cmsgov/mint-app/pkg/shared/oddmail"
+
+	"github.com/cmsgov/mint-app/pkg/graph/model"
+
+	"github.com/cmsgov/mint-app/pkg/authentication"
+)
+
+// SendFeedbackEmail sends a feedback email to the mint team
+func SendFeedbackEmail(
+	emailService oddmail.EmailService,
+	emailTemplateService email.TemplateService,
+	addressBook email.AddressBook,
+	principal authentication.Principal,
+	input model.SendFeedbackEmailInput,
+) (bool, error) {
+	if emailService != nil && emailTemplateService != nil {
+		emailTemplate, err := emailTemplateService.GetEmailTemplate(email.SendFeedbackTemplateName)
+		if err != nil {
+			return false, err
+		}
+
+		emailSubject, err := emailTemplate.GetExecutedSubject(email.SendFeedbackSubjectContent{})
+		if err != nil {
+			return false, err
+		}
+
+		emailBody, err := emailTemplate.GetExecutedBody(email.SendFeedbackBodyContent{
+			IsAnonymousSubmission: input.IsAnonymousSubmission,
+			ReporterName:          principal.Account().CommonName,
+			ReporterEmail:         principal.Account().Email,
+			AllowContact:          input.AllowContact,
+			CMSRole:               input.CmsRole,
+			MINTUsedFor:           humanizeFeedbackMINTUses(input.MintUsedFor, input.MintUsedForOther),
+			SystemEasyToUse:       humanizeFeedbackEasyToUse(input.SystemEasyToUse, input.SystemEasyToUseOther),
+			HowSatisfied:          humanizeFeedbackSatisfaction(input.HowSatisfied),
+			HowCanWeImprove:       input.HowCanWeImprove,
+		})
+		if err != nil {
+			return false, err
+		}
+
+		// TODO: SW pull un the address book from the report a problem email
+		err = emailService.Send(addressBook.DefaultSender, []string{addressBook.DevTeamEmail}, nil, emailSubject, "text/html", emailBody)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+
+	}
+
+	return true, nil
+}
+
+func humanizeFeedbackMINTUses(usedFor []model.MintUses, usedForOther *string) []string {
+	//TODO: SW implement
+	uses := []string{}
+	for _, use := range usedFor {
+		uses = append(uses, string(use))
+	}
+	if usedForOther != nil { //TODO, remove other above?
+		uses = append(uses, *usedForOther)
+	}
+
+	return uses
+
+}
+
+func humanizeFeedbackEasyToUse(ease model.EaseOfUse, easeOther *string) string {
+	// TODO: SW implement
+	if easeOther != nil {
+		return *easeOther
+	}
+	return string(ease)
+}
+
+func humanizeFeedbackSatisfaction(satisfactionLevel model.SatisfactionLevel) string {
+	// TODO: SW implement
+	return string(satisfactionLevel)
+}

--- a/pkg/graph/resolvers/send_feedback_email.go
+++ b/pkg/graph/resolvers/send_feedback_email.go
@@ -28,11 +28,12 @@ func SendFeedbackEmail(
 			return false, err
 		}
 
+		//TODO: SW handle if an input is null. Should the schema reflect that? Or should we just expect empty strings?
 		emailBody, err := emailTemplate.GetExecutedBody(email.SendFeedbackBodyContent{
 			IsAnonymousSubmission: input.IsAnonymousSubmission,
 			ReporterName:          principal.Account().CommonName,
 			ReporterEmail:         principal.Account().Email,
-			AllowContact:          input.AllowContact,
+			AllowContact:          humanizeFeedbackAllowContact(&input.AllowContact), //TODO: SW update bool to not be required
 			CMSRole:               input.CmsRole,
 			MINTUsedFor:           humanizeFeedbackMINTUses(input.MintUsedFor, input.MintUsedForOther),
 			SystemEasyToUse:       humanizeFeedbackEasyToUse(input.SystemEasyToUse, input.SystemEasyToUseOther),
@@ -53,6 +54,19 @@ func SendFeedbackEmail(
 	}
 
 	return true, nil
+}
+
+func humanizeFeedbackAllowContact(allowFeedback *bool) string {
+	if allowFeedback == nil {
+		return "" //the text for this case is part of the email template to allow formatting
+		// return "User didn’t specify if they could be contacted"
+	}
+	if *allowFeedback {
+		return "Yes, the MINT team may contact me for additional information."
+	}
+
+	return "No, the MINT team may not contact me for additional information."
+
 }
 
 func humanizeFeedbackMINTUses(usedFor []model.MintUses, usedForOther *string) []string {

--- a/pkg/graph/resolvers/send_feedback_email.go
+++ b/pkg/graph/resolvers/send_feedback_email.go
@@ -59,25 +59,68 @@ func humanizeFeedbackMINTUses(usedFor []model.MintUses, usedForOther *string) []
 	//TODO: SW implement
 	uses := []string{}
 	for _, use := range usedFor {
-		uses = append(uses, string(use))
+		humanized := humanizeFeedbackMINTUse(use)
+		if humanized == "" {
+			continue
+		}
+		uses = append(uses, humanized)
 	}
-	if usedForOther != nil { //TODO, remove other above?
-		uses = append(uses, *usedForOther)
+	if usedForOther != nil {
+		uses = append(uses, "Other - "+*usedForOther)
 	}
 
 	return uses
 
 }
+func humanizeFeedbackMINTUse(use model.MintUses) string {
+	switch use {
+	case model.MintUsesViewModel:
+		return "To view Model Plans"
+	case model.MintUsesEditModel:
+		return "To edit Model Plans"
+	case model.MintUsesShareModel:
+		return "To share or export Model Plan content"
+	case model.MintUsesTrackSolutions:
+		return "To track operational solutions"
+	case model.MintUsesContributeDiscussions:
+		return "To contribute to Model Discussions"
+	case model.MintUsesViewHelp:
+		return "To view the Help Center"
+	case model.MintUsesOther:
+		return "" // TODO: SW should we include the actual word other?
+	default:
+		return string(use)
+	}
+}
 
 func humanizeFeedbackEasyToUse(ease model.EaseOfUse, easeOther *string) string {
-	// TODO: SW implement
 	if easeOther != nil {
-		return *easeOther
+		return "I'm not sure - " + *easeOther
 	}
-	return string(ease)
+	switch ease {
+	case model.EaseOfUseAgree:
+		return "Agree"
+	case model.EaseOfUseDisagree:
+		return "Disagree"
+	default:
+		return string(ease)
+	}
 }
 
 func humanizeFeedbackSatisfaction(satisfactionLevel model.SatisfactionLevel) string {
-	// TODO: SW implement
-	return string(satisfactionLevel)
+
+	switch satisfactionLevel {
+	case model.SatisfactionLevelVerySatisfied:
+		return "VERY_SATISFIED"
+	case model.SatisfactionLevelSatisfied:
+		return "SATISFIED"
+	case model.SatisfactionLevelNeutral:
+		return "NEUTRAL"
+	case model.SatisfactionLevelDissatisfied:
+		return "DISSATISFIED"
+	case model.SatisfactionLevelVeryDissatisfied:
+		return "VERY_DISSATISFIED"
+	default:
+		return string(satisfactionLevel)
+	}
 }

--- a/pkg/graph/resolvers/send_feedback_email.go
+++ b/pkg/graph/resolvers/send_feedback_email.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"github.com/cmsgov/mint-app/pkg/email"
+	"github.com/cmsgov/mint-app/pkg/models"
 	"github.com/cmsgov/mint-app/pkg/shared/oddmail"
 
 	"github.com/cmsgov/mint-app/pkg/graph/model"
@@ -33,12 +34,12 @@ func SendFeedbackEmail(
 			IsAnonymousSubmission: input.IsAnonymousSubmission,
 			ReporterName:          principal.Account().CommonName,
 			ReporterEmail:         principal.Account().Email,
-			AllowContact:          humanizeFeedbackAllowContact(&input.AllowContact), //TODO: SW update bool to not be required
-			CMSRole:               input.CmsRole,
+			AllowContact:          humanizeFeedbackAllowContact(input.AllowContact), //TODO: SW update bool to not be required
+			CMSRole:               models.ValueOrEmpty(input.CmsRole),
 			MINTUsedFor:           humanizeFeedbackMINTUses(input.MintUsedFor, input.MintUsedForOther),
 			SystemEasyToUse:       humanizeFeedbackEasyToUse(input.SystemEasyToUse, input.SystemEasyToUseOther),
 			HowSatisfied:          humanizeFeedbackSatisfaction(input.HowSatisfied),
-			HowCanWeImprove:       input.HowCanWeImprove,
+			HowCanWeImprove:       models.ValueOrEmpty(input.HowCanWeImprove),
 		})
 		if err != nil {
 			return false, err
@@ -107,34 +108,40 @@ func humanizeFeedbackMINTUse(use model.MintUses) string {
 	}
 }
 
-func humanizeFeedbackEasyToUse(ease model.EaseOfUse, easeOther *string) string {
+func humanizeFeedbackEasyToUse(ease *model.EaseOfUse, easeOther *string) string {
 	if easeOther != nil {
 		return "I'm not sure - " + *easeOther
 	}
-	switch ease {
+	if ease == nil {
+		return ""
+	}
+	switch *ease {
 	case model.EaseOfUseAgree:
 		return "Agree"
 	case model.EaseOfUseDisagree:
 		return "Disagree"
 	default:
-		return string(ease)
+		return string(*ease)
 	}
 }
 
-func humanizeFeedbackSatisfaction(satisfactionLevel model.SatisfactionLevel) string {
+func humanizeFeedbackSatisfaction(satisfactionLevel *model.SatisfactionLevel) string {
 
-	switch satisfactionLevel {
+	if satisfactionLevel == nil {
+		return ""
+	}
+	switch *satisfactionLevel {
 	case model.SatisfactionLevelVerySatisfied:
-		return "VERY_SATISFIED"
+		return "Very Satisfied"
 	case model.SatisfactionLevelSatisfied:
-		return "SATISFIED"
+		return "Satisfied"
 	case model.SatisfactionLevelNeutral:
-		return "NEUTRAL"
+		return "Neutral"
 	case model.SatisfactionLevelDissatisfied:
-		return "DISSATISFIED"
+		return "Dissatisfied"
 	case model.SatisfactionLevelVeryDissatisfied:
-		return "VERY_DISSATISFIED"
+		return "Very Dissatisfied"
 	default:
-		return string(satisfactionLevel)
+		return string(*satisfactionLevel)
 	}
 }

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -490,7 +490,8 @@ func (r *mutationResolver) ShareModelPlan(ctx context.Context, modelPlanID uuid.
 
 // SendFeedbackEmail is the resolver for the sendFeedbackEmail field.
 func (r *mutationResolver) SendFeedbackEmail(ctx context.Context, input model.SendFeedbackEmailInput) (bool, error) {
-	return false, nil
+	principal := appcontext.Principal(ctx)
+	return resolvers.SendFeedbackEmail(r.emailService, r.emailTemplateService, r.addressBook, principal, input)
 }
 
 // Solutions is the resolver for the solutions field.

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -174,6 +174,7 @@ func (s *Server) routes(
 		DefaultSender:                  s.Config.GetString(appconfig.EmailSenderKey),
 		MINTTeamEmail:                  s.Config.GetString(appconfig.MINTTeamEmailKey),
 		ModelPlanDateChangedRecipients: dateChangedRecipientEmails,
+		DevTeamEmail:                   s.Config.GetString(appconfig.DevTeamEmailKey),
 	}
 
 	var emailService *oddmail.GoSimpleMailService


### PR DESCRIPTION
# EASI-3349

## Changes and Description

- Create the email for Send Feedback email
- Backend Resolver for Send Feedback
   -  Note optional strings and "" are treated equivalently. They are represented as nullable in the schema to reflect the intended requirements of the form.
- Postman Query to Send Feedback



## How to test this change
1. Bring up the app
2. Use the postman query as is to send an email with all fields filled out
3.  Verify the email using [mailcatcher](http://127.0.0.1:1085/)
4. If desired, comment out  parameters in the query to see what the email looks like without optional parameters.

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
