### PR TITLE
Fixed styling on footer than made it expand vertically on large screens

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -13,7 +13,6 @@ import classNames from 'classnames';
 import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import UswdsReactLink from 'components/LinkWrapper';
-import MainContent from 'components/MainContent';
 import ExternalLink from 'components/shared/ExternalLink';
 import useCheckResponsiveScreen from 'hooks/useCheckMobile';
 import cmsGovLogo from 'images/cmsGovLogo.png';
@@ -56,7 +55,7 @@ const Footer = () => {
       {authState?.isAuthenticated &&
         feedbackEnabled &&
         location.pathname !== '/pre-decisional-notice' && (
-          <MainContent
+          <div
             className={classNames('bg-mint-cool-5 padding-y-2', {
               'margin-top-7': authState?.isAuthenticated
             })}
@@ -132,7 +131,7 @@ const Footer = () => {
                 )}
               </Grid>
             </GridContainer>
-          </MainContent>
+          </div>
         )}
 
       <UswdsFooter

--- a/src/views/ModelPlan/TaskList/ITSolutions/LinkDocuments/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/ITSolutions/LinkDocuments/__snapshots__/index.test.tsx.snap
@@ -601,7 +601,7 @@ exports[`IT Solutions Link Documents > matches snapshot 1`] = `
                 role="cell"
                 style="padding-left: 0px;"
               >
-                Concept Paper
+                ICIP Draft
               </td>
               <td
                 role="cell"
@@ -623,13 +623,7 @@ exports[`IT Solutions Link Documents > matches snapshot 1`] = `
                 role="cell"
                 style="padding-left: 0px;"
               >
-                <button
-                  class="usa-button usa-button--unstyled margin-right-1"
-                  data-testid="button"
-                  type="button"
-                >
-                  View
-                </button>
+                Virus scan in progress...
               </td>
             </tr>
           </tbody>

--- a/src/views/ModelPlan/TaskList/ITSolutions/LinkDocuments/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/ITSolutions/LinkDocuments/__snapshots__/index.test.tsx.snap
@@ -601,7 +601,7 @@ exports[`IT Solutions Link Documents > matches snapshot 1`] = `
                 role="cell"
                 style="padding-left: 0px;"
               >
-                ICIP Draft
+                Concept Paper
               </td>
               <td
                 role="cell"
@@ -623,7 +623,13 @@ exports[`IT Solutions Link Documents > matches snapshot 1`] = `
                 role="cell"
                 style="padding-left: 0px;"
               >
-                Virus scan in progress...
+                <button
+                  class="usa-button usa-button--unstyled margin-right-1"
+                  data-testid="button"
+                  type="button"
+                >
+                  View
+                </button>
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
# NOREF

## Changes and Description

- Removed styling `<MainContent />` element on footer that caused it to expand vertically on large screens with empty space

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
