### PR TITLE
[EASI-3931] - Tooltip render option fix

### DIFF
--- a/src/views/ModelPlan/ReadOnly/Payments/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/Payments/index.tsx
@@ -16,7 +16,8 @@ import { NotFoundPartial } from 'views/NotFound';
 import { checkGroupMap } from '../_components/FilterView/util';
 import ReadOnlySection, {
   formatListItems,
-  formatListOtherItems
+  formatListOtherItems,
+  formatListTooltips
 } from '../_components/ReadOnlySection';
 import SideBySideReadOnlySection from '../_components/SideBySideReadOnlySection';
 import TitleAndStatus from '../_components/TitleAndStatus';
@@ -174,9 +175,7 @@ const ReadOnlyPayments = ({
               fundingSource,
               allPaymentData
             )}
-            tooltips={fundingSource?.map((type): string =>
-              paymentsT(`fundingSource.optionsLabels.${type}`)
-            )}
+            tooltips={formatListTooltips(fundingSourceConfig, fundingSource)}
           />
         )}
 
@@ -204,9 +203,7 @@ const ReadOnlyPayments = ({
               fundingSourceR,
               allPaymentData
             )}
-            tooltips={fundingSourceR?.map((type): string =>
-              paymentsT(`fundingSourceR.optionsLabels.${type}`)
-            )}
+            tooltips={formatListTooltips(fundingSourceRConfig, fundingSourceR)}
           />
         )}
 

--- a/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.test.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { FundingSource } from 'gql/gen/graphql';
+import i18next from 'i18next';
 
 import { payments } from 'i18n/en-US/modelPlan/payments';
 
 import ReadOnlySection, {
   formatListItems,
-  formatListOtherItems
+  formatListOtherItems,
+  formatListTooltips
 } from './index';
 
 describe('The Read Only Section', () => {
@@ -106,6 +108,28 @@ describe('The Read Only Section', () => {
       expect(
         formatListOtherItems(payments.fundingSource, values, allValues)
       ).toEqual(expectedOrder);
+    });
+
+    it('orders tooltip/optionsLabels values correctly', async () => {
+      const values: FundingSource[] = [
+        FundingSource.OTHER,
+        FundingSource.MEDICARE_PART_B_SMI_TRUST_FUND,
+        FundingSource.MEDICARE_PART_A_HI_TRUST_FUND
+      ];
+
+      const expectedOrder: string[] = [
+        i18next.t<string>(
+          'payments:fundingSource.optionsLabels.MEDICARE_PART_A_HI_TRUST_FUND'
+        ),
+        i18next.t<string>(
+          'payments:fundingSource.optionsLabels.MEDICARE_PART_B_SMI_TRUST_FUND'
+        ),
+        ''
+      ];
+
+      expect(formatListTooltips(payments.fundingSource, values)).toEqual(
+        expectedOrder
+      );
     });
   });
 });

--- a/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.tsx
@@ -185,7 +185,7 @@ const ReadOnlySection = ({
 };
 
 /*
-  Util function for prepping data to listItems prop of ReadOnlySection
+  Util function for prepping option data to listItems prop of ReadOnlySection
   Using translation config instead of raw data allows us to ensure a predetermined order of render
 */
 export const formatListItems = <T extends string | keyof T>(
@@ -210,6 +210,21 @@ export const formatListOtherItems = <T extends string | keyof T>(
     .filter(option => value?.includes(option))
     .map((option): string | null | undefined => {
       return values[config.optionsRelatedInfo?.[option]];
+    });
+};
+
+/*
+  Util function for prepping optionsLabels translation data to formatListTooltips prop of ReadOnlySection
+  Using translation config instead of raw data allows us to ensure a predetermined order of render
+*/
+export const formatListTooltips = <T extends string | keyof T>(
+  config: TranslationFieldPropertiesWithOptions<T>, // Translation config
+  value: T[] | undefined // field value/enum array
+): (string | null | undefined)[] => {
+  return getKeys(config.options)
+    .filter(option => value?.includes(option))
+    .map((option): string | null | undefined => {
+      return config.optionsLabels?.[option];
     });
 };
 


### PR DESCRIPTION
# EASI-3931

## Changes and Description

- Fixed issue where tooltip was not aligning with the appropriate option
- Added unit test


## How to test this change

- Fill out funding source questions in varying combinations
- Verify the tooltips render correctly on the readonly view
- Unit tests should pass

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
