### PR TITLE
[EASI-3488] - Fixed missing read more link on model summary

### DIFF
--- a/src/components/shared/CollapsableLink/index.tsx
+++ b/src/components/shared/CollapsableLink/index.tsx
@@ -19,6 +19,7 @@ type CollapsableLinkProps = {
   eyeIcon?: boolean;
   iconPosition?: 'left' | 'right';
   startOpen?: boolean;
+  showDescription?: (show: boolean) => void;
   labelPosition?: 'top' | 'bottom';
 };
 
@@ -32,6 +33,7 @@ const CollapsableLink = ({
   eyeIcon,
   iconPosition,
   startOpen = false,
+  showDescription,
   labelPosition = 'top'
 }: CollapsableLinkProps) => {
   // TODO: should this state instead be held in the parent and passed in as prop?
@@ -61,7 +63,10 @@ const CollapsableLink = ({
   const collapseButton: React.ReactNode = (
     <Button
       type="button"
-      onClick={() => setOpen(!isOpen)}
+      onClick={() => {
+        setOpen(!isOpen);
+        if (showDescription) showDescription(!isOpen);
+      }}
       aria-expanded={isOpen}
       aria-controls={id}
       className={className}

--- a/src/views/ModelPlan/ReadOnly/_components/ModelSummary/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/ModelSummary/index.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Grid, IconExpandMore } from '@trussworks/react-uswds';
 import classnames from 'classnames';
@@ -19,9 +19,7 @@ import { formatDateLocal } from 'utils/date';
 type ModelSummaryProps = {
   characteristics: CharacteristicsType;
   crTdls: CRTDLsTypes[] | null;
-  descriptionRef: RefObject<HTMLElement>;
   goal: string;
-  isDescriptionExpandable: boolean;
   loading: boolean;
   modelLeads: CollaboratorsType[];
   modelName: string;
@@ -31,9 +29,7 @@ type ModelSummaryProps = {
 const ModelSummary = ({
   characteristics,
   crTdls,
-  descriptionRef,
   goal,
-  isDescriptionExpandable,
   loading,
   modelLeads,
   modelName,
@@ -74,6 +70,25 @@ const ModelSummary = ({
     return idNumbers.join(', ');
   };
 
+  const descriptionRef = React.createRef<HTMLElement>();
+
+  const [
+    isDescriptionExpandable,
+    setIsDescriptionExpandable
+  ] = useState<boolean>(false);
+
+  const [descriptionOpen, isDescriptionOpen] = useState<boolean>(false);
+
+  // Enable the description toggle if it overflows
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    const { current: el } = descriptionRef;
+    if (!el) return;
+    if (el.scrollHeight > el.offsetHeight) {
+      setIsDescriptionExpandable(true);
+    }
+  }, [descriptionRef, descriptionOpen]);
+
   return (
     <CollapsableLink
       className="margin-top-3 padding-0"
@@ -82,6 +97,7 @@ const ModelSummary = ({
       closeLabel={h('hideSummary')}
       styleLeftBar={false}
       id={`${modelName?.replace(/\s+/g, '-').toLowerCase()}--description`}
+      showDescription={isDescriptionOpen}
       label={h('showSummary')}
     >
       <div

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RootStateOrAny, useSelector } from 'react-redux';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
@@ -212,13 +212,6 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   // Used to check if user is assessment for rendering subnav to task list
   const { groups } = useSelector((state: RootStateOrAny) => state.auth);
 
-  const descriptionRef = React.createRef<HTMLElement>();
-
-  const [
-    isDescriptionExpandable,
-    setIsDescriptionExpandable
-  ] = useState<boolean>(false);
-
   const [statusMessage, setStatusMessage] = useState<StatusMessageType | null>(
     null
   );
@@ -228,16 +221,6 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
   );
 
   const [isExportModalOpen, setIsExportModalOpen] = useState<boolean>(false);
-
-  // Enable the description toggle if it overflows
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    const { current: el } = descriptionRef;
-    if (!el) return;
-    if (el.scrollHeight > el.offsetHeight) {
-      setIsDescriptionExpandable(true);
-    }
-  });
 
   const { data, loading, error, refetch } = useQuery<GetModelSummaryType>(
     GetModelSummary,
@@ -369,11 +352,9 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
         {!isViewingFilteredGroup && (
           <div className="mint-no-print">
             <ModelSummary
-              descriptionRef={descriptionRef}
               goal={basics?.goal ?? ''}
               loading={loading}
               modelName={modelName}
-              isDescriptionExpandable={isDescriptionExpandable}
               characteristics={generalCharacteristics}
               performancePeriodStarts={basics?.performancePeriodStarts}
               modelLeads={collaborators?.filter(


### PR DESCRIPTION
# EASI-3488

## Changes and Description

The `Read more` link in the model summary was not rendering on load.  This work moves the logic for controlling the state of expanded description to rerender when the summary is collapsed/shown

- Fixed the link in model summary to read more

<!-- Put a description here! -->

## How to test this change

Verify the read more link for long descriptions renders
To get a long description, populate the Goals textarea in model basics

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
