### PR TITLE
NOREF: correct typo in emptyStateCMFFS translation

### DIFF
--- a/src/i18n/en-US/readOnly/generalReadOnly.ts
+++ b/src/i18n/en-US/readOnly/generalReadOnly.ts
@@ -18,7 +18,7 @@ const generalReadOnly = {
     emptyStatePayment:
       'Not assigned - speak with Model lead(s) for payment-related questions',
     emptyStateCMFFS:
-      'Not assigned - speak with Model leads(s) for CM FFS counterpart-related questions',
+      'Not assigned - speak with Model lead(s) for CM FFS counterpart-related questions',
     sendAnEmail: 'Send an email',
     moreTeamMembers: 'More team members',
     cmFFS: 'CM FFS counterpart'


### PR DESCRIPTION

## Changes and Description

- Correct typo in CM FFS empty state translation

<!-- Put a description here! -->

## How to test this change
1. Bring up the application
2. Make a new model
3. Navigate to the read only view for dsfwm
4. Confirm the empty state doesn't have an extra s in `leads(s)` --> `lead(s)`
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
