### PR TITLE
[EASI-3906] Remove rogue "Payments" fields in ops, eval, and learning

### DIFF
--- a/src/components/ShareExport/__snapshots__/index.test.tsx.snap
+++ b/src/components/ShareExport/__snapshots__/index.test.tsx.snap
@@ -4366,12 +4366,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                 data-testid="grid"
               >
                 <div
-                  class="read-only-section read-only-section--payments margin-bottom-3"
+                  class="read-only-section read-only-section--will-you-make-risk-adjustments-to-payments margin-bottom-3"
                 >
                   <p
                     class="text-bold margin-y-0 font-body-sm line-height-sans-4 text-pre-line"
                   >
-                    Payments
+                    Will you make risk adjustments to payments?
                   </p>
                   <p
                     class="margin-y-0 font-body-md line-height-sans-4 text-pre-line"
@@ -4491,12 +4491,12 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                 data-testid="grid"
               >
                 <div
-                  class="read-only-section read-only-section--payments margin-bottom-3"
+                  class="read-only-section read-only-section--will-participants-be-able-to-appeal-payments margin-bottom-3"
                 >
                   <p
                     class="text-bold margin-y-0 font-body-sm line-height-sans-4 text-pre-line"
                   >
-                    Payments
+                    Will participants be able to appeal payments?
                   </p>
                   <p
                     class="margin-y-0 font-body-md line-height-sans-4 text-pre-line"
@@ -11181,12 +11181,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                 data-testid="grid"
               >
                 <div
-                  class="read-only-section read-only-section--payments margin-bottom-3"
+                  class="read-only-section read-only-section--will-you-make-risk-adjustments-to-payments margin-bottom-3"
                 >
                   <p
                     class="text-bold margin-y-0 font-body-sm line-height-sans-4 text-pre-line"
                   >
-                    Payments
+                    Will you make risk adjustments to payments?
                   </p>
                   <p
                     class="margin-y-0 font-body-md line-height-sans-4 text-pre-line"
@@ -11306,12 +11306,12 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                 data-testid="grid"
               >
                 <div
-                  class="read-only-section read-only-section--payments margin-bottom-3"
+                  class="read-only-section read-only-section--will-participants-be-able-to-appeal-payments margin-bottom-3"
                 >
                   <p
                     class="text-bold margin-y-0 font-body-sm line-height-sans-4 text-pre-line"
                   >
-                    Payments
+                    Will participants be able to appeal payments?
                   </p>
                   <p
                     class="margin-y-0 font-body-md line-height-sans-4 text-pre-line"

--- a/src/views/ModelPlan/ReadOnly/OpsEvalAndLearning/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/OpsEvalAndLearning/__snapshots__/index.test.tsx.snap
@@ -937,12 +937,12 @@ exports[`Read Only Model Plan Summary -- Operations, Evaluation, and Learning > 
         data-testid="grid"
       >
         <div
-          class="read-only-section read-only-section--payments margin-bottom-3"
+          class="read-only-section read-only-section--will-you-make-risk-adjustments-to-payments margin-bottom-3"
         >
           <p
             class="text-bold margin-y-0 font-body-sm line-height-sans-4 text-pre-line"
           >
-            Payments
+            Will you make risk adjustments to payments?
           </p>
           <p
             class="margin-y-0 font-body-md line-height-sans-4 text-pre-line"
@@ -1062,12 +1062,12 @@ exports[`Read Only Model Plan Summary -- Operations, Evaluation, and Learning > 
         data-testid="grid"
       >
         <div
-          class="read-only-section read-only-section--payments margin-bottom-3"
+          class="read-only-section read-only-section--will-participants-be-able-to-appeal-payments margin-bottom-3"
         >
           <p
             class="text-bold margin-y-0 font-body-sm line-height-sans-4 text-pre-line"
           >
-            Payments
+            Will participants be able to appeal payments?
           </p>
           <p
             class="margin-y-0 font-body-md line-height-sans-4 text-pre-line"

--- a/src/views/ModelPlan/ReadOnly/OpsEvalAndLearning/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/OpsEvalAndLearning/index.tsx
@@ -633,7 +633,7 @@ const ReadOnlyOpsEvalAndLearning = ({
           filteredQuestions,
           'riskAdjustPayments',
           <ReadOnlySection
-            heading={opsEvalAndLearningT('riskAdjustPayments.label')}
+            heading={opsEvalAndLearningT('riskAdjustPayments.readonlyLabel')}
             copy={riskAdjustNote}
           />
         )}
@@ -688,7 +688,7 @@ const ReadOnlyOpsEvalAndLearning = ({
           filteredQuestions,
           'appealPayments',
           <ReadOnlySection
-            heading={opsEvalAndLearningT('appealPayments.label')}
+            heading={opsEvalAndLearningT('appealPayments.readonlyLabel')}
             copy={appealNote}
           />
         )}


### PR DESCRIPTION
# EASI-3906

## Changes and Description

- Changed the label to use the correct read only label translation
- Updated snaps

<!-- Put a description here! -->

## How to test this change

1. Navigate to `Operations, evaluation, and learning` Read only page 
2. Verify that rogue payments are gone. 


|| |
|---|---|
|Before|![image](https://github.com/CMSgov/mint-app/assets/2349702/bd0fff4a-f617-4bc8-82e6-ca45f6a5bd01)|
|After|![image](https://github.com/CMSgov/mint-app/assets/2349702/aa7078c0-db08-4711-a569-4a11c0631262)|



<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
