### PR TITLE
[EASI-3238] - Removed share export ld flag

### DIFF
--- a/src/components/ShareExport/__snapshots__/index.test.tsx.snap
+++ b/src/components/ShareExport/__snapshots__/index.test.tsx.snap
@@ -142,6 +142,13 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                   >
                     Filter
                   </button>
+                  <button
+                    class="usa-button usa-button--outline text-white shadow-none border-white border-2px"
+                    data-testid="button"
+                    type="button"
+                  >
+                    Share or export
+                  </button>
                 </div>
               </div>
             </div>
@@ -6351,6 +6358,13 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     type="button"
                   >
                     Filter
+                  </button>
+                  <button
+                    class="usa-button usa-button--outline text-white shadow-none border-white border-2px"
+                    data-testid="button"
+                    type="button"
+                  >
+                    Share or export
                   </button>
                 </div>
               </div>

--- a/src/types/flags.ts
+++ b/src/types/flags.ts
@@ -2,7 +2,6 @@ export type Flags = {
   hideITLeadExperience: boolean;
   downgradeAssessmentTeam: boolean;
   hideGroupView: boolean;
-  shareExportEnabled: boolean;
   helpScoutEnabled: boolean;
   feedbackEnabled: boolean;
 };

--- a/src/utils/user.test.ts
+++ b/src/utils/user.test.ts
@@ -42,7 +42,6 @@ describe('user', () => {
             downgradeAssessmentTeam: true,
             hideITLeadExperience: false,
             hideGroupView: true,
-            shareExportEnabled: false,
             helpScoutEnabled: false,
             feedbackEnabled: false
           })

--- a/src/views/FlagsWrapper/index.tsx
+++ b/src/views/FlagsWrapper/index.tsx
@@ -36,7 +36,6 @@ const UserTargetingWrapper = ({ children }: WrapperProps) => {
             hideITLeadExperience: true,
             downgradeAssessmentTeam: false,
             hideGroupView: true,
-            shareExportEnabled: false,
             helpScoutEnabled: false,
             feedbackEnabled: false
           }

--- a/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
@@ -303,6 +303,13 @@ exports[`Read Only Model Plan Summary > matches snapshot 1`] = `
               >
                 Filter
               </button>
+              <button
+                class="usa-button usa-button--outline text-white shadow-none border-white border-2px"
+                data-testid="button"
+                type="button"
+              >
+                Share or export
+              </button>
             </div>
           </div>
         </div>

--- a/src/views/ModelPlan/ReadOnly/_components/FilterView/Banner/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterView/Banner/__snapshots__/index.test.tsx.snap
@@ -63,6 +63,13 @@ exports[`Filter View Modal > matches snapshot 1`] = `
             >
               Filter
             </button>
+            <button
+              class="usa-button usa-button--outline text-white shadow-none border-white border-2px"
+              data-testid="button"
+              type="button"
+            >
+              Share or export
+            </button>
           </div>
         </div>
       </div>

--- a/src/views/ModelPlan/ReadOnly/_components/FilterView/Banner/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/FilterView/Banner/index.tsx
@@ -7,7 +7,6 @@ import {
   IconInfo,
   IconVisiblity
 } from '@trussworks/react-uswds';
-import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import Tooltip from 'components/shared/Tooltip';
 
@@ -30,8 +29,6 @@ const FilterViewBanner = ({
   const { t: generalReadOnlyT } = useTranslation('generalReadOnly');
 
   const history = useHistory();
-
-  const flags = useFlags();
 
   return (
     <div
@@ -76,15 +73,13 @@ const FilterViewBanner = ({
                 {t('filterButton')}
               </Button>
 
-              {flags.shareExportEnabled && (
-                <Button
-                  type="button"
-                  className="usa-button--outline text-white shadow-none border-white border-2px"
-                  onClick={openExportModal}
-                >
-                  {generalReadOnlyT('shareExport')}
-                </Button>
-              )}
+              <Button
+                type="button"
+                className="usa-button--outline text-white shadow-none border-white border-2px"
+                onClick={openExportModal}
+              >
+                {generalReadOnlyT('shareExport')}
+              </Button>
             </div>
           </div>
         </div>

--- a/src/views/ModelPlan/TaskList/_components/TaskListSideNav/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/_components/TaskListSideNav/__snapshots__/index.test.tsx.snap
@@ -20,16 +20,13 @@ exports[`The TaskListSideNavActions > matches snapshot 1`] = `
     <div
       class="flex-align-self-center margin-y-2"
     >
-      <div>
-        <button
-          class="usa-button usa-button--unstyled display-flex"
-          type="button"
-        >
-          <span>
-            Download this Model Plan (CSV)
-          </span>
-        </button>
-      </div>
+      <button
+        class="usa-button usa-button--unstyled"
+        data-testid="button"
+        type="button"
+      >
+        Share or export this model plan
+      </button>
     </div>
     <button
       class="usa-button usa-button--unstyled line-height-body-5 test-withdraw-request text-red"

--- a/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.tsx
+++ b/src/views/ModelPlan/TaskList/_components/TaskListSideNav/index.tsx
@@ -3,7 +3,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
 import { Button } from '@trussworks/react-uswds';
-import { useFlags } from 'launchdarkly-react-client-sdk';
 
 import UswdsReactLink from 'components/LinkWrapper';
 import Modal from 'components/Modal';
@@ -17,7 +16,6 @@ import { GetModelCollaborators_modelPlan_collaborators as GetCollaboratorsType }
 import { ArchiveModelPlanVariables } from 'queries/types/ArchiveModelPlan';
 import { GetModelPlan_modelPlan as GetModelPlanType } from 'queries/types/GetModelPlan';
 import { TeamRole } from 'types/graphql-global-types';
-import CsvExportLink from 'utils/export/CsvExportLink';
 
 import { StatusMessageType } from '../..';
 
@@ -31,8 +29,6 @@ const TaskListSideNav = ({
   setStatusMessage: (message: StatusMessageType) => void;
 }) => {
   const { id: modelID } = modelPlan;
-
-  const flags = useFlags();
 
   const history = useHistory();
 
@@ -141,21 +137,15 @@ const TaskListSideNav = ({
           {t('sideNav.readOnlyView')}
         </UswdsReactLink>
 
-        {flags.shareExportEnabled ? (
-          <div className="flex-align-self-center margin-y-2">
-            <Button
-              type="button"
-              className="usa-button--unstyled"
-              onClick={() => setIsExportModalOpen(true)}
-            >
-              {generalReadOnlyT('shareExportLink')}
-            </Button>
-          </div>
-        ) : (
-          <div className="flex-align-self-center margin-y-2">
-            <CsvExportLink modelPlanID={modelID} />
-          </div>
-        )}
+        <div className="flex-align-self-center margin-y-2">
+          <Button
+            type="button"
+            className="usa-button--unstyled"
+            onClick={() => setIsExportModalOpen(true)}
+          >
+            {generalReadOnlyT('shareExportLink')}
+          </Button>
+        </div>
 
         <Button
           className="line-height-body-5 test-withdraw-request text-red"


### PR DESCRIPTION
# EASI-3238

## Changes and Description

- Removed instances of `shareExportEnabled` LD flag
- Updated snaps
<!-- Put a description here! -->

## How to test this change

Verify Share/Export behaves the same

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
