### PR TITLE
[NOREF] - Fixed bullet not rendering, updated snaps

### DIFF
--- a/src/components/ShareExport/__snapshots__/index.test.tsx.snap
+++ b/src/components/ShareExport/__snapshots__/index.test.tsx.snap
@@ -211,12 +211,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                   class="margin-y-0 padding-left-3"
                 >
                   <li
-                    class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                    class="font-sans-md line-height-sans-4"
                   >
                     First Name
                   </li>
                   <li
-                    class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                    class="font-sans-md line-height-sans-4"
                   >
                     Second Name
                   </li>
@@ -373,7 +373,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                       class="margin-y-0 padding-left-2"
                     >
                       <li
-                        class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                        class="font-sans-md line-height-sans-4"
                       >
                         <span
                           class="display-flex flex-align-center"
@@ -448,12 +448,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                       class="margin-y-0 padding-left-3"
                     >
                       <li
-                        class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                        class="font-sans-md line-height-sans-4"
                       >
                         Center for Medicare (CM)
                       </li>
                       <li
-                        class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                        class="font-sans-md line-height-sans-4"
                       >
                         Center for Medicaid and CHIP Services (CMCS)
                       </li>
@@ -481,12 +481,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                       class="margin-y-0 padding-left-3"
                     >
                       <li
-                        class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                        class="font-sans-md line-height-sans-4"
                       >
                         State and Population Health Group (SPHG)
                       </li>
                       <li
-                        class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                        class="font-sans-md line-height-sans-4"
                       >
                         Policy and Programs Group (PPG)
                       </li>
@@ -1068,12 +1068,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Regular APM
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       MIPS APM
                     </li>
@@ -1115,22 +1115,22 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Population-based Model
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Payment Model
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Service Delivery Model
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -1438,7 +1438,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                         class="margin-y-0 padding-left-3"
                       >
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           Other
                         </li>
@@ -1479,12 +1479,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                         class="margin-y-0 padding-left-3"
                       >
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           Beneficiaries
                         </li>
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           Other
                         </li>
@@ -1579,7 +1579,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -1727,12 +1727,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       3021 Affordable Care Act (ACA)
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -1819,12 +1819,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                         class="margin-y-0 padding-left-3"
                       >
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           Fraud and Abuse
                         </li>
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           Medicaid
                         </li>
@@ -1900,22 +1900,22 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Medicaid providers
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       States
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       State Medicaid agencies
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -2160,12 +2160,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Use an application review and scoring tool
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Another CMS component or process will provide support
                     </li>
@@ -2211,12 +2211,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Manage ongoing communications with participants using an IT tool
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Send mass emails to new participants
                     </li>
@@ -2463,7 +2463,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -2518,7 +2518,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       CCNs
                     </li>
@@ -2600,7 +2600,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Add retrospectively (once an interaction happens this year)
                     </li>
@@ -2642,7 +2642,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Not applicable
                     </li>
@@ -2754,12 +2754,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Disease-specific
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Dually-eligible beneficiaries
                     </li>
@@ -2996,7 +2996,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Historical claims
                     </li>
@@ -3116,7 +3116,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Yes
                     </li>
@@ -3180,12 +3180,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Yes, we will partner with states
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -3240,17 +3240,17 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Beneficiaries
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Participants
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Providers
                     </li>
@@ -3338,12 +3338,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                         class="margin-y-0 padding-left-3"
                       >
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           May have separate contractors for different implementation functions
                         </li>
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           Other
                         </li>
@@ -3733,12 +3733,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Part A
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Part B
                     </li>
@@ -4296,12 +4296,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Interrupted time series
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -4356,12 +4356,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Yes, for evaluation
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -4416,17 +4416,17 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Clinical data
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Medicare claims
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -4481,17 +4481,17 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Baseline/historical data
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Beneficiary-level data
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -4765,7 +4765,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Daily
                     </li>
@@ -4826,7 +4826,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Monthly
                     </li>
@@ -4908,17 +4908,17 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       We plan to use an IT platform (Connect)
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       No, we will not have a learning strategy
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -5024,7 +5024,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Patient Protection Affordable Care Act (Sec 3021)
                     </li>
@@ -5079,7 +5079,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Patient Protection Affordable Care Act (Sec 3021)
                     </li>
@@ -5134,7 +5134,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Beneficiaries
                     </li>
@@ -5176,7 +5176,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Claims-Based Payments
                     </li>
@@ -5225,7 +5225,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Adjustments to FFS payments
                     </li>
@@ -5707,7 +5707,7 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Semiannually
                     </li>
@@ -6622,12 +6622,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                   class="margin-y-0 padding-left-3"
                 >
                   <li
-                    class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                    class="font-sans-md line-height-sans-4"
                   >
                     First Name
                   </li>
                   <li
-                    class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                    class="font-sans-md line-height-sans-4"
                   >
                     Second Name
                   </li>
@@ -6784,7 +6784,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                       class="margin-y-0 padding-left-2"
                     >
                       <li
-                        class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                        class="font-sans-md line-height-sans-4"
                       >
                         <span
                           class="display-flex flex-align-center"
@@ -6859,12 +6859,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                       class="margin-y-0 padding-left-3"
                     >
                       <li
-                        class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                        class="font-sans-md line-height-sans-4"
                       >
                         Center for Medicare (CM)
                       </li>
                       <li
-                        class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                        class="font-sans-md line-height-sans-4"
                       >
                         Center for Medicaid and CHIP Services (CMCS)
                       </li>
@@ -6892,12 +6892,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                       class="margin-y-0 padding-left-3"
                     >
                       <li
-                        class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                        class="font-sans-md line-height-sans-4"
                       >
                         State and Population Health Group (SPHG)
                       </li>
                       <li
-                        class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                        class="font-sans-md line-height-sans-4"
                       >
                         Policy and Programs Group (PPG)
                       </li>
@@ -7479,12 +7479,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Regular APM
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       MIPS APM
                     </li>
@@ -7526,22 +7526,22 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Population-based Model
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Payment Model
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Service Delivery Model
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -7849,7 +7849,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                         class="margin-y-0 padding-left-3"
                       >
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           Other
                         </li>
@@ -7890,12 +7890,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                         class="margin-y-0 padding-left-3"
                       >
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           Beneficiaries
                         </li>
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           Other
                         </li>
@@ -7990,7 +7990,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -8138,12 +8138,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       3021 Affordable Care Act (ACA)
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -8230,12 +8230,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                         class="margin-y-0 padding-left-3"
                       >
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           Fraud and Abuse
                         </li>
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           Medicaid
                         </li>
@@ -8311,22 +8311,22 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Medicaid providers
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       States
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       State Medicaid agencies
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -8571,12 +8571,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Use an application review and scoring tool
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Another CMS component or process will provide support
                     </li>
@@ -8622,12 +8622,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Manage ongoing communications with participants using an IT tool
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Send mass emails to new participants
                     </li>
@@ -8874,7 +8874,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -8929,7 +8929,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       CCNs
                     </li>
@@ -9011,7 +9011,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Add retrospectively (once an interaction happens this year)
                     </li>
@@ -9053,7 +9053,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Not applicable
                     </li>
@@ -9165,12 +9165,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Disease-specific
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Dually-eligible beneficiaries
                     </li>
@@ -9407,7 +9407,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Historical claims
                     </li>
@@ -9527,7 +9527,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Yes
                     </li>
@@ -9591,12 +9591,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Yes, we will partner with states
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -9651,17 +9651,17 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Beneficiaries
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Participants
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Providers
                     </li>
@@ -9749,12 +9749,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                         class="margin-y-0 padding-left-3"
                       >
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           May have separate contractors for different implementation functions
                         </li>
                         <li
-                          class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                          class="font-sans-md line-height-sans-4"
                         >
                           Other
                         </li>
@@ -10144,12 +10144,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Part A
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Part B
                     </li>
@@ -10707,12 +10707,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Interrupted time series
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -10767,12 +10767,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Yes, for evaluation
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -10827,17 +10827,17 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Clinical data
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Medicare claims
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -10892,17 +10892,17 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Baseline/historical data
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Beneficiary-level data
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -11176,7 +11176,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Daily
                     </li>
@@ -11237,7 +11237,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Monthly
                     </li>
@@ -11319,17 +11319,17 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       We plan to use an IT platform (Connect)
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       No, we will not have a learning strategy
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Other
                     </li>
@@ -11435,7 +11435,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Patient Protection Affordable Care Act (Sec 3021)
                     </li>
@@ -11490,7 +11490,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Patient Protection Affordable Care Act (Sec 3021)
                     </li>
@@ -11545,7 +11545,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Beneficiaries
                     </li>
@@ -11587,7 +11587,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Claims-Based Payments
                     </li>
@@ -11636,7 +11636,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Adjustments to FFS payments
                     </li>
@@ -12118,7 +12118,7 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Semiannually
                     </li>

--- a/src/views/ModelPlan/ReadOnly/Beneficiaries/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/Beneficiaries/__snapshots__/index.test.tsx.snap
@@ -44,12 +44,12 @@ exports[`Read Only Model Plan Summary -- Beneficiaries > matches snapshot 1`] = 
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Disease-specific
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Dually-eligible beneficiaries
             </li>
@@ -286,7 +286,7 @@ exports[`Read Only Model Plan Summary -- Beneficiaries > matches snapshot 1`] = 
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Historical claims
             </li>
@@ -406,7 +406,7 @@ exports[`Read Only Model Plan Summary -- Beneficiaries > matches snapshot 1`] = 
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Yes
             </li>

--- a/src/views/ModelPlan/ReadOnly/GeneralCharacteristics/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/GeneralCharacteristics/__snapshots__/index.test.tsx.snap
@@ -227,12 +227,12 @@ exports[`Read Only Model Plan Summary -- General Characteristics > matches snaps
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Regular APM
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               MIPS APM
             </li>
@@ -274,22 +274,22 @@ exports[`Read Only Model Plan Summary -- General Characteristics > matches snaps
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Population-based Model
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Payment Model
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Service Delivery Model
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Other
             </li>
@@ -597,7 +597,7 @@ exports[`Read Only Model Plan Summary -- General Characteristics > matches snaps
                 class="margin-y-0 padding-left-3"
               >
                 <li
-                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                  class="font-sans-md line-height-sans-4"
                 >
                   Other
                 </li>
@@ -638,12 +638,12 @@ exports[`Read Only Model Plan Summary -- General Characteristics > matches snaps
                 class="margin-y-0 padding-left-3"
               >
                 <li
-                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                  class="font-sans-md line-height-sans-4"
                 >
                   Beneficiaries
                 </li>
                 <li
-                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                  class="font-sans-md line-height-sans-4"
                 >
                   Other
                 </li>
@@ -738,7 +738,7 @@ exports[`Read Only Model Plan Summary -- General Characteristics > matches snaps
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Other
             </li>
@@ -886,12 +886,12 @@ exports[`Read Only Model Plan Summary -- General Characteristics > matches snaps
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               3021 Affordable Care Act (ACA)
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Other
             </li>
@@ -978,12 +978,12 @@ exports[`Read Only Model Plan Summary -- General Characteristics > matches snaps
                 class="margin-y-0 padding-left-3"
               >
                 <li
-                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                  class="font-sans-md line-height-sans-4"
                 >
                   Fraud and Abuse
                 </li>
                 <li
-                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                  class="font-sans-md line-height-sans-4"
                 >
                   Medicaid
                 </li>

--- a/src/views/ModelPlan/ReadOnly/ModelBasics/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/ModelBasics/__snapshots__/index.test.tsx.snap
@@ -41,12 +41,12 @@ exports[`Read Only Model Plan Summary -- Model Basics > matches snapshot 1`] = `
           class="margin-y-0 padding-left-3"
         >
           <li
-            class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+            class="font-sans-md line-height-sans-4"
           >
             First Name
           </li>
           <li
-            class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+            class="font-sans-md line-height-sans-4"
           >
             Second Name
           </li>
@@ -203,7 +203,7 @@ exports[`Read Only Model Plan Summary -- Model Basics > matches snapshot 1`] = `
               class="margin-y-0 padding-left-2"
             >
               <li
-                class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                class="font-sans-md line-height-sans-4"
               >
                 <span
                   class="display-flex flex-align-center"
@@ -278,12 +278,12 @@ exports[`Read Only Model Plan Summary -- Model Basics > matches snapshot 1`] = `
               class="margin-y-0 padding-left-3"
             >
               <li
-                class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                class="font-sans-md line-height-sans-4"
               >
                 Center for Medicare (CM)
               </li>
               <li
-                class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                class="font-sans-md line-height-sans-4"
               >
                 Center for Medicaid and CHIP Services (CMCS)
               </li>
@@ -311,12 +311,12 @@ exports[`Read Only Model Plan Summary -- Model Basics > matches snapshot 1`] = `
               class="margin-y-0 padding-left-3"
             >
               <li
-                class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                class="font-sans-md line-height-sans-4"
               >
                 State and Population Health Group (SPHG)
               </li>
               <li
-                class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                class="font-sans-md line-height-sans-4"
               >
                 Policy and Programs Group (PPG)
               </li>

--- a/src/views/ModelPlan/ReadOnly/OpsEvalAndLearning/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/OpsEvalAndLearning/__snapshots__/index.test.tsx.snap
@@ -44,12 +44,12 @@ exports[`Read Only Model Plan Summary -- Operations, Evaluation, and Learning > 
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Yes, we will partner with states
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Other
             </li>
@@ -104,17 +104,17 @@ exports[`Read Only Model Plan Summary -- Operations, Evaluation, and Learning > 
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Beneficiaries
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Participants
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Providers
             </li>
@@ -202,12 +202,12 @@ exports[`Read Only Model Plan Summary -- Operations, Evaluation, and Learning > 
                 class="margin-y-0 padding-left-3"
               >
                 <li
-                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                  class="font-sans-md line-height-sans-4"
                 >
                   May have separate contractors for different implementation functions
                 </li>
                 <li
-                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                  class="font-sans-md line-height-sans-4"
                 >
                   Other
                 </li>
@@ -597,12 +597,12 @@ exports[`Read Only Model Plan Summary -- Operations, Evaluation, and Learning > 
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Part A
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Part B
             </li>
@@ -1160,12 +1160,12 @@ exports[`Read Only Model Plan Summary -- Operations, Evaluation, and Learning > 
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Interrupted time series
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Other
             </li>
@@ -1220,12 +1220,12 @@ exports[`Read Only Model Plan Summary -- Operations, Evaluation, and Learning > 
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Yes, for evaluation
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Other
             </li>
@@ -1280,17 +1280,17 @@ exports[`Read Only Model Plan Summary -- Operations, Evaluation, and Learning > 
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Clinical data
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Medicare claims
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Other
             </li>
@@ -1345,17 +1345,17 @@ exports[`Read Only Model Plan Summary -- Operations, Evaluation, and Learning > 
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Baseline/historical data
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Beneficiary-level data
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Other
             </li>
@@ -1629,7 +1629,7 @@ exports[`Read Only Model Plan Summary -- Operations, Evaluation, and Learning > 
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Daily
             </li>
@@ -1690,7 +1690,7 @@ exports[`Read Only Model Plan Summary -- Operations, Evaluation, and Learning > 
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Monthly
             </li>
@@ -1772,17 +1772,17 @@ exports[`Read Only Model Plan Summary -- Operations, Evaluation, and Learning > 
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               We plan to use an IT platform (Connect)
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               No, we will not have a learning strategy
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Other
             </li>

--- a/src/views/ModelPlan/ReadOnly/ParticipantsAndProviders/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/ParticipantsAndProviders/__snapshots__/index.test.tsx.snap
@@ -44,22 +44,22 @@ exports[`Read Only Model Plan Summary -- Participants And Providers > matches sn
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Medicaid providers
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               States
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               State Medicaid agencies
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Other
             </li>
@@ -304,12 +304,12 @@ exports[`Read Only Model Plan Summary -- Participants And Providers > matches sn
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Use an application review and scoring tool
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Another CMS component or process will provide support
             </li>
@@ -355,12 +355,12 @@ exports[`Read Only Model Plan Summary -- Participants And Providers > matches sn
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Manage ongoing communications with participants using an IT tool
             </li>
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Send mass emails to new participants
             </li>
@@ -607,7 +607,7 @@ exports[`Read Only Model Plan Summary -- Participants And Providers > matches sn
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Other
             </li>
@@ -662,7 +662,7 @@ exports[`Read Only Model Plan Summary -- Participants And Providers > matches sn
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               CCNs
             </li>
@@ -744,7 +744,7 @@ exports[`Read Only Model Plan Summary -- Participants And Providers > matches sn
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Add retrospectively (once an interaction happens this year)
             </li>
@@ -786,7 +786,7 @@ exports[`Read Only Model Plan Summary -- Participants And Providers > matches sn
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Not applicable
             </li>

--- a/src/views/ModelPlan/ReadOnly/Payments/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/Payments/__snapshots__/index.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`Read Only Model Plan Summary -- Payment > matches snapshot 1`] = `
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Patient Protection Affordable Care Act (Sec 3021)
             </li>
@@ -99,7 +99,7 @@ exports[`Read Only Model Plan Summary -- Payment > matches snapshot 1`] = `
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Patient Protection Affordable Care Act (Sec 3021)
             </li>
@@ -154,7 +154,7 @@ exports[`Read Only Model Plan Summary -- Payment > matches snapshot 1`] = `
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Beneficiaries
             </li>
@@ -196,7 +196,7 @@ exports[`Read Only Model Plan Summary -- Payment > matches snapshot 1`] = `
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Claims-Based Payments
             </li>
@@ -245,7 +245,7 @@ exports[`Read Only Model Plan Summary -- Payment > matches snapshot 1`] = `
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Adjustments to FFS payments
             </li>
@@ -727,7 +727,7 @@ exports[`Read Only Model Plan Summary -- Payment > matches snapshot 1`] = `
             class="margin-y-0 padding-left-3"
           >
             <li
-              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+              class="font-sans-md line-height-sans-4"
             >
               Semiannually
             </li>

--- a/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
@@ -534,12 +534,12 @@ exports[`Read Only Model Plan Summary > matches snapshot 1`] = `
                             class="margin-y-0 padding-left-3"
                           >
                             <li
-                              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                              class="font-sans-md line-height-sans-4"
                             >
                               First Name
                             </li>
                             <li
-                              class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                              class="font-sans-md line-height-sans-4"
                             >
                               Second Name
                             </li>
@@ -696,7 +696,7 @@ exports[`Read Only Model Plan Summary > matches snapshot 1`] = `
                                 class="margin-y-0 padding-left-2"
                               >
                                 <li
-                                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                                  class="font-sans-md line-height-sans-4"
                                 >
                                   <span
                                     class="display-flex flex-align-center"
@@ -771,12 +771,12 @@ exports[`Read Only Model Plan Summary > matches snapshot 1`] = `
                                 class="margin-y-0 padding-left-3"
                               >
                                 <li
-                                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                                  class="font-sans-md line-height-sans-4"
                                 >
                                   Center for Medicare (CM)
                                 </li>
                                 <li
-                                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                                  class="font-sans-md line-height-sans-4"
                                 >
                                   Center for Medicaid and CHIP Services (CMCS)
                                 </li>
@@ -804,12 +804,12 @@ exports[`Read Only Model Plan Summary > matches snapshot 1`] = `
                                 class="margin-y-0 padding-left-3"
                               >
                                 <li
-                                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                                  class="font-sans-md line-height-sans-4"
                                 >
                                   State and Population Health Group (SPHG)
                                 </li>
                                 <li
-                                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                                  class="font-sans-md line-height-sans-4"
                                 >
                                   Policy and Programs Group (PPG)
                                 </li>

--- a/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.tsx
@@ -100,16 +100,18 @@ const ReadOnlySection = ({
               isElement(listItems[index]) ? index : `${sectionName}--${item}`
             }
           >
-            <li className="font-sans-md line-height-sans-4 display-flex flex-align-center">
+            <li className="font-sans-md line-height-sans-4">
               {item}
               {tooltips && tooltips[index] && (
-                <Tooltip
-                  label={tooltips[index]!}
-                  position="right"
-                  className="margin-left-05"
-                >
-                  <Icon.Info className="text-base-light" />
-                </Tooltip>
+                <span className="top-2px position-relative">
+                  <Tooltip
+                    label={tooltips[index]!}
+                    position="right"
+                    className="margin-left-05"
+                  >
+                    <Icon.Info className="text-base-light" />
+                  </Tooltip>
+                </span>
               )}
             </li>
             {(item === 'Other' || listOtherItems) && (

--- a/src/views/ModelPlan/TaskList/PrepareForClearance/ClearanceReview/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/TaskList/PrepareForClearance/ClearanceReview/__snapshots__/index.test.tsx.snap
@@ -112,12 +112,12 @@ exports[`ClearanceReview component > matches snapshot 1`] = `
                 class="margin-y-0 padding-left-3"
               >
                 <li
-                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                  class="font-sans-md line-height-sans-4"
                 >
                   First Name
                 </li>
                 <li
-                  class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                  class="font-sans-md line-height-sans-4"
                 >
                   Second Name
                 </li>
@@ -274,7 +274,7 @@ exports[`ClearanceReview component > matches snapshot 1`] = `
                     class="margin-y-0 padding-left-2"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       <span
                         class="display-flex flex-align-center"
@@ -349,12 +349,12 @@ exports[`ClearanceReview component > matches snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Center for Medicare (CM)
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Center for Medicaid and CHIP Services (CMCS)
                     </li>
@@ -382,12 +382,12 @@ exports[`ClearanceReview component > matches snapshot 1`] = `
                     class="margin-y-0 padding-left-3"
                   >
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       State and Population Health Group (SPHG)
                     </li>
                     <li
-                      class="font-sans-md line-height-sans-4 display-flex flex-align-center"
+                      class="font-sans-md line-height-sans-4"
                     >
                       Policy and Programs Group (PPG)
                     </li>


### PR DESCRIPTION
# NOREF

## Changes and Description

There was a change that added `display: flex` to a parent element of a list item, which was inherited and overrode `display:list-item` causing the bullet to not render on the first level bullet point (child bullets renders)

![Screenshot 2023-12-20 at 2 23 03 PM](https://github.com/CMSgov/mint-app/assets/95709965/cac1cfa0-5e06-4d4d-82aa-fbe0b0af1da0)

[Figma](https://www.figma.com/file/6tkIhfNfcsKEAkqXo1qvXH/MINT---Read-Only-View?type=design&node-id=3405-204354&mode=design&t=bDso5buWC9hYTemq-0)

- Removed `display-flex` to ensure bullets get rendered
- Updated snaps

<!-- Put a description here! -->

## How to test this change

- Fill out some multilselect data, verify that the readonly renders the bullets correctly

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
