### PR TITLE
[NOREF] - Resolved react warning for error values passed to native elements

### DIFF
--- a/src/components/shared/FieldGroup/index.tsx
+++ b/src/components/shared/FieldGroup/index.tsx
@@ -20,6 +20,7 @@ const FieldGroup = ({
     { 'usa-form-group--error': error },
     className
   );
+
   return (
     <div className={fieldGroupClasses} data-scroll={scrollElement} {...props}>
       {children}

--- a/src/views/ModelPlan/CRTDL/AddCRTDL/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/CRTDL/AddCRTDL/__snapshots__/index.test.tsx.snap
@@ -118,7 +118,6 @@ exports[`Model Plan Add CR and TDL page > matches snapshot 1`] = `
                         aria-hidden="true"
                         class="usa-input usa-sr-only usa-date-picker__internal-input"
                         data-testid="date-picker-internal-input"
-                        error="0"
                         maxlength="50"
                         name="dateInitiated"
                         readonly=""
@@ -133,7 +132,6 @@ exports[`Model Plan Add CR and TDL page > matches snapshot 1`] = `
                         <input
                           class="usa-input usa-date-picker__external-input"
                           data-testid="date-picker-external-input"
-                          error="0"
                           id="cr-tdl-date-initiated"
                           maxlength="50"
                           type="text"

--- a/src/views/ModelPlan/CRTDL/AddCRTDL/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/CRTDL/AddCRTDL/__snapshots__/index.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`Model Plan Add CR and TDL page > matches snapshot 1`] = `
                         aria-hidden="true"
                         class="usa-input usa-sr-only usa-date-picker__internal-input"
                         data-testid="date-picker-internal-input"
+                        error="0"
                         maxlength="50"
                         name="dateInitiated"
                         readonly=""
@@ -132,6 +133,7 @@ exports[`Model Plan Add CR and TDL page > matches snapshot 1`] = `
                         <input
                           class="usa-input usa-date-picker__external-input"
                           data-testid="date-picker-external-input"
+                          error="0"
                           id="cr-tdl-date-initiated"
                           maxlength="50"
                           type="text"

--- a/src/views/ModelPlan/CRTDL/AddCRTDL/index.tsx
+++ b/src/views/ModelPlan/CRTDL/AddCRTDL/index.tsx
@@ -296,6 +296,7 @@ const AddCRTDL = () => {
                                 <Field
                                   as={DatePicker}
                                   id="cr-tdl-date-initiated"
+                                  error={+!!flatErrors.dateInitiated}
                                   data-testid="cr-tdl-date-initiated"
                                   maxLength={50}
                                   name="dateInitiated"

--- a/src/views/ModelPlan/CRTDL/AddCRTDL/index.tsx
+++ b/src/views/ModelPlan/CRTDL/AddCRTDL/index.tsx
@@ -268,7 +268,6 @@ const AddCRTDL = () => {
                             <FieldErrorMsg>{flatErrors.idNumber}</FieldErrorMsg>
                             <Field
                               as={TextInput}
-                              error={!!flatErrors.idNumber}
                               id="cr-tdl-id-number"
                               data-testid="cr-tdl-id-number"
                               maxLength={50}
@@ -296,7 +295,6 @@ const AddCRTDL = () => {
                               <div className="width-card-lg position-relative">
                                 <Field
                                   as={DatePicker}
-                                  error={+!!flatErrors.dateInitiated}
                                   id="cr-tdl-date-initiated"
                                   data-testid="cr-tdl-date-initiated"
                                   maxLength={50}
@@ -327,7 +325,6 @@ const AddCRTDL = () => {
                             <FieldErrorMsg>{flatErrors.title}</FieldErrorMsg>
                             <Field
                               as={TextAreaField}
-                              error={!!flatErrors.title}
                               className="maxw-none mint-textarea"
                               id="cr-tdl-title"
                               data-testid="cr-tdl-title"
@@ -348,7 +345,6 @@ const AddCRTDL = () => {
                             <Field
                               as={Textarea}
                               className="height-15"
-                              error={flatErrors.note}
                               id="cr-tdl-note"
                               data-testid="cr-tdl-note"
                               value={values.note || ''}

--- a/src/views/ModelPlan/NewPlan/index.tsx
+++ b/src/views/ModelPlan/NewPlan/index.tsx
@@ -125,7 +125,6 @@ const NewPlanContent = () => {
 
                       <Field
                         as={TextInput}
-                        error={!!flatErrors.modelName}
                         id="new-plan-model-name"
                         maxLength={50}
                         name="modelName"

--- a/src/views/ModelPlan/TaskList/Basics/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/index.tsx
@@ -291,7 +291,6 @@ const BasicsContent = () => {
 
                           <Field
                             as={TextInput}
-                            error={!!flatErrors.modelName}
                             id="plan-basics-model-name"
                             maxLength={50}
                             name="modelName"
@@ -317,7 +316,6 @@ const BasicsContent = () => {
 
                           <Field
                             as={TextInput}
-                            error={!!flatErrors.abbreviation}
                             id="plan-basics-abbreviation"
                             maxLength={50}
                             name="abbreviation"
@@ -371,7 +369,6 @@ const BasicsContent = () => {
 
                                 <Field
                                   as={TextInput}
-                                  error={!!flatErrors['basics.amsModelID']}
                                   id="plan-basics-ams-model-id"
                                   maxLength={50}
                                   name="basics.amsModelID"
@@ -394,7 +391,6 @@ const BasicsContent = () => {
 
                                 <Field
                                   as={TextInput}
-                                  error={!!flatErrors['basics.demoCode']}
                                   id="plan-basics-demo-code"
                                   maxLength={50}
                                   name="basics.demoCode"

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/KeyCharacteristics/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/KeyCharacteristics/index.tsx
@@ -380,7 +380,6 @@ const KeyCharacteristics = () => {
                       <Field
                         as={TextInput}
                         data-testid="plan-characteristics-key-other"
-                        error={!!flatErrors.keyCharacteristicsOther}
                         id="plan-characteristics-key-other"
                         maxLength={50}
                         name="keyCharacteristicsOther"

--- a/src/views/ModelPlan/TaskList/ITSolutions/AddCustomSolution/index.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/AddCustomSolution/index.tsx
@@ -321,7 +321,6 @@ const AddCustomSolution = () => {
 
                                 <Field
                                   as={TextInput}
-                                  error={!!flatErrors.nameOther}
                                   id="it-solution-custom-name-other"
                                   data-testid="it-solution-custom-name-other"
                                   maxLength={50}
@@ -347,7 +346,6 @@ const AddCustomSolution = () => {
 
                                 <Field
                                   as={TextInput}
-                                  error={!!flatErrors.otherHeader}
                                   id="it-solution-other-header"
                                   data-testid="it-solution-other-header"
                                   maxLength={50}
@@ -376,7 +374,6 @@ const AddCustomSolution = () => {
 
                               <Field
                                 as={TextInput}
-                                error={!!flatErrors.pocName}
                                 id="it-solution-custom-poc-name"
                                 data-testid="it-solution-custom-poc-name"
                                 maxLength={50}
@@ -403,7 +400,6 @@ const AddCustomSolution = () => {
 
                               <Field
                                 as={TextInput}
-                                error={!!flatErrors.pocEmail}
                                 id="it-solution-custom-poc-email"
                                 data-testid="it-solution-custom-poc-email"
                                 maxLength={50}

--- a/src/views/ModelPlan/TaskList/ITSolutions/Subtasks/index.tsx
+++ b/src/views/ModelPlan/TaskList/ITSolutions/Subtasks/index.tsx
@@ -441,7 +441,6 @@ const Subtasks = ({
                                           </FieldErrorMsg>
                                           <Field
                                             as={TextInput}
-                                            error={!!flatErrors.name}
                                             id={`subtask-name--${index}`}
                                             data-testid={`subtask-name--${index}`}
                                             maxLength={50}

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOC/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOC/index.tsx
@@ -337,7 +337,6 @@ const IDDOC = () => {
 
                     <Field
                       as={TextInput}
-                      error={!!flatErrors.icdOwner}
                       id="ops-eval-and-learning-capture-icd-owner"
                       data-testid="ops-eval-and-learning-capture-icd-owner"
                       maxLength={50}

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCMonitoring/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCMonitoring/index.tsx
@@ -360,7 +360,6 @@ const IDDOCMonitoring = () => {
 
                     <Field
                       as={TextInput}
-                      error={!!flatErrors.fileNamingConventions}
                       id="ops-eval-and-learning-file-naming-convention"
                       data-testid="ops-eval-and-learning-file-naming-convention"
                       maxLength={50}

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCTesting/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCTesting/index.tsx
@@ -237,7 +237,6 @@ const IDDOCTesting = () => {
                     <Field
                       as={TextAreaField}
                       className="height-15"
-                      error={flatErrors.uatNeeds}
                       id="ops-eval-and-learning-uat-needs"
                       name="uatNeeds"
                     />
@@ -257,7 +256,6 @@ const IDDOCTesting = () => {
                     <Field
                       as={TextAreaField}
                       className="height-15"
-                      error={flatErrors.stcNeeds}
                       id="ops-eval-and-learning-stc-needs"
                       data-testid="ops-eval-and-learning-stc-needs"
                       name="stcNeeds"
@@ -278,7 +276,6 @@ const IDDOCTesting = () => {
                     <Field
                       as={TextAreaField}
                       className="height-15"
-                      error={flatErrors.testingTimelines}
                       id="ops-eval-and-learning-testing-timelines"
                       name="testingTimelines"
                     />
@@ -380,7 +377,6 @@ const IDDOCTesting = () => {
 
                     <Field
                       as={TextInput}
-                      error={!!flatErrors.dataResponseType}
                       id="ops-eval-and-learning-data-response-type"
                       maxLength={50}
                       name="dataResponseType"
@@ -402,7 +398,6 @@ const IDDOCTesting = () => {
 
                     <Field
                       as={TextInput}
-                      error={!!flatErrors.dataResponseFileFrequency}
                       id="ops-eval-and-learning-data-file-frequency"
                       maxLength={50}
                       name="dataResponseFileFrequency"


### PR DESCRIPTION
# NOREF

## Changes and Description

There were some form elements that was unnecessarily passing error values to the Formik's `Field` element.  These props were propagated and rendering a slew of warnings to the console - `Warning: Received `false` for a non-boolean attribute. `.  Errors are already being handled in forms by the use of `FieldGroup`, allowing errors to target specific form elements and scroll to them accordingly.

- Removed unneeded `error` props on some form elements

<!-- Put a description here! -->

## How to test this change

- Run unit tests and verify that no warning are thrown related to the ^ above error message

The test suite still throws some known warning, so can disregard those

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
