### PR TITLE
[EASI-3753] - Added grid on readonly to mirror task list/stable position

### DIFF
--- a/src/views/ModelPlan/Discussions/DiscussionModalWrapper.tsx
+++ b/src/views/ModelPlan/Discussions/DiscussionModalWrapper.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactModal from 'react-modal';
-import { GridContainer, Icon } from '@trussworks/react-uswds';
+import { Grid, GridContainer, Icon } from '@trussworks/react-uswds';
 import noScroll from 'no-scroll';
 
 type DiscussionModalWrapperProps = {
@@ -51,7 +51,9 @@ const DiscussionModalWrapper = ({
           </button>
           <h4 className="margin-0">{t('modalHeading')}</h4>
         </div>
-        <GridContainer className="padding-y-6">{children}</GridContainer>
+        <GridContainer className="padding-y-6">
+          <Grid desktop={{ col: 12 }}>{children}</Grid>
+        </GridContainer>
       </div>
     </ReactModal>
   );

--- a/src/views/ModelPlan/ReadOnly/Discussions/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/Discussions/index.tsx
@@ -13,7 +13,11 @@ const ReadOnlyDiscussions = ({ modelID }: { modelID: string }) => {
       className="read-only-model-plan--discussions"
       data-testid="read-only-model-plan--discussions"
     >
-      <Discussions modelID={modelID} readOnly discussionID={discussionID} />
+      <Discussions
+        modelID={modelID}
+        readOnly
+        discussionID={discussionID || 'discussion-readonly'}
+      />
     </div>
   );
 };


### PR DESCRIPTION
# EASI-3753

## Changes and Description

Natasha noticed in the readonly view that the mention dropdown was appearing in the wrong position.  After a bit of headache, figured some funky css was being propagated due to the missing grid container much higher in the readonly html/css hierarchy

- Fixed the tiptap/mention dropdown position on the readonly view to always render in the same position

<!-- Put a description here! -->

## How to test this change

Verify the mention dropdown always appears in the correct position in readonly

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
