### PR TITLE
NOREF/Discussion Reply email subject and template efficiency

### DIFF
--- a/cmd/test_email/discussion_reply_emails.go
+++ b/cmd/test_email/discussion_reply_emails.go
@@ -38,6 +38,10 @@ func sendDiscussionReplyOriginatorEmail(
 	if err != nil {
 		return err
 	}
+	replyCount := len(replies)
+	if replyCount > 2 {
+		replies = replies[:2] // only retain the first two replies
+	}
 
 	emailBody, err := emailTemplate.GetExecutedBody(email.DiscussionReplyCreatedOriginatorBody{
 		ClientAddress:     emailService.GetConfig().GetClientAddress(),
@@ -49,6 +53,7 @@ func sendDiscussionReplyOriginatorEmail(
 		OriginatorName:    originatorName,
 		OriginatorRole:    originatorRole,
 		Replies:           replies,
+		ReplyCount:        replyCount,
 	})
 	if err != nil {
 		return err

--- a/cmd/test_email/discussion_reply_emails.go
+++ b/cmd/test_email/discussion_reply_emails.go
@@ -33,7 +33,8 @@ func sendDiscussionReplyOriginatorEmail(
 	}
 
 	emailSubject, err := emailTemplate.GetExecutedSubject(email.DiscussionReplyCreatedOriginatorSubject{
-		UserName: mostRecentReplyName,
+		ModelName:         modelPlanName,
+		ModelAbbreviation: modelPlanAbbreviation,
 	})
 	if err != nil {
 		return err

--- a/pkg/email/discussion_reply_created_originator.go
+++ b/pkg/email/discussion_reply_created_originator.go
@@ -12,7 +12,8 @@ import (
 
 // DiscussionReplyCreatedOriginatorSubject is the subject for hte email
 type DiscussionReplyCreatedOriginatorSubject struct {
-	UserName string // The full name of the user replying
+	ModelName         string
+	ModelAbbreviation string
 }
 
 // DiscussionReplyCreatedOriginatorBody is the fields needed for reply body

--- a/pkg/email/discussion_reply_created_originator.go
+++ b/pkg/email/discussion_reply_created_originator.go
@@ -25,7 +25,8 @@ type DiscussionReplyCreatedOriginatorBody struct {
 	ModelAbbreviation string
 	OriginatorName    string
 	OriginatorRole    string
-	Replies           []DiscussionReplyEmailContent // all relevant reply information
+	ReplyCount        int
+	Replies           []DiscussionReplyEmailContent // two most recent  replies with all relevant reply information
 }
 
 // DiscussionReplyEmailContent represents the replies for a discussion

--- a/pkg/email/templates/discussion_reply_created_originator_body.html
+++ b/pkg/email/templates/discussion_reply_created_originator_body.html
@@ -15,8 +15,8 @@
         <p>{{.DiscussionContent}}</p>
         <br/>
 
-        {{ $length := len .Replies }} {{ if gt $length 2 }}
-            <i class="subtitle">{{ len (slice (printf "%*s" $length "") 2) }} earlier {{if eq $length 3}} reply {{end}} {{if gt $length 3}} replies {{end}} not shown</i>
+        {{ if gt .ReplyCount 2 }}
+            <i class="subtitle">{{ len (slice (printf "%*s" .ReplyCount "") 2) }} earlier {{if eq .ReplyCount 3}} reply {{end}} {{if gt .ReplyCount 3}} replies {{end}} not shown</i>
             <br/>
             <br/>
         {{end}}

--- a/pkg/email/templates/discussion_reply_created_originator_subject.html
+++ b/pkg/email/templates/discussion_reply_created_originator_subject.html
@@ -1,1 +1,1 @@
-{{.UserName}} replied to your discussion
+New reply to your discussion for {{.ModelName}} {{ if .ModelAbbreviation}} ({{.ModelAbbreviation}}) {{end}}

--- a/pkg/graph/resolvers/discussion_emails.go
+++ b/pkg/graph/resolvers/discussion_emails.go
@@ -38,7 +38,8 @@ func sendDiscussionReplyOriginatorEmail(
 	}
 
 	emailSubject, err := emailTemplate.GetExecutedSubject(email.DiscussionReplyCreatedOriginatorSubject{
-		UserName: mostRecentReplyName,
+		ModelName:         modelPlanName,
+		ModelAbbreviation: modelPlanAbbreviation,
 	})
 	if err != nil {
 		return err

--- a/pkg/graph/resolvers/discussion_emails.go
+++ b/pkg/graph/resolvers/discussion_emails.go
@@ -43,6 +43,10 @@ func sendDiscussionReplyOriginatorEmail(
 	if err != nil {
 		return err
 	}
+	replyCount := len(replies)
+	if replyCount > 2 {
+		replies = replies[:2] // only retain the first two replies
+	}
 
 	emailBody, err := emailTemplate.GetExecutedBody(email.DiscussionReplyCreatedOriginatorBody{
 		ClientAddress:     emailService.GetConfig().GetClientAddress(),
@@ -54,6 +58,7 @@ func sendDiscussionReplyOriginatorEmail(
 		OriginatorName:    originatorName,
 		OriginatorRole:    originatorRole,
 		Replies:           replies,
+		ReplyCount:        replyCount,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
# [EASI-3601](https://jiraent.cms.gov/browse/EASI-3601)

## Changes and Description

- Update email subject to be based on model name
   - I discussed this with UX. I noticed while deploying that using the username of the user who made the reply results in emails being grouped oddly in gmail. To make them group more logically, the subject will be based on the name of the model plan.
- Update templating efficiency
    - in response to suggestion by @OddTomBrooks [here](https://github.com/CMSgov/mint-app/pull/854#discussion_r1428475833), I updated the template logic. We now explicitly pass the count of the number of replies, and only the first two actual replies.

## How to test this change
1. Run the app
2. Make a discussion
3. Make a reply
   a. confirm the account you used to make the discussion is sent an email
4. Keep making replies
   a.  ensure that it always goes to the account that made the discussion
   b. ensure that the two most recent replies are displayed
   c. ensure that there is a count of all the remaining discussions.
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
