### PR TITLE
[NOREF] - Added util and test to correctly order readonly items

### DIFF
--- a/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.test.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.test.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { FundingSource } from 'gql/gen/graphql';
 
-import ReadOnlySection from './index';
+import { payments } from 'i18n/en-US/modelPlan/payments';
+
+import ReadOnlySection, {
+  formatListItems,
+  formatListOtherItems
+} from './index';
 
 describe('The Read Only Section', () => {
   describe('As a Non-list Component', () => {
@@ -53,6 +59,51 @@ describe('The Read Only Section', () => {
       expect(screen.getByText(defaultListProps.heading)).toBeInTheDocument();
       expect(screen.getByText('Other')).toBeInTheDocument();
       expect(screen.getByTestId('other-entry')).toBeInTheDocument();
+    });
+  });
+
+  describe('Util functions', () => {
+    it('orders enum values correctly', async () => {
+      const values: FundingSource[] = [
+        FundingSource.OTHER,
+        FundingSource.MEDICARE_PART_B_SMI_TRUST_FUND,
+        FundingSource.MEDICARE_PART_A_HI_TRUST_FUND
+      ];
+
+      const expectedOrder: string[] = [
+        'Medicare Part A (HI) Trust Fund',
+        'Medicare Part B (SMI) Trust Fund',
+        'Other'
+      ];
+
+      expect(formatListItems(payments.fundingSource, values)).toEqual(
+        expectedOrder
+      );
+    });
+
+    it('matches additionalInfo/other values to their corresponding values', async () => {
+      const values: FundingSource[] = [
+        FundingSource.OTHER,
+        FundingSource.MEDICARE_PART_B_SMI_TRUST_FUND,
+        FundingSource.MEDICARE_PART_A_HI_TRUST_FUND
+      ];
+
+      const allValues = {
+        fundingSource: values,
+        fundingSourceOther: 'Other',
+        fundingSourceMedicareAInfo: 'Medicare A',
+        fundingSourceMedicareBInfo: 'Medicare B'
+      };
+
+      const expectedOrder = [
+        allValues.fundingSourceMedicareAInfo,
+        allValues.fundingSourceMedicareBInfo,
+        allValues.fundingSourceOther
+      ];
+
+      expect(
+        formatListOtherItems(payments.fundingSource, values, allValues)
+      ).toEqual(expectedOrder);
     });
   });
 });

--- a/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.tsx
@@ -3,6 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { Grid, Icon } from '@trussworks/react-uswds';
 
 import Tooltip from 'components/shared/Tooltip';
+import {
+  getKeys,
+  TranslationFieldPropertiesWithOptions
+} from 'types/translation';
 
 export type ReadOnlySectionProps = {
   copy?: string | null | React.ReactNode;
@@ -147,6 +151,35 @@ const ReadOnlySection = ({
       )}
     </Grid>
   );
+};
+
+/* 
+  Util function for prepping data to listItems prop of ReadOnlySection
+  Using translation config instead of raw data allows us to ensure a predetermined order of render
+*/
+export const formatListItems = <T extends string | keyof T>(
+  config: TranslationFieldPropertiesWithOptions<T>, // Translation config
+  value: T[] | undefined // field value/enum array
+): string[] => {
+  return getKeys(config.options)
+    .filter(option => value?.includes(option))
+    .map((option): string => config.options[option]);
+};
+
+/* 
+  Util function for prepping data to listOtherItems prop of ReadOnlySection
+  Using translation config instead of raw data allows us to ensure a predetermined order of render
+*/
+export const formatListOtherItems = <T extends string | keyof T>(
+  config: TranslationFieldPropertiesWithOptions<T>, // Translation config
+  value: T[] | undefined, // field value/enum array
+  values: any // All data for the task list section returned from query
+): (string | null | undefined)[] => {
+  return getKeys(config.options)
+    .filter(option => value?.includes(option))
+    .map((option): string | null | undefined => {
+      return values[config.optionsRelatedInfo?.[option]];
+    });
 };
 
 export default ReadOnlySection;


### PR DESCRIPTION
# NOREF

## Changes and Description

Previously readonly enum values were not maintaining the correct order from Figma when rendered.  The BE does not persist order of multiselect.  This work add a util function to order the readonly values as they are defined in the translation file, rather than the default BE order

This work also defines another util function for readonly.  When values have multiple additional info/other values, we need to properly map those to their respective values.  For example `fundingSource` on `Payments` has 4 enum values.  3 of those 4 values all trigger additional fields with text values.  In the readonly, we need to match up those values to their conditional parent values, while in the correct order.

- Added util to correctly order readonly enum values
- Added util function to match up conditional fields with parent enum values
- Added unit testes

<!-- Put a description here! -->

## How to test this change

These are merely util functions with no implementation yet.  Verify their functionality with the written unit tests

- Run the unit tests

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
