### PR TITLE
[EASI-3590] - Discussion order fix

### DIFF
--- a/pkg/email/templates/plan_discussion_tagged_solution_body.html
+++ b/pkg/email/templates/plan_discussion_tagged_solution_body.html
@@ -14,7 +14,7 @@
         <p class="subtitle"> {{.Role}}</p>
         <p>{{.DiscussionContent}}</p>
         <p style="font-weight: normal">
-          <a href="{{.ClientAddress}}/models/{{.ModelID}}/task-list?discussionID={{.DiscussionID}}">
+          <a href="{{.ClientAddress}}/models/{{.ModelID}}/read-only/discussions?discussionID={{.DiscussionID}}">
             Respond to this discussion in MINT
           </a>
         </p>

--- a/pkg/email/templates/plan_discussion_tagged_user_body.html
+++ b/pkg/email/templates/plan_discussion_tagged_user_body.html
@@ -14,7 +14,7 @@
         <p class="subtitle"> {{.Role}}</p>
         <p>{{.DiscussionContent}}</p>
         <p style="font-weight: normal">
-          <a href="{{.ClientAddress}}/models/{{.ModelID}}/task-list?discussionID={{.DiscussionID}}">
+          <a href="{{.ClientAddress}}/models/{{.ModelID}}/read-only/discussions?discussionID={{.DiscussionID}}">
             Respond to this discussion in MINT
           </a>
         </p>

--- a/pkg/storage/SQL/discussion_reply/get_by_discussion_id_LOADER.sql
+++ b/pkg/storage/SQL/discussion_reply/get_by_discussion_id_LOADER.sql
@@ -18,4 +18,5 @@ SELECT
     discR.modified_by,
     discR.modified_dts
 FROM QUERIED_IDS AS qIDs
-INNER JOIN discussion_reply AS discR ON discR.discussion_id = qIDs.discussion_id;
+INNER JOIN discussion_reply AS discR ON discR.discussion_id = qIDs.discussion_id
+ORDER BY discR.created_dts ASC;

--- a/pkg/storage/SQL/discussion_reply/get_by_id.sql
+++ b/pkg/storage/SQL/discussion_reply/get_by_id.sql
@@ -11,3 +11,4 @@ SELECT
     modified_dts
 FROM discussion_reply
 WHERE id = :id
+ORDER BY created_dts ASC

--- a/pkg/storage/SQL/plan_discussion/get_by_model_plan_id_LOADER.sql
+++ b/pkg/storage/SQL/plan_discussion/get_by_model_plan_id_LOADER.sql
@@ -18,4 +18,5 @@ SELECT
     disc.modified_by,
     disc.modified_dts
 FROM QUERIED_IDS AS qIDs
-INNER JOIN plan_discussion AS disc ON disc.model_plan_id = qIDs.model_plan_id;
+INNER JOIN plan_discussion AS disc ON disc.model_plan_id = qIDs.model_plan_id
+ORDER BY disc.created_dts DESC;

--- a/src/i18n/en-US/draftModelPlan/discussions.ts
+++ b/src/i18n/en-US/draftModelPlan/discussions.ts
@@ -55,6 +55,8 @@ const discussions = {
   assessment: 'MINT Team',
   viewMoreQuestions: 'View more questions',
   viewFewerQuestions: 'View fewer questions',
+  viewMoreReplies: 'View more replies',
+  viewFewerReplies: 'View fewer replies',
   alreadyAnswered:
     '“{{-question}}” has already been answered. You can view it in the answered questions below.',
   role: 'Your role',

--- a/src/views/ModelPlan/Discussions/QuestionAndReply.tsx
+++ b/src/views/ModelPlan/Discussions/QuestionAndReply.tsx
@@ -114,7 +114,10 @@ const QuestionAndReply = ({
             </div>
           </div>
 
-          <Replies originalDiscussion={reply as DiscussionType} />
+          <Replies
+            originalDiscussion={reply as DiscussionType}
+            discussionReplyID={discussionReplyID}
+          />
 
           <PageHeading
             headingLevel="h2"

--- a/src/views/ModelPlan/Discussions/Replies/index.tsx
+++ b/src/views/ModelPlan/Discussions/Replies/index.tsx
@@ -101,8 +101,8 @@ const Replies = ({
                 onClick={() => setIsAccordionExpanded(!isAccordionExpanded)}
               >
                 {isAccordionExpanded
-                  ? discussionsT('viewFewerQuestions')
-                  : discussionsT('viewMoreQuestions')}
+                  ? discussionsT('viewFewerReplies')
+                  : discussionsT('viewMoreReplies')}
               </Button>
             </SectionWrapper>
           )}

--- a/src/views/ModelPlan/Discussions/Replies/index.tsx
+++ b/src/views/ModelPlan/Discussions/Replies/index.tsx
@@ -13,14 +13,20 @@ import { GetModelPlanDiscussions_modelPlan_discussions as DiscussionType } from 
 import DiscussionUserInfo from '../_components/DiscussionUserInfo';
 
 const Replies = ({
-  originalDiscussion: { replies }
+  originalDiscussion: { replies },
+  discussionReplyID
 }: {
   originalDiscussion: DiscussionType;
+  discussionReplyID?: string | null | undefined;
 }) => {
   const { t: discussionsT } = useTranslation('discussions');
 
-  const [areRepliesShowing, setAreRepliesShowing] = useState(true);
-  const [isAccordionExpanded, setIsAccordionExpanded] = useState(false);
+  const [areRepliesShowing, setAreRepliesShowing] = useState<boolean>(true);
+
+  // If opening from email, auto-expand all replies
+  const [isAccordionExpanded, setIsAccordionExpanded] = useState<boolean>(
+    !!discussionReplyID
+  );
 
   const hasReplies = replies.length > 0;
   const repliesList = isAccordionExpanded ? replies : replies.slice(0, 4);

--- a/src/views/ModelPlan/Discussions/index.tsx
+++ b/src/views/ModelPlan/Discussions/index.tsx
@@ -123,6 +123,8 @@ const Discussions = ({
     );
 
     if (discussionToReply && !loading) {
+      setIsDiscussionOpen(true);
+      setDiscussionType('reply');
       setReply(discussionToReply);
     }
   }, [discussionReplyID, discussions, loading]);

--- a/src/views/ModelPlan/ReadOnly/Discussions/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/Discussions/index.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 
 import Discussions from 'views/ModelPlan/Discussions';
 
 const ReadOnlyDiscussions = ({ modelID }: { modelID: string }) => {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  const discussionID = params.get('discussionID');
+
   return (
     <div
       className="read-only-model-plan--discussions"
       data-testid="read-only-model-plan--discussions"
     >
-      <Discussions modelID={modelID} readOnly />
+      <Discussions modelID={modelID} readOnly discussionID={discussionID} />
     </div>
   );
 };


### PR DESCRIPTION
# EASI-3590

## Changes and Description

- Ensured discussion/reply correct sorting through GQL
  - Discussions should be sorted newest to oldest
  - Replies should be sorted oldest to newest
- Fixes incorrect translation - `View more replies`
- Changed email to open discussion in readonly section for tagged users
- Auto expand replies when opened from email

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
