### PR TITLE
feat: only populate other in the email if not nil or empty string

### DIFF
--- a/pkg/graph/resolvers/send_feedback_email.go
+++ b/pkg/graph/resolvers/send_feedback_email.go
@@ -69,20 +69,24 @@ func humanizeFeedbackAllowContact(allowFeedback *bool) string {
 }
 
 func humanizeFeedbackMINTUses(usedFor []model.MintUses, usedForOther *string) []string {
-	//TODO: SW implement
+
 	uses := []string{}
+	containsOther := false
 	for _, use := range usedFor {
 		humanized := humanizeFeedbackMINTUse(use)
 		if humanized == "" {
 			continue
 		}
+		if humanized == "Other" {
+			containsOther = true
+			if models.ValueOrEmpty(usedForOther) != "" { // only add the text if isn't nil or empty.
+				humanized = humanized + " - " + *usedForOther
+			}
+		}
 		uses = append(uses, humanized)
 	}
-	if usedForOther != nil {
-		use := "Other"
-		if *usedForOther != "" {
-			use = use + " - " + *usedForOther
-		}
+	if !containsOther && models.ValueOrEmpty(usedForOther) != "" { // It other wasn't selected, but the optional text was filled out include it anyways
+		use := "Other - " + *usedForOther
 		uses = append(uses, use)
 	}
 
@@ -104,7 +108,7 @@ func humanizeFeedbackMINTUse(use model.MintUses) string {
 	case model.MintUsesViewHelp:
 		return "To view the Help Center"
 	case model.MintUsesOther:
-		return "" // TODO: SW should we include the actual word other?
+		return "Other" // TODO: SW should we include the actual word other?
 	default:
 		return string(use)
 	}

--- a/pkg/graph/resolvers/send_feedback_email.go
+++ b/pkg/graph/resolvers/send_feedback_email.go
@@ -108,7 +108,7 @@ func humanizeFeedbackMINTUse(use model.MintUses) string {
 	case model.MintUsesViewHelp:
 		return "To view the Help Center"
 	case model.MintUsesOther:
-		return "Other" // TODO: SW should we include the actual word other?
+		return "Other"
 	default:
 		return string(use)
 	}


### PR DESCRIPTION
## Changes and Description

- The email was displaying `Other` even if the input was an empty string. It also would not populate other if no optional text was populated.
- This will populate `Other`  even if no optional text is provided. It will also populate Other if it isn't selected but the optional usedForOther field is populated

## How to test this change
1. Send feedback without selecting other
2. Ensure that it isn't visible in the email
3. Send feedback with other and without optional text
4. Ensure it is visible in the email
5. Send feedback with optional text filled out, but the other option deselected
6. Ensure you can see the other value populated in the email.
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
