### PR TITLE
NOREF: Watch SQL files in backend DEV Server

### DIFF
--- a/.air.conf
+++ b/.air.conf
@@ -13,7 +13,7 @@ bin = "bin/mint"
 # Customize binary.
 full_bin = "bin/mint serve"
 # Watch these filename extensions.
-include_ext = ["go"]
+include_ext = ["go", "sql"]
 # Ignore these filename extensions or directories.
 # exclude_dir = ["assets", "tmp", "vendor", "frontend/node_modules"]
 # Watch these directories if you specified.

--- a/.airDebug.conf
+++ b/.airDebug.conf
@@ -13,7 +13,7 @@ bin = "bin/mint"
 # Customize binary.
 full_bin = "dlv debug  --continue --accept-multiclient --headless --listen :2350 ./cmd/mint -- serve " 
 # Watch these filename extensions.
-include_ext = ["go"]
+include_ext = ["go", "sql"]
 # Ignore these filename extensions or directories.
 # exclude_dir = ["assets", "tmp", "vendor", "frontend/node_modules"]
 # Watch these directories if you specified.

--- a/.airDebugWait.conf
+++ b/.airDebugWait.conf
@@ -13,7 +13,7 @@ bin = "bin/mint"
 # Customize binary.
 full_bin = "dlv debug --accept-multiclient --headless --listen :2350 ./cmd/mint -- serve " 
 # Watch these filename extensions.
-include_ext = ["go"]
+include_ext = ["go", "sql"]
 # Ignore these filename extensions or directories.
 # exclude_dir = ["assets", "tmp", "vendor", "frontend/node_modules"]
 # Watch these directories if you specified.


### PR DESCRIPTION

## Changes and Description
We use AIR for hot reloading our BE dev server. This updates the config to rebuild the app not just for GO file changes, but also if the SQL file changes. This makes it so you don't have to rebuild the container manually when you update a SQL script
## How to test this change
1. Bring the app up `scripts/dev up:backend:debug`
2. Modify a SQL file
3. Inspect the backend docker container to make sure that the server re-builds.
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
