### PR TITLE
[NOREF] GA tracking id env var

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -20,6 +20,7 @@ export VITE_GRAPHQL_ADDRESS=$CLIENT_PROTOCOL://$CLIENT_DOMAIN:$API_PORT/api/grap
 export VITE_APP_ENV=$APP_ENV
 export LOCAL_AUTH_ENABLED=true
 export VITE_LOCAL_AUTH_ENABLED=true
+export VITE_GA_TRACKING_ID=G-WDNFWR6RD3 # This, by default points to the `MINT (Localhost)` environment. We do NOT recommend changing this value.
 
 # Email variables
 export EMAIL_ENABLED=true

--- a/.github/workflows/build_frontend_assets.yml
+++ b/.github/workflows/build_frontend_assets.yml
@@ -41,6 +41,7 @@ jobs:
           OKTA_SERVER_ID: ${{ secrets.OKTA_SERVER_ID }}
           STATIC_S3_BUCKET: ${{ secrets.STATIC_S3_BUCKET }}
           VITE_BEACON_ID: ${{ secrets.VITE_BEACON_ID }}
+          VITE_GA_TRACKING_ID: ${{ secrets.VITE_GA_TRACKING_ID }}
         run: |
           ./scripts/build_static.sh
       - name: Upload Frontend assets

--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -21,6 +21,7 @@ services:
       - VITE_LD_CLIENT_ID
       - VITE_LOCAL_AUTH_ENABLED
       - VITE_BEACON_ID
+      - VITE_GA_TRACKING_ID
     volumes:
       - .:/app
       - /app/node_modules # Create an empty volume to override node_modules from the local filesystem (we always want to use the node_modules from the container)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,13 +30,16 @@ import './index.scss';
 
 const apiHost = new URL(import.meta.env.VITE_API_ADDRESS || '').host;
 
-ReactGA.initialize([
-  {
-    trackingId: 'G-45PX7VBWQK',
-    gaOptions: {}, // optional
-    gtagOptions: {} // optional
-  }
-]);
+const trackingID = import.meta.env.VITE_GA_TRACKING_ID;
+if (trackingID) {
+  ReactGA.initialize([
+    {
+      trackingId: trackingID,
+      gaOptions: {}, // optional
+      gtagOptions: {} // optional
+    }
+  ]);
+}
 
 /**
  * Extract auth token from local storage and return a header


### PR DESCRIPTION
# NOREF

## Changes and Description

- Introduces environment variable to configure per-env GA Tracking IDs
- Adds a default value to track data when developing locally (uses a different property / tracking ID than any of the other envs)

## How to test this change

- Start the server locally
- Use the app
- Navigate to GA and see if data is ingested under the `MINT (Localhost)` property

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
