### PR TITLE
Email template standardization - 1

### DIFF
--- a/pkg/email/template_service_impl.go
+++ b/pkg/email/template_service_impl.go
@@ -70,8 +70,17 @@ var modelPlanShareSubjectTemplate string
 //go:embed templates/model_plan_share_body.html
 var modelPlanShareBodyTemplate string
 
+//go:embed templates/shared_style.html
+var sharedStyleTemplate string
+
+//go:embed templates/shared_header_old.html
+var sharedHeaderOldTemplate string
+
 //go:embed templates/shared_header.html
 var sharedHeaderTemplate string
+
+//go:embed templates/shared_footer.html
+var sharedFooterTemplate string
 
 // ReportAProblemTemplateName is the template name definition for the corresponding email template
 const ReportAProblemTemplateName string = "report_a_problem"
@@ -175,7 +184,10 @@ func (t *TemplateServiceImpl) loadEmailTemplate(emailTemplateName string, subjec
 	}
 
 	predefinedTemplates := map[string]string{
-		"shared_header.html": sharedHeaderTemplate,
+		"shared_style.html":      sharedStyleTemplate,
+		"shared_header.html":     sharedHeaderTemplate,
+		"shared_footer.html":     sharedFooterTemplate,
+		"shared_header_old.html": sharedHeaderOldTemplate,
 	}
 
 	err = t.templateCache.LoadHTMLTemplateFromString(bodyEmailTemplateName, bodyTemplate, predefinedTemplates)

--- a/pkg/email/templates/added_as_collaborator_body.html
+++ b/pkg/email/templates/added_as_collaborator_body.html
@@ -1,4 +1,4 @@
-{{template "shared_header.html"}}
+{{template "shared_header_old.html"}}
 
 <body>
   <h1>MINT</h1>

--- a/pkg/email/templates/model_plan_created_body.html
+++ b/pkg/email/templates/model_plan_created_body.html
@@ -1,4 +1,4 @@
-{{template "shared_header.html"}}
+{{template "shared_header_old.html"}}
 
 <body>
 <h1 style="padding-top: 3pt;">MINT</h1>

--- a/pkg/email/templates/model_plan_date_changed_body.html
+++ b/pkg/email/templates/model_plan_date_changed_body.html
@@ -1,4 +1,4 @@
-{{template "shared_header.html"}}
+{{template "shared_header_old.html"}}
 
 <body>
 <h1>MINT</h1>

--- a/pkg/email/templates/model_plan_share_body.html
+++ b/pkg/email/templates/model_plan_share_body.html
@@ -1,4 +1,4 @@
-{{template "shared_header.html"}}
+{{template "shared_header_old.html"}}
 
 <body>
 <h1 style="padding-top: 3pt;">MINT</h1>

--- a/pkg/email/templates/plan_discussion_created_body.html
+++ b/pkg/email/templates/plan_discussion_created_body.html
@@ -1,4 +1,4 @@
-{{template "shared_header.html"}}
+{{template "shared_header_old.html"}}
 
 <body>
   <h1>MINT</h1>

--- a/pkg/email/templates/send_feedback_body.html
+++ b/pkg/email/templates/send_feedback_body.html
@@ -1,159 +1,68 @@
-<!DOCTYPE  html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-  <title>Content</title>
-  <style type="text/css">
-    /* CSS Reset */
-    * body {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-      font-family: 'Public Sans', sans-serif;
-    }
+{{template "shared_header.html" "Feedback"}}
 
-    /* General */
-    body {
-      padding-left: 5px;
-      text-align: left;
-    }
+<h3>Reporter</h3>
 
-    /* Headings */
-    h1 {
-      font-size: 39pt;
-      font-weight: bold;
-      font-style: normal;
-      color: #1A1A1A;
-      text-decoration: none;
-      margin: 0;
-    }
+{{if .IsAnonymousSubmission }}
+  <p>Anonymous</p>
+{{else}}
+  <p>{{.ReporterName}}</p>
+  <a href="mailto:{{.ReporterEmail}}">{{.ReporterEmail}}</a>
+  <br />
+  <br />
+  {{if .AllowContact}}
+    <p>{{.AllowContact}}</p>
+  {{else}}
+    <i>User didn't specify if they could be contacted</i>
+  {{end}}
+{{end}}
 
-    h2 {
-      font-size: 2rem;
-      font-style: normal;
-      font-weight: 700;
-      line-height: 2.375rem; /* 118.75% */
-      margin: 0;
-    }
+<br />
+<hr />
 
-    h3 {
-      font-size: 1rem;
-      font-style: normal;
-      font-weight: 700;
-      line-height: 1.5625rem; /* 156.25% */
-      letter-spacing: -0.01rem;
-      margin: 0;
-    }
+<h3 style="padding-top: 14pt;">What is your role?</h3>
 
-    /* Subtitle */
-    .subtitle {
-      font-size: 15.5pt;
-      font-weight: normal;
-      font-style: normal;
-      color: #707579;
-      text-decoration: none;
-    }
+{{ if .CMSRole}}
+  <p>{{.CMSRole}}</p>
+{{else}}
+  <i>Left Blank</i>
+{{end}}
 
-    /* Paragraph */
-    p {
-      font-size: 1rem;
-      font-style: normal;
-      font-weight: 400;
-      line-height: 1.5625rem; /* 156.25% */
-      letter-spacing: -0.01rem;
-      margin: 0;
-    }
+<h3 style="padding-top: 14pt;">What have you used MINT for?</h3>
 
-    i {
-      font-size: 1rem;
-      font-weight: 400;
-      line-height: 1.5625rem; /* 156.25% */
-      letter-spacing: -0.01rem;
-    }
+{{ if .MINTUsedFor}}
+<ul>
+{{range $use := .MINTUsedFor}}
+<li>
+  {{$use}}
+</li>
+{{end}}
+</ul>
+{{else}}
+  <i>Left Blank</i>
+{{end}}
 
-    /* Links */
-    a {
-      font-size: 1rem;
-      font-style: normal;
-      font-weight: 400;
-      line-height: 1.5625rem;
-      letter-spacing: -0.01rem;
-      text-decoration-line: underline;
-    }
-    /* Lists */
-    ul,
-    li {
-      font-size: 1rem;
-      font-style: normal;
-      font-weight: 400;
-      line-height: 1.5625rem; /* 156.25% */
-      letter-spacing: -0.01rem;
-    }
-    ul {
-      padding: 10px 0 0 25px ;
-     }
-  </style>
-</head>
+<h3 style="padding-top: 14pt;">The system is easy to use.</h3>
 
-<body>
-    <h1 style="padding-top: 3pt;">MINT</h1>
-    <p class="subtitle" style="padding-top: 11pt;">The Model Innovation Tool</p>
-    <br/>
-    <h2 style="padding-top: 18pt">Feedback</h2>
-    <br />
-    <h3 style="padding-top: 14pt;">Reporter</h3>
-    {{if .IsAnonymousSubmission }}
-      <p>Anonymous</p>
-    {{else}}
-      <p>{{.ReporterName}}</p>
-      <a href="mailto:{{.ReporterEmail}}">{{.ReporterEmail}}</a>
-      <br />
-      <br />
-      {{if .AllowContact}}
-        <p>{{.AllowContact}}</p>
-      {{else}}
-        <i>User didn't specify if they could be contacted</i>
-      {{end}}
-    {{end}}
-    <br />
-    <hr />
-    <h3 style="padding-top: 14pt;">What is your role?</h3>
-    {{ if .CMSRole}}
-      <p>{{.CMSRole}}</p>
-    {{else}}
-      <i>Left Blank</i>
-    {{end}}
-    <h3 style="padding-top: 14pt;">What have you used MINT for?</h3>
-    {{ if .MINTUsedFor}}
-    <ul>
-    {{range $use := .MINTUsedFor}}
-    <li>
-      {{$use}}
-    </li>
-    {{end}}
-    </ul>
-    {{else}}
-      <i>Left Blank</i>
-    {{end}}
-    <h3 style="padding-top: 14pt;">The system is easy to use.</h3>
-    {{ if .SystemEasyToUse}}
-      <p>{{.SystemEasyToUse}}</p>
-    {{else}}
-      <i>Left Blank</i>
-    {{end}}
-    <h3 style="padding-top: 14pt;">Overall, how satisfied are you with MINT?</h3>
-    {{ if .HowSatisfied}}
-      <p>{{.HowSatisfied}}</p>
-    {{else}}
-      <i>Left Blank</i>
-    {{end}}
-    <h3 style="padding-top: 14pt;">How can we improve MINT?</h3>
-    {{ if .HowCanWeImprove}}
-      <p>{{.HowCanWeImprove}}</p>
-    {{else}}
-      <i>Left Blank</i>
-    {{end}}
-    
-    </body>
-    </html>
+{{ if .SystemEasyToUse}}
+  <p>{{.SystemEasyToUse}}</p>
+{{else}}
+  <i>Left Blank</i>
+{{end}}
+
+<h3 style="padding-top: 14pt;">Overall, how satisfied are you with MINT?</h3>
+
+{{ if .HowSatisfied}}
+  <p>{{.HowSatisfied}}</p>
+{{else}}
+  <i>Left Blank</i>
+{{end}}
+
+<h3 style="padding-top: 14pt;">How can we improve MINT?</h3>
+
+{{ if .HowCanWeImprove}}
+  <p>{{.HowCanWeImprove}}</p>
+{{else}}
+  <i>Left Blank</i>
+{{end}}
+
+{{template "shared_footer.html"}}

--- a/pkg/email/templates/shared_footer.html
+++ b/pkg/email/templates/shared_footer.html
@@ -1,0 +1,8 @@
+                        <br>
+                        <br>
+                    </div>
+                </td>
+            </tr>
+        </table>
+    </body>
+</html>

--- a/pkg/email/templates/shared_header.html
+++ b/pkg/email/templates/shared_header.html
@@ -1,132 +1,19 @@
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-  <title>Content</title>
-  <style type="text/css">
-    /* CSS Reset */
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
+{{template "shared_style.html"}}
 
-    /* General */
-    body {
-      padding-left: 5px;
-      text-align: left;
-    }
+<body>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0">
+      <tr>
+          <td align="center">      
 
-    /* Headings */
-    h1 {
-      font-size: 30pt;
-      font-weight: bold;
-      font-style: normal;
-      color: #1B1B1B;
-      font-family: 'Public Sans', sans-serif;
-      text-decoration: none;
-    }
+            <div class="container-border">
 
-    h2 {
-      font-size: 24pt;
-      font-weight: bold;
-      font-style: normal;
-      color: #1B1B1B;
-      font-family: 'Public Sans', sans-serif;
-      text-decoration: none;
-    }
+                <h1 style="padding-top: 3pt;">MINT</h1>
 
-    h3 {
-      font-size: 16.5pt;
-      font-weight: bold;
-      font-style: normal;
-      color: #1B1B1B;
-      font-family: 'Public Sans', sans-serif;
-      text-decoration: none;
-      line-height: 1.4;
-    }
+                <p class="subtitle">The Model Innovation Tool</p>
 
-    h5 {
-      font-size: 15px;
-      font-weight: normal;
-      font-style: normal;
-      color: #71767A;
-      font-family: 'Public Sans', sans-serif;
-      text-decoration: none;
-      line-height: 16px;
-      padding-top: 5px;
-    }
+                <br>
+                <br>
 
-    /* Subtitle */
-    .subtitle {
-      font-size: 15px;
-      font-weight: normal;
-      font-style: normal;
-      color: #71767A;
-      font-family: 'Public Sans', sans-serif;
-      text-decoration: none;
-      padding-top: 10px;
-    }
+                <h2>{{.}}</h2>
 
-    /* Paragraph */
-    p {
-      font-size: 16px;
-      font-weight: normal;
-      font-style: normal;
-      color: #1B1B1B;
-      font-family: 'Public Sans', sans-serif;
-      text-decoration: none;
-      line-height: 25px;
-    }
-
-    /* Span */
-    span {
-      font-size: 12pt;
-      font-weight: normal;
-      font-style: normal;
-      color: #1B1B1B;
-      font-family: 'Public Sans', sans-serif;
-      text-decoration: none;
-      line-height: 1.4;
-    }
-
-    /* Links */
-    a {
-      font-size: 12pt;
-      color: #005EA2;
-      font-family: 'Public Sans', sans-serif;
-      font-weight: bold;
-      line-height: 25px;
-    }
-
-    td {
-      white-space: normal;
-      word-wrap: break-word;
-    }
-
-    body {
-      padding: 40px 20px 20px 40px;
-    }
-
-    table {
-      border: 1px solid #E6E6E6;
-      border-radius: 6px;
-      padding: 20px;
-      display: inline-table;
-      width: 100%
-    }
-
-    .formatting-table {
-      width: 100%;
-      padding: 0;
-      border-radius: 0;
-      border: 0;
-    }
-
-    .blue-footer-table {
-      height: 120px;
-      padding: 15px 20px 20px 20px;
-      gap: 10px;
-      background: #E7F6F8;
-      display: inline-table;
-      border-radius: 0;
-    }
-  </style>
+                <br>

--- a/pkg/email/templates/shared_header_old.html
+++ b/pkg/email/templates/shared_header_old.html
@@ -1,0 +1,132 @@
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <title>Content</title>
+    <style type="text/css">
+      /* CSS Reset */
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+  
+      /* General */
+      body {
+        padding-left: 5px;
+        text-align: left;
+      }
+  
+      /* Headings */
+      h1 {
+        font-size: 30pt;
+        font-weight: bold;
+        font-style: normal;
+        color: #1B1B1B;
+        font-family: 'Public Sans', sans-serif;
+        text-decoration: none;
+      }
+  
+      h2 {
+        font-size: 24pt;
+        font-weight: bold;
+        font-style: normal;
+        color: #1B1B1B;
+        font-family: 'Public Sans', sans-serif;
+        text-decoration: none;
+      }
+  
+      h3 {
+        font-size: 16.5pt;
+        font-weight: bold;
+        font-style: normal;
+        color: #1B1B1B;
+        font-family: 'Public Sans', sans-serif;
+        text-decoration: none;
+        line-height: 1.4;
+      }
+  
+      h5 {
+        font-size: 15px;
+        font-weight: normal;
+        font-style: normal;
+        color: #71767A;
+        font-family: 'Public Sans', sans-serif;
+        text-decoration: none;
+        line-height: 16px;
+        padding-top: 5px;
+      }
+  
+      /* Subtitle */
+      .subtitle {
+        font-size: 15px;
+        font-weight: normal;
+        font-style: normal;
+        color: #71767A;
+        font-family: 'Public Sans', sans-serif;
+        text-decoration: none;
+        padding-top: 10px;
+      }
+  
+      /* Paragraph */
+      p {
+        font-size: 16px;
+        font-weight: normal;
+        font-style: normal;
+        color: #1B1B1B;
+        font-family: 'Public Sans', sans-serif;
+        text-decoration: none;
+        line-height: 25px;
+      }
+  
+      /* Span */
+      span {
+        font-size: 12pt;
+        font-weight: normal;
+        font-style: normal;
+        color: #1B1B1B;
+        font-family: 'Public Sans', sans-serif;
+        text-decoration: none;
+        line-height: 1.4;
+      }
+  
+      /* Links */
+      a {
+        font-size: 12pt;
+        color: #005EA2;
+        font-family: 'Public Sans', sans-serif;
+        font-weight: bold;
+        line-height: 25px;
+      }
+  
+      td {
+        white-space: normal;
+        word-wrap: break-word;
+      }
+  
+      body {
+        padding: 40px 20px 20px 40px;
+      }
+  
+      table {
+        border: 1px solid #E6E6E6;
+        border-radius: 6px;
+        padding: 20px;
+        display: inline-table;
+        width: 100%
+      }
+  
+      .formatting-table {
+        width: 100%;
+        padding: 0;
+        border-radius: 0;
+        border: 0;
+      }
+  
+      .blue-footer-table {
+        height: 120px;
+        padding: 15px 20px 20px 20px;
+        gap: 10px;
+        background: #E7F6F8;
+        display: inline-table;
+        border-radius: 0;
+      }
+    </style>

--- a/pkg/email/templates/shared_style.html
+++ b/pkg/email/templates/shared_style.html
@@ -1,0 +1,161 @@
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <title>Content</title>
+  <style type="text/css">
+
+    /* CSS Reset */
+    * html {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    * body {
+      font-family: 'Public Sans', sans-serif;
+      font-style: normal;
+      font-weight: 400;
+      color: #1B1B1B;
+    }
+
+    /* GENERAL */
+
+    body {
+      padding: 40px 20px 20px 40px;
+      text-align: left;      
+    }
+
+    /* HEADERS */
+    
+    /* easi/h1 */
+    h1 {      
+      font-size: 2.5rem;
+      font-weight: 700;
+      line-height: 3.125rem; /* 125% */
+      margin-top: 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+
+    /* easi/h2 */
+    h2 {
+      font-size: 2rem;
+      font-weight: 700;
+      line-height: 2.375rem; /* 118.75% */
+      margin-top: 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+
+    /* easi/h3 */
+    h3 {
+      font-size: 1.375rem;
+      font-weight: 700;
+      line-height: 1.625rem; /* 118.182% */
+      margin-top: 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+
+    /* easi/h5 */
+    h5 {
+      font-size: 0.9375rem;
+      line-height: 1rem; /* 106.667% */
+    }
+
+    /* BODY */
+
+    /* easi/body */
+    p {
+      font-size: 1rem;
+      line-height: 1.5625rem; /* 156.25% */
+      letter-spacing: -0.01rem;
+      margin: 0;
+    }
+
+    i {
+      font-size: 1rem;
+      line-height: 1.5625rem; /* 156.25% */
+      letter-spacing: -0.01rem;
+      margin: 0;
+    }
+
+    
+    /* LINKS */
+
+    /* easi/body bold underline */
+    a {
+      color: #005EA2;
+      font-size: 1rem;
+      font-weight: 700;
+      line-height: 1.5625rem; /* 156.25% */
+      letter-spacing: -0.01rem;
+      text-decoration-line: underline;
+      margin: 0;
+    }
+
+
+    /* LISTS */
+    ul,
+    li {
+      font-size: 1rem;
+      line-height: 1.5625rem; /* 156.25% */
+      letter-spacing: -0.01rem;
+    }
+
+    ul {
+      padding: 10px 0 0 25px ;
+    }
+
+    /* TABLE */
+    td {
+      white-space: normal;
+      word-wrap: break-word;
+    }
+
+    table {
+      padding: 20px;
+      display: inline-table;
+      width: 100%
+    }
+
+    /* UTIL */
+    .bold {      
+      font-weight: 700;
+    }
+
+    /* easi/body medium */
+    .body-med {      
+      font-size: 1.0625rem;
+      font-weight: 300;
+    }
+
+    /* MISC CLASSES */
+
+    /* default scale/xs */
+    .subtitle {
+      font-size: 0.9375rem;
+      line-height: normal;
+      color: #71767A;
+    }
+
+    .container-border {
+      border: 1px solid #E6E6E6;
+      border-radius: 6px;
+      max-width: 500px;
+      padding: 1rem;
+      text-align: left;
+    }
+
+    .formatting-table {
+      width: 100%;
+      padding: 0;
+      border-radius: 0;
+      border: 0;
+    }
+
+    .blue-footer-table {
+      height: 120px;
+      padding: 15px 20px 20px 20px;
+      gap: 10px;
+      background: #E7F6F8;
+      display: inline-table;
+      border-radius: 0;
+    }
+  </style>


### PR DESCRIPTION
# NOREF

## Changes and Description

- Renamed and standardized styling into own html template
- Created template for header and footer
- Implemented new style template only for `send_feedback_body.html`
- Header template now take in a parameter for header name - ex: `{{template "shared_header.html" "Feedback"}}`

This is part one to be merged into this noref/feature branch.  The subsequent email templates will be worked on next.

## How to test this change

Complete the submit feedback form and verify email styling matches figma

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
