### PR TITLE
[Easi-4043] User notification preferences flag to array

### DIFF
--- a/MINT.postman_collection.json
+++ b/MINT.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "32329f70-986e-430d-8a0b-4509ca71dab1",
+		"_postman_id": "58f72d3a-ea92-4df4-8d3d-4627cbf7eb3b",
 		"name": "MINT",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "20320964"
@@ -2276,7 +2276,7 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "mutation NotificationUpdate {\nupdateUserNotificationPreferences( changes:{\n    dailyDigestComplete: IN_APP_ONLY\n    \n    addedAsCollaborator: ALL\n\n    taggedInDiscussion: ALL\n\n    taggedInDiscussionReply: ALL\n\n    newDiscussionReply: ALL\n\n    modelPlanShared: ALL\n\n    \n\n}) {\n\n        dailyDigestComplete\n\n        addedAsCollaborator\n\n        taggedInDiscussion\n\n        taggedInDiscussionReply\n\n        newDiscussionReply\n\n        modelPlanShared\n\n      \n    }\n}\n",
+								"query": "mutation NotificationUpdate {\nupdateUserNotificationPreferences( changes:{\n    dailyDigestComplete: [EMAIL,IN_APP]\n    \n    addedAsCollaborator: [EMAIL,IN_APP]\n\n    taggedInDiscussion:[IN_APP]\n\n    taggedInDiscussionReply:[EMAIL,IN_APP]\n\n    newDiscussionReply: [EMAIL,IN_APP]\n\n    modelPlanShared: [EMAIL,IN_APP]\n\n    \n\n}) {\n\n        dailyDigestComplete\n\n        addedAsCollaborator\n\n        taggedInDiscussion\n\n        taggedInDiscussionReply\n\n        newDiscussionReply\n\n        modelPlanShared\n\n      \n    }\n}\n",
 								"variables": ""
 							}
 						},

--- a/MINT.postman_collection.json
+++ b/MINT.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "58f72d3a-ea92-4df4-8d3d-4627cbf7eb3b",
+		"_postman_id": "32329f70-986e-430d-8a0b-4509ca71dab1",
 		"name": "MINT",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "20320964"

--- a/migrations/V149__User_Notification_Preferences_Flags_To_Array.sql
+++ b/migrations/V149__User_Notification_Preferences_Flags_To_Array.sql
@@ -1,0 +1,58 @@
+ALTER TABLE user_notification_preferences
+ALTER COLUMN daily_digest_complete  DROP DEFAULT,
+ALTER COLUMN added_as_collaborator  DROP DEFAULT,
+ALTER COLUMN tagged_in_discussion  DROP DEFAULT,
+ALTER COLUMN tagged_in_discussion_reply  DROP DEFAULT,
+ALTER COLUMN new_discussion_reply  DROP DEFAULT,
+ALTER COLUMN model_plan_shared  DROP DEFAULT;
+
+
+-- Cast all values as text array
+ALTER TABLE user_notification_preferences
+ALTER COLUMN daily_digest_complete  TYPE TEXT[] USING ARRAY[daily_digest_complete]::TEXT[],
+ALTER COLUMN added_as_collaborator  TYPE TEXT[] USING ARRAY[added_as_collaborator]::TEXT[],
+ALTER COLUMN tagged_in_discussion  TYPE TEXT[] USING ARRAY[tagged_in_discussion]::TEXT[],
+ALTER COLUMN tagged_in_discussion_reply  TYPE TEXT[] USING ARRAY[tagged_in_discussion_reply]::TEXT[],
+ALTER COLUMN new_discussion_reply  TYPE TEXT[] USING ARRAY[new_discussion_reply]::TEXT[],
+ALTER COLUMN model_plan_shared  TYPE TEXT[] USING ARRAY[model_plan_shared]::TEXT[];
+
+
+-- Drop the the existing enum type
+DROP TYPE USER_NOTIFICATION_PREFERENCE_FLAG;
+
+-- Create the new enum type
+CREATE TYPE USER_NOTIFICATION_PREFERENCE_FLAG AS ENUM (
+    'IN_APP', 'EMAIL'
+);
+
+-- Update all values to the default since this is not a modified feature currently
+UPDATE user_notification_preferences
+SET 
+    daily_digest_complete = '{IN_APP, EMAIL}',
+    added_as_collaborator = '{IN_APP, EMAIL}',
+    tagged_in_discussion = '{IN_APP, EMAIL}',
+    tagged_in_discussion_reply = '{IN_APP, EMAIL}',
+    new_discussion_reply = '{IN_APP, EMAIL}',
+    model_plan_shared = '{IN_APP, EMAIL}',
+    modified_by = '00000001-0001-0001-0001-000000000001',
+    modified_dts = now();
+
+
+-- Cast all values as USER_NOTIFICATION_PREFERENCE_FLAG array
+ALTER TABLE user_notification_preferences
+ALTER COLUMN daily_digest_complete  TYPE USER_NOTIFICATION_PREFERENCE_FLAG[] USING daily_digest_complete::USER_NOTIFICATION_PREFERENCE_FLAG[],
+ALTER COLUMN added_as_collaborator  TYPE USER_NOTIFICATION_PREFERENCE_FLAG[] USING added_as_collaborator::USER_NOTIFICATION_PREFERENCE_FLAG[],
+ALTER COLUMN tagged_in_discussion  TYPE USER_NOTIFICATION_PREFERENCE_FLAG[] USING tagged_in_discussion::USER_NOTIFICATION_PREFERENCE_FLAG[],
+ALTER COLUMN tagged_in_discussion_reply  TYPE USER_NOTIFICATION_PREFERENCE_FLAG[] USING tagged_in_discussion_reply::USER_NOTIFICATION_PREFERENCE_FLAG[],
+ALTER COLUMN new_discussion_reply  TYPE USER_NOTIFICATION_PREFERENCE_FLAG[] USING new_discussion_reply::USER_NOTIFICATION_PREFERENCE_FLAG[],
+ALTER COLUMN model_plan_shared  TYPE USER_NOTIFICATION_PREFERENCE_FLAG[] USING model_plan_shared::USER_NOTIFICATION_PREFERENCE_FLAG[];
+
+
+-- Set default column values of IN_APP and Email (like ALL previously)
+ALTER TABLE user_notification_preferences
+ALTER COLUMN daily_digest_complete  SET DEFAULT '{IN_APP, EMAIL}',
+ALTER COLUMN added_as_collaborator  SET DEFAULT '{IN_APP, EMAIL}',
+ALTER COLUMN tagged_in_discussion  SET DEFAULT '{IN_APP, EMAIL}',
+ALTER COLUMN tagged_in_discussion_reply  SET DEFAULT '{IN_APP, EMAIL}',
+ALTER COLUMN new_discussion_reply  SET DEFAULT '{IN_APP, EMAIL}',
+ALTER COLUMN model_plan_shared  SET DEFAULT '{IN_APP, EMAIL}';

--- a/migrations/V149__User_Notification_Preferences_Flags_To_Array.sql
+++ b/migrations/V149__User_Notification_Preferences_Flags_To_Array.sql
@@ -1,3 +1,4 @@
+-- Drop the current DEFAULT
 ALTER TABLE user_notification_preferences
 ALTER COLUMN daily_digest_complete  DROP DEFAULT,
 ALTER COLUMN added_as_collaborator  DROP DEFAULT,
@@ -6,6 +7,14 @@ ALTER COLUMN tagged_in_discussion_reply  DROP DEFAULT,
 ALTER COLUMN new_discussion_reply  DROP DEFAULT,
 ALTER COLUMN model_plan_shared  DROP DEFAULT;
 
+-- DROP the not null constraint
+ALTER TABLE user_notification_preferences
+ALTER COLUMN daily_digest_complete  DROP NOT NULL,
+ALTER COLUMN added_as_collaborator  DROP NOT NULL,
+ALTER COLUMN tagged_in_discussion  DROP NOT NULL,
+ALTER COLUMN tagged_in_discussion_reply  DROP NOT NULL,
+ALTER COLUMN new_discussion_reply  DROP NOT NULL,
+ALTER COLUMN model_plan_shared  DROP NOT NULL;
 
 -- Cast all values as text array
 ALTER TABLE user_notification_preferences

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -69,6 +69,7 @@ type ResolverRoot interface {
 	TaggedInDiscussionReplyActivityMeta() TaggedInDiscussionReplyActivityMetaResolver
 	TaggedInPlanDiscussionActivityMeta() TaggedInPlanDiscussionActivityMetaResolver
 	UserNotification() UserNotificationResolver
+	UserNotificationPreferences() UserNotificationPreferencesResolver
 }
 
 type DirectiveRoot struct {
@@ -1364,6 +1365,14 @@ type TaggedInPlanDiscussionActivityMetaResolver interface {
 }
 type UserNotificationResolver interface {
 	Activity(ctx context.Context, obj *models.UserNotification) (*models.Activity, error)
+}
+type UserNotificationPreferencesResolver interface {
+	DailyDigestComplete(ctx context.Context, obj *models.UserNotificationPreferences) ([]models.UserNotificationPreferenceFlag, error)
+	AddedAsCollaborator(ctx context.Context, obj *models.UserNotificationPreferences) ([]models.UserNotificationPreferenceFlag, error)
+	TaggedInDiscussion(ctx context.Context, obj *models.UserNotificationPreferences) ([]models.UserNotificationPreferenceFlag, error)
+	TaggedInDiscussionReply(ctx context.Context, obj *models.UserNotificationPreferences) ([]models.UserNotificationPreferenceFlag, error)
+	NewDiscussionReply(ctx context.Context, obj *models.UserNotificationPreferences) ([]models.UserNotificationPreferenceFlag, error)
+	ModelPlanShared(ctx context.Context, obj *models.UserNotificationPreferences) ([]models.UserNotificationPreferenceFlag, error)
 }
 
 type executableSchema struct {
@@ -10751,10 +10760,8 @@ markAllNotificationsAsRead: [UserNotification!]!
 }
 `, BuiltIn: false},
 	{Name: "../schema/types/user_notification_preferences.graphql", Input: `enum UserNotificationPreferenceFlag {
-  ALL,
-  IN_APP_ONLY,
-  EMAIL_ONLY,
-  NONE
+  IN_APP,
+  EMAIL
 }
 
 
@@ -10765,17 +10772,17 @@ type UserNotificationPreferences {
   id: UUID!
 	userID: UUID!
 
-  dailyDigestComplete: UserNotificationPreferenceFlag!
+  dailyDigestComplete: [UserNotificationPreferenceFlag!]
 
-  addedAsCollaborator: UserNotificationPreferenceFlag!
+  addedAsCollaborator: [UserNotificationPreferenceFlag!]
 
-  taggedInDiscussion: UserNotificationPreferenceFlag!
+  taggedInDiscussion: [UserNotificationPreferenceFlag!]
 
-  taggedInDiscussionReply: UserNotificationPreferenceFlag!
+  taggedInDiscussionReply: [UserNotificationPreferenceFlag!]
 
-  newDiscussionReply: UserNotificationPreferenceFlag!
+  newDiscussionReply: [UserNotificationPreferenceFlag!]
 
-  modelPlanShared: UserNotificationPreferenceFlag!
+  modelPlanShared: [UserNotificationPreferenceFlag!]
 
 
   createdBy: UUID!
@@ -10793,17 +10800,17 @@ UserNotificationPreferencesChanges represents the ways that a UserNotifications 
 """
 input UserNotificationPreferencesChanges @goModel(model: "map[string]interface{}")  {
 
-  dailyDigestComplete: UserNotificationPreferenceFlag
+  dailyDigestComplete: [UserNotificationPreferenceFlag!]
 
-  addedAsCollaborator: UserNotificationPreferenceFlag
+  addedAsCollaborator: [UserNotificationPreferenceFlag!]
 
-  taggedInDiscussion: UserNotificationPreferenceFlag
+  taggedInDiscussion: [UserNotificationPreferenceFlag!]
 
-  taggedInDiscussionReply: UserNotificationPreferenceFlag
+  taggedInDiscussionReply: [UserNotificationPreferenceFlag!]
 
-  newDiscussionReply: UserNotificationPreferenceFlag
+  newDiscussionReply: [UserNotificationPreferenceFlag!]
 
-  modelPlanShared: UserNotificationPreferenceFlag
+  modelPlanShared: [UserNotificationPreferenceFlag!]
 
 
 }
@@ -56561,29 +56568,26 @@ func (ec *executionContext) _UserNotificationPreferences_dailyDigestComplete(ctx
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.DailyDigestComplete, nil
+		return ec.resolvers.UserNotificationPreferences().DailyDigestComplete(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(models.UserNotificationPreferenceFlag)
+	res := resTmp.([]models.UserNotificationPreferenceFlag)
 	fc.Result = res
-	return ec.marshalNUserNotificationPreferenceFlag2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlag(ctx, field.Selections, res)
+	return ec.marshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserNotificationPreferences_dailyDigestComplete(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "UserNotificationPreferences",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type UserNotificationPreferenceFlag does not have child fields")
 		},
@@ -56605,29 +56609,26 @@ func (ec *executionContext) _UserNotificationPreferences_addedAsCollaborator(ctx
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.AddedAsCollaborator, nil
+		return ec.resolvers.UserNotificationPreferences().AddedAsCollaborator(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(models.UserNotificationPreferenceFlag)
+	res := resTmp.([]models.UserNotificationPreferenceFlag)
 	fc.Result = res
-	return ec.marshalNUserNotificationPreferenceFlag2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlag(ctx, field.Selections, res)
+	return ec.marshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserNotificationPreferences_addedAsCollaborator(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "UserNotificationPreferences",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type UserNotificationPreferenceFlag does not have child fields")
 		},
@@ -56649,29 +56650,26 @@ func (ec *executionContext) _UserNotificationPreferences_taggedInDiscussion(ctx 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.TaggedInDiscussion, nil
+		return ec.resolvers.UserNotificationPreferences().TaggedInDiscussion(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(models.UserNotificationPreferenceFlag)
+	res := resTmp.([]models.UserNotificationPreferenceFlag)
 	fc.Result = res
-	return ec.marshalNUserNotificationPreferenceFlag2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlag(ctx, field.Selections, res)
+	return ec.marshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserNotificationPreferences_taggedInDiscussion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "UserNotificationPreferences",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type UserNotificationPreferenceFlag does not have child fields")
 		},
@@ -56693,29 +56691,26 @@ func (ec *executionContext) _UserNotificationPreferences_taggedInDiscussionReply
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.TaggedInDiscussionReply, nil
+		return ec.resolvers.UserNotificationPreferences().TaggedInDiscussionReply(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(models.UserNotificationPreferenceFlag)
+	res := resTmp.([]models.UserNotificationPreferenceFlag)
 	fc.Result = res
-	return ec.marshalNUserNotificationPreferenceFlag2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlag(ctx, field.Selections, res)
+	return ec.marshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserNotificationPreferences_taggedInDiscussionReply(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "UserNotificationPreferences",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type UserNotificationPreferenceFlag does not have child fields")
 		},
@@ -56737,29 +56732,26 @@ func (ec *executionContext) _UserNotificationPreferences_newDiscussionReply(ctx 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.NewDiscussionReply, nil
+		return ec.resolvers.UserNotificationPreferences().NewDiscussionReply(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(models.UserNotificationPreferenceFlag)
+	res := resTmp.([]models.UserNotificationPreferenceFlag)
 	fc.Result = res
-	return ec.marshalNUserNotificationPreferenceFlag2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlag(ctx, field.Selections, res)
+	return ec.marshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserNotificationPreferences_newDiscussionReply(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "UserNotificationPreferences",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type UserNotificationPreferenceFlag does not have child fields")
 		},
@@ -56781,29 +56773,26 @@ func (ec *executionContext) _UserNotificationPreferences_modelPlanShared(ctx con
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.ModelPlanShared, nil
+		return ec.resolvers.UserNotificationPreferences().ModelPlanShared(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(models.UserNotificationPreferenceFlag)
+	res := resTmp.([]models.UserNotificationPreferenceFlag)
 	fc.Result = res
-	return ec.marshalNUserNotificationPreferenceFlag2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlag(ctx, field.Selections, res)
+	return ec.marshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserNotificationPreferences_modelPlanShared(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "UserNotificationPreferences",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type UserNotificationPreferenceFlag does not have child fields")
 		},
@@ -69893,35 +69882,203 @@ func (ec *executionContext) _UserNotificationPreferences(ctx context.Context, se
 				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "dailyDigestComplete":
-			out.Values[i] = ec._UserNotificationPreferences_dailyDigestComplete(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserNotificationPreferences_dailyDigestComplete(ctx, field, obj)
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "addedAsCollaborator":
-			out.Values[i] = ec._UserNotificationPreferences_addedAsCollaborator(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserNotificationPreferences_addedAsCollaborator(ctx, field, obj)
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "taggedInDiscussion":
-			out.Values[i] = ec._UserNotificationPreferences_taggedInDiscussion(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserNotificationPreferences_taggedInDiscussion(ctx, field, obj)
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "taggedInDiscussionReply":
-			out.Values[i] = ec._UserNotificationPreferences_taggedInDiscussionReply(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserNotificationPreferences_taggedInDiscussionReply(ctx, field, obj)
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "newDiscussionReply":
-			out.Values[i] = ec._UserNotificationPreferences_newDiscussionReply(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserNotificationPreferences_newDiscussionReply(ctx, field, obj)
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "modelPlanShared":
-			out.Values[i] = ec._UserNotificationPreferences_modelPlanShared(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserNotificationPreferences_modelPlanShared(ctx, field, obj)
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "createdBy":
 			out.Values[i] = ec._UserNotificationPreferences_createdBy(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -78966,21 +79123,71 @@ func (ec *executionContext) marshalOUserAccount2ᚖgithubᚗcomᚋcmsgovᚋmint�
 	return ec._UserAccount(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalOUserNotificationPreferenceFlag2ᚖgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlag(ctx context.Context, v interface{}) (*models.UserNotificationPreferenceFlag, error) {
+func (ec *executionContext) unmarshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx context.Context, v interface{}) ([]models.UserNotificationPreferenceFlag, error) {
 	if v == nil {
 		return nil, nil
 	}
-	tmp, err := graphql.UnmarshalString(v)
-	res := models.UserNotificationPreferenceFlag(tmp)
-	return &res, graphql.ErrorOnPath(ctx, err)
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]models.UserNotificationPreferenceFlag, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNUserNotificationPreferenceFlag2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlag(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
-func (ec *executionContext) marshalOUserNotificationPreferenceFlag2ᚖgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlag(ctx context.Context, sel ast.SelectionSet, v *models.UserNotificationPreferenceFlag) graphql.Marshaler {
+func (ec *executionContext) marshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx context.Context, sel ast.SelectionSet, v []models.UserNotificationPreferenceFlag) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
-	res := graphql.MarshalString(string(*v))
-	return res
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNUserNotificationPreferenceFlag2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlag(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalOWaiverType2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋgraphᚋmodelᚐWaiverTypeᚄ(ctx context.Context, v interface{}) ([]model.WaiverType, error) {

--- a/pkg/graph/generated/generated.go
+++ b/pkg/graph/generated/generated.go
@@ -10772,17 +10772,17 @@ type UserNotificationPreferences {
   id: UUID!
 	userID: UUID!
 
-  dailyDigestComplete: [UserNotificationPreferenceFlag!]
+  dailyDigestComplete: [UserNotificationPreferenceFlag!]!
 
-  addedAsCollaborator: [UserNotificationPreferenceFlag!]
+  addedAsCollaborator: [UserNotificationPreferenceFlag!]!
 
-  taggedInDiscussion: [UserNotificationPreferenceFlag!]
+  taggedInDiscussion: [UserNotificationPreferenceFlag!]!
 
-  taggedInDiscussionReply: [UserNotificationPreferenceFlag!]
+  taggedInDiscussionReply: [UserNotificationPreferenceFlag!]!
 
-  newDiscussionReply: [UserNotificationPreferenceFlag!]
+  newDiscussionReply: [UserNotificationPreferenceFlag!]!
 
-  modelPlanShared: [UserNotificationPreferenceFlag!]
+  modelPlanShared: [UserNotificationPreferenceFlag!]!
 
 
   createdBy: UUID!
@@ -56575,11 +56575,14 @@ func (ec *executionContext) _UserNotificationPreferences_dailyDigestComplete(ctx
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]models.UserNotificationPreferenceFlag)
 	fc.Result = res
-	return ec.marshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
+	return ec.marshalNUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserNotificationPreferences_dailyDigestComplete(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -56616,11 +56619,14 @@ func (ec *executionContext) _UserNotificationPreferences_addedAsCollaborator(ctx
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]models.UserNotificationPreferenceFlag)
 	fc.Result = res
-	return ec.marshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
+	return ec.marshalNUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserNotificationPreferences_addedAsCollaborator(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -56657,11 +56663,14 @@ func (ec *executionContext) _UserNotificationPreferences_taggedInDiscussion(ctx 
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]models.UserNotificationPreferenceFlag)
 	fc.Result = res
-	return ec.marshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
+	return ec.marshalNUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserNotificationPreferences_taggedInDiscussion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -56698,11 +56707,14 @@ func (ec *executionContext) _UserNotificationPreferences_taggedInDiscussionReply
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]models.UserNotificationPreferenceFlag)
 	fc.Result = res
-	return ec.marshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
+	return ec.marshalNUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserNotificationPreferences_taggedInDiscussionReply(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -56739,11 +56751,14 @@ func (ec *executionContext) _UserNotificationPreferences_newDiscussionReply(ctx 
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]models.UserNotificationPreferenceFlag)
 	fc.Result = res
-	return ec.marshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
+	return ec.marshalNUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserNotificationPreferences_newDiscussionReply(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -56780,11 +56795,14 @@ func (ec *executionContext) _UserNotificationPreferences_modelPlanShared(ctx con
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]models.UserNotificationPreferenceFlag)
 	fc.Result = res
-	return ec.marshalOUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
+	return ec.marshalNUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_UserNotificationPreferences_modelPlanShared(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -69891,6 +69909,9 @@ func (ec *executionContext) _UserNotificationPreferences(ctx context.Context, se
 					}
 				}()
 				res = ec._UserNotificationPreferences_dailyDigestComplete(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -69924,6 +69945,9 @@ func (ec *executionContext) _UserNotificationPreferences(ctx context.Context, se
 					}
 				}()
 				res = ec._UserNotificationPreferences_addedAsCollaborator(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -69957,6 +69981,9 @@ func (ec *executionContext) _UserNotificationPreferences(ctx context.Context, se
 					}
 				}()
 				res = ec._UserNotificationPreferences_taggedInDiscussion(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -69990,6 +70017,9 @@ func (ec *executionContext) _UserNotificationPreferences(ctx context.Context, se
 					}
 				}()
 				res = ec._UserNotificationPreferences_taggedInDiscussionReply(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -70023,6 +70053,9 @@ func (ec *executionContext) _UserNotificationPreferences(ctx context.Context, se
 					}
 				}()
 				res = ec._UserNotificationPreferences_newDiscussionReply(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -70056,6 +70089,9 @@ func (ec *executionContext) _UserNotificationPreferences(ctx context.Context, se
 					}
 				}()
 				res = ec._UserNotificationPreferences_modelPlanShared(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -75412,6 +75448,67 @@ func (ec *executionContext) marshalNUserNotificationPreferenceFlag2githubᚗcom�
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx context.Context, v interface{}) ([]models.UserNotificationPreferenceFlag, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]models.UserNotificationPreferenceFlag, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNUserNotificationPreferenceFlag2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlag(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNUserNotificationPreferenceFlag2ᚕgithubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlagᚄ(ctx context.Context, sel ast.SelectionSet, v []models.UserNotificationPreferenceFlag) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNUserNotificationPreferenceFlag2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferenceFlag(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalNUserNotificationPreferences2githubᚗcomᚋcmsgovᚋmintᚑappᚋpkgᚋmodelsᚐUserNotificationPreferences(ctx context.Context, sel ast.SelectionSet, v models.UserNotificationPreferences) graphql.Marshaler {

--- a/pkg/graph/resolvers/user_notification_preferences.resolvers.go
+++ b/pkg/graph/resolvers/user_notification_preferences.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/cmsgov/mint-app/pkg/appcontext"
+	"github.com/cmsgov/mint-app/pkg/graph/generated"
 	"github.com/cmsgov/mint-app/pkg/models"
 )
 
@@ -18,3 +19,40 @@ func (r *mutationResolver) UpdateUserNotificationPreferences(ctx context.Context
 
 	return UserNotificationPreferencesUpdate(ctx, logger, principal, r.store, changes)
 }
+
+// DailyDigestComplete is the resolver for the dailyDigestComplete field.
+func (r *userNotificationPreferencesResolver) DailyDigestComplete(ctx context.Context, obj *models.UserNotificationPreferences) ([]models.UserNotificationPreferenceFlag, error) {
+	return obj.DailyDigestComplete, nil
+}
+
+// AddedAsCollaborator is the resolver for the addedAsCollaborator field.
+func (r *userNotificationPreferencesResolver) AddedAsCollaborator(ctx context.Context, obj *models.UserNotificationPreferences) ([]models.UserNotificationPreferenceFlag, error) {
+	return obj.AddedAsCollaborator, nil
+}
+
+// TaggedInDiscussion is the resolver for the taggedInDiscussion field.
+func (r *userNotificationPreferencesResolver) TaggedInDiscussion(ctx context.Context, obj *models.UserNotificationPreferences) ([]models.UserNotificationPreferenceFlag, error) {
+	return obj.TaggedInDiscussion, nil
+}
+
+// TaggedInDiscussionReply is the resolver for the taggedInDiscussionReply field.
+func (r *userNotificationPreferencesResolver) TaggedInDiscussionReply(ctx context.Context, obj *models.UserNotificationPreferences) ([]models.UserNotificationPreferenceFlag, error) {
+	return obj.TaggedInDiscussionReply, nil
+}
+
+// NewDiscussionReply is the resolver for the newDiscussionReply field.
+func (r *userNotificationPreferencesResolver) NewDiscussionReply(ctx context.Context, obj *models.UserNotificationPreferences) ([]models.UserNotificationPreferenceFlag, error) {
+	return obj.NewDiscussionReply, nil
+}
+
+// ModelPlanShared is the resolver for the modelPlanShared field.
+func (r *userNotificationPreferencesResolver) ModelPlanShared(ctx context.Context, obj *models.UserNotificationPreferences) ([]models.UserNotificationPreferenceFlag, error) {
+	return obj.ModelPlanShared, nil
+}
+
+// UserNotificationPreferences returns generated.UserNotificationPreferencesResolver implementation.
+func (r *Resolver) UserNotificationPreferences() generated.UserNotificationPreferencesResolver {
+	return &userNotificationPreferencesResolver{r}
+}
+
+type userNotificationPreferencesResolver struct{ *Resolver }

--- a/pkg/graph/resolvers/user_notification_preferences_test.go
+++ b/pkg/graph/resolvers/user_notification_preferences_test.go
@@ -21,23 +21,28 @@ func (s *ResolverSuite) TestUserNotificationPreferencesUpdate() {
 	pref, err := UserNotificationPreferencesGetByUserID(s.testConfigs.Context, s.testConfigs.Principal.Account().ID)
 	s.NoError(err)
 	s.NotNil(pref)
+	inAppOnly := models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp}
 	changes := map[string]interface{}{
-		"dailyDigestComplete":     models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp},
-		"addedAsCollaborator":     models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp},
-		"taggedInDiscussion":      models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp},
-		"taggedInDiscussionReply": models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp},
-		"newDiscussionReply":      models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp},
-		"modelPlanShared":         models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp},
+		"dailyDigestComplete":     inAppOnly,
+		"addedAsCollaborator":     inAppOnly,
+		"taggedInDiscussion":      inAppOnly,
+		"taggedInDiscussionReply": inAppOnly,
+		"newDiscussionReply":      inAppOnly,
+		"modelPlanShared":         nil,
 	}
 	updatedPref, err := UserNotificationPreferencesUpdate(s.testConfigs.Context, s.testConfigs.Logger, s.testConfigs.Principal, s.testConfigs.Store, changes)
 	s.NoError(err)
 	s.NotNil(updatedPref)
 
-	s.EqualValues(models.UserNotificationPreferenceInApp, updatedPref.DailyDigestComplete)
-	s.EqualValues(models.UserNotificationPreferenceInApp, updatedPref.AddedAsCollaborator)
-	s.EqualValues(models.UserNotificationPreferenceInApp, updatedPref.TaggedInDiscussion)
-	s.EqualValues(models.UserNotificationPreferenceInApp, updatedPref.TaggedInDiscussionReply)
-	s.EqualValues(models.UserNotificationPreferenceInApp, updatedPref.NewDiscussionReply)
-	s.EqualValues(models.UserNotificationPreferenceInApp, updatedPref.ModelPlanShared)
+	s.EqualValues(inAppOnly, updatedPref.DailyDigestComplete)
+	s.EqualValues(inAppOnly, updatedPref.AddedAsCollaborator)
+	s.EqualValues(inAppOnly, updatedPref.TaggedInDiscussion)
+	s.EqualValues(inAppOnly, updatedPref.TaggedInDiscussionReply)
+	s.EqualValues(inAppOnly, updatedPref.NewDiscussionReply)
+	s.EqualValues(models.UserNotificationPreferenceFlags(nil), updatedPref.ModelPlanShared)
+
+	// Ensure a nil reference evaluates correctly
+	s.False(updatedPref.ModelPlanShared.InApp())
+	s.False(updatedPref.ModelPlanShared.SendEmail())
 
 }

--- a/pkg/graph/resolvers/user_notification_preferences_test.go
+++ b/pkg/graph/resolvers/user_notification_preferences_test.go
@@ -7,12 +7,12 @@ func (s *ResolverSuite) TestUserNotificationPreferencesGetByUserID() {
 	s.NoError(err)
 	s.NotNil(pref)
 
-	s.EqualValues(models.UserNotificationPreferenceAll, pref.DailyDigestComplete)
-	s.EqualValues(models.UserNotificationPreferenceAll, pref.AddedAsCollaborator)
-	s.EqualValues(models.UserNotificationPreferenceAll, pref.TaggedInDiscussion)
-	s.EqualValues(models.UserNotificationPreferenceAll, pref.TaggedInDiscussionReply)
-	s.EqualValues(models.UserNotificationPreferenceAll, pref.NewDiscussionReply)
-	s.EqualValues(models.UserNotificationPreferenceAll, pref.ModelPlanShared)
+	s.EqualValues(models.DefaultUserNotificationPreferencesFlags(), pref.DailyDigestComplete)
+	s.EqualValues(models.DefaultUserNotificationPreferencesFlags(), pref.AddedAsCollaborator)
+	s.EqualValues(models.DefaultUserNotificationPreferencesFlags(), pref.TaggedInDiscussion)
+	s.EqualValues(models.DefaultUserNotificationPreferencesFlags(), pref.TaggedInDiscussionReply)
+	s.EqualValues(models.DefaultUserNotificationPreferencesFlags(), pref.NewDiscussionReply)
+	s.EqualValues(models.DefaultUserNotificationPreferencesFlags(), pref.ModelPlanShared)
 
 }
 
@@ -22,22 +22,22 @@ func (s *ResolverSuite) TestUserNotificationPreferencesUpdate() {
 	s.NoError(err)
 	s.NotNil(pref)
 	changes := map[string]interface{}{
-		"dailyDigestComplete":     "IN_APP_ONLY",
-		"addedAsCollaborator":     "IN_APP_ONLY",
-		"taggedInDiscussion":      "IN_APP_ONLY",
-		"taggedInDiscussionReply": "IN_APP_ONLY",
-		"newDiscussionReply":      "IN_APP_ONLY",
-		"modelPlanShared":         "IN_APP_ONLY",
+		"dailyDigestComplete":     models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp},
+		"addedAsCollaborator":     models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp},
+		"taggedInDiscussion":      models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp},
+		"taggedInDiscussionReply": models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp},
+		"newDiscussionReply":      models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp},
+		"modelPlanShared":         models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp},
 	}
 	updatedPref, err := UserNotificationPreferencesUpdate(s.testConfigs.Context, s.testConfigs.Logger, s.testConfigs.Principal, s.testConfigs.Store, changes)
 	s.NoError(err)
 	s.NotNil(updatedPref)
 
-	s.EqualValues(models.UserNotificationPreferenceInAppOnly, updatedPref.DailyDigestComplete)
-	s.EqualValues(models.UserNotificationPreferenceInAppOnly, updatedPref.AddedAsCollaborator)
-	s.EqualValues(models.UserNotificationPreferenceInAppOnly, updatedPref.TaggedInDiscussion)
-	s.EqualValues(models.UserNotificationPreferenceInAppOnly, updatedPref.TaggedInDiscussionReply)
-	s.EqualValues(models.UserNotificationPreferenceInAppOnly, updatedPref.NewDiscussionReply)
-	s.EqualValues(models.UserNotificationPreferenceInAppOnly, updatedPref.ModelPlanShared)
+	s.EqualValues(models.UserNotificationPreferenceInApp, updatedPref.DailyDigestComplete)
+	s.EqualValues(models.UserNotificationPreferenceInApp, updatedPref.AddedAsCollaborator)
+	s.EqualValues(models.UserNotificationPreferenceInApp, updatedPref.TaggedInDiscussion)
+	s.EqualValues(models.UserNotificationPreferenceInApp, updatedPref.TaggedInDiscussionReply)
+	s.EqualValues(models.UserNotificationPreferenceInApp, updatedPref.NewDiscussionReply)
+	s.EqualValues(models.UserNotificationPreferenceInApp, updatedPref.ModelPlanShared)
 
 }

--- a/pkg/graph/schema/types/user_notification_preferences.graphql
+++ b/pkg/graph/schema/types/user_notification_preferences.graphql
@@ -11,17 +11,17 @@ type UserNotificationPreferences {
   id: UUID!
 	userID: UUID!
 
-  dailyDigestComplete: [UserNotificationPreferenceFlag!]
+  dailyDigestComplete: [UserNotificationPreferenceFlag!]!
 
-  addedAsCollaborator: [UserNotificationPreferenceFlag!]
+  addedAsCollaborator: [UserNotificationPreferenceFlag!]!
 
-  taggedInDiscussion: [UserNotificationPreferenceFlag!]
+  taggedInDiscussion: [UserNotificationPreferenceFlag!]!
 
-  taggedInDiscussionReply: [UserNotificationPreferenceFlag!]
+  taggedInDiscussionReply: [UserNotificationPreferenceFlag!]!
 
-  newDiscussionReply: [UserNotificationPreferenceFlag!]
+  newDiscussionReply: [UserNotificationPreferenceFlag!]!
 
-  modelPlanShared: [UserNotificationPreferenceFlag!]
+  modelPlanShared: [UserNotificationPreferenceFlag!]!
 
 
   createdBy: UUID!

--- a/pkg/graph/schema/types/user_notification_preferences.graphql
+++ b/pkg/graph/schema/types/user_notification_preferences.graphql
@@ -1,8 +1,6 @@
 enum UserNotificationPreferenceFlag {
-  ALL,
-  IN_APP_ONLY,
-  EMAIL_ONLY,
-  NONE
+  IN_APP,
+  EMAIL
 }
 
 
@@ -13,17 +11,17 @@ type UserNotificationPreferences {
   id: UUID!
 	userID: UUID!
 
-  dailyDigestComplete: UserNotificationPreferenceFlag!
+  dailyDigestComplete: [UserNotificationPreferenceFlag!]
 
-  addedAsCollaborator: UserNotificationPreferenceFlag!
+  addedAsCollaborator: [UserNotificationPreferenceFlag!]
 
-  taggedInDiscussion: UserNotificationPreferenceFlag!
+  taggedInDiscussion: [UserNotificationPreferenceFlag!]
 
-  taggedInDiscussionReply: UserNotificationPreferenceFlag!
+  taggedInDiscussionReply: [UserNotificationPreferenceFlag!]
 
-  newDiscussionReply: UserNotificationPreferenceFlag!
+  newDiscussionReply: [UserNotificationPreferenceFlag!]
 
-  modelPlanShared: UserNotificationPreferenceFlag!
+  modelPlanShared: [UserNotificationPreferenceFlag!]
 
 
   createdBy: UUID!
@@ -41,17 +39,17 @@ UserNotificationPreferencesChanges represents the ways that a UserNotifications 
 """
 input UserNotificationPreferencesChanges @goModel(model: "map[string]interface{}")  {
 
-  dailyDigestComplete: UserNotificationPreferenceFlag
+  dailyDigestComplete: [UserNotificationPreferenceFlag!]
 
-  addedAsCollaborator: UserNotificationPreferenceFlag
+  addedAsCollaborator: [UserNotificationPreferenceFlag!]
 
-  taggedInDiscussion: UserNotificationPreferenceFlag
+  taggedInDiscussion: [UserNotificationPreferenceFlag!]
 
-  taggedInDiscussionReply: UserNotificationPreferenceFlag
+  taggedInDiscussionReply: [UserNotificationPreferenceFlag!]
 
-  newDiscussionReply: UserNotificationPreferenceFlag
+  newDiscussionReply: [UserNotificationPreferenceFlag!]
 
-  modelPlanShared: UserNotificationPreferenceFlag
+  modelPlanShared: [UserNotificationPreferenceFlag!]
 
 
 }

--- a/pkg/models/user_notification_preferences.go
+++ b/pkg/models/user_notification_preferences.go
@@ -1,7 +1,12 @@
 package models
 
 import (
+	"database/sql/driver"
+
 	"github.com/google/uuid"
+	"github.com/samber/lo"
+
+	"github.com/cmsgov/mint-app/pkg/serialization"
 )
 
 // UserNotificationPreferences represents a discrete event that has happened in the application that might be notifiable.
@@ -10,12 +15,12 @@ type UserNotificationPreferences struct {
 	// The id of the user this preferences object is for
 	UserID uuid.UUID `json:"userID" db:"user_id"`
 
-	DailyDigestComplete     UserNotificationPreferenceFlag `json:"dailyDigestComplete" db:"daily_digest_complete"`
-	AddedAsCollaborator     UserNotificationPreferenceFlag `json:"addedAsCollaborator" db:"added_as_collaborator"`
-	TaggedInDiscussion      UserNotificationPreferenceFlag `json:"taggedInDiscussion" db:"tagged_in_discussion"`
-	TaggedInDiscussionReply UserNotificationPreferenceFlag `json:"taggedInDiscussionReply" db:"tagged_in_discussion_reply"`
-	NewDiscussionReply      UserNotificationPreferenceFlag `json:"newDiscussionReply" db:"new_discussion_reply"`
-	ModelPlanShared         UserNotificationPreferenceFlag `json:"modelPlanShared" db:"model_plan_shared"`
+	DailyDigestComplete     UserNotificationPreferenceFlags `json:"dailyDigestComplete" db:"daily_digest_complete"`
+	AddedAsCollaborator     UserNotificationPreferenceFlags `json:"addedAsCollaborator" db:"added_as_collaborator"`
+	TaggedInDiscussion      UserNotificationPreferenceFlags `json:"taggedInDiscussion" db:"tagged_in_discussion"`
+	TaggedInDiscussionReply UserNotificationPreferenceFlags `json:"taggedInDiscussionReply" db:"tagged_in_discussion_reply"`
+	NewDiscussionReply      UserNotificationPreferenceFlags `json:"newDiscussionReply" db:"new_discussion_reply"`
+	ModelPlanShared         UserNotificationPreferenceFlags `json:"modelPlanShared" db:"model_plan_shared"`
 }
 
 // NewUserNotificationPreferences returns a New UserNotificationPreferences
@@ -24,32 +29,51 @@ func NewUserNotificationPreferences(userID uuid.UUID) *UserNotificationPreferenc
 		baseStruct: NewBaseStruct(userID),
 		UserID:     userID,
 
-		DailyDigestComplete:     UserNotificationPreferenceAll,
-		AddedAsCollaborator:     UserNotificationPreferenceAll,
-		TaggedInDiscussion:      UserNotificationPreferenceAll,
-		TaggedInDiscussionReply: UserNotificationPreferenceAll,
-		NewDiscussionReply:      UserNotificationPreferenceAll,
-		ModelPlanShared:         UserNotificationPreferenceAll,
+		DailyDigestComplete:     DefaultUserNotificationPreferencesFlags(),
+		AddedAsCollaborator:     DefaultUserNotificationPreferencesFlags(),
+		TaggedInDiscussion:      DefaultUserNotificationPreferencesFlags(),
+		TaggedInDiscussionReply: DefaultUserNotificationPreferencesFlags(),
+		NewDiscussionReply:      DefaultUserNotificationPreferencesFlags(),
+		ModelPlanShared:         DefaultUserNotificationPreferencesFlags(),
 	}
 }
+
+// DefaultUserNotificationPreferencesFlags returns the default Preferences flag for any user, defaulting to all turned on.
+func DefaultUserNotificationPreferencesFlags() []UserNotificationPreferenceFlag {
+	return []UserNotificationPreferenceFlag{UserNotificationPreferenceInApp, UserNotificationPreferenceEmail}
+}
+
+// UserNotificationPreferenceFlags represents an array or User Notification Preference flags
+// Note, this typically would just be represented as a pq.StringArray, however, it is important to write receiver methods on the type
+// As such, we implement the sqlx Valuer and Scanner interfaces so we can serialize and deserialize directly to and from the database.
+type UserNotificationPreferenceFlags []UserNotificationPreferenceFlag
 
 // UserNotificationPreferenceFlag is an enum that represents the role of a user in a Discussion
 type UserNotificationPreferenceFlag string
 
 // These constants represent the possible values of a DiscussionUserRole
 const (
-	UserNotificationPreferenceAll       UserNotificationPreferenceFlag = "ALL"
-	UserNotificationPreferenceInAppOnly UserNotificationPreferenceFlag = "IN_APP_ONLY"
-	UserNotificationPreferenceEmailOnly UserNotificationPreferenceFlag = "EMAIL_ONLY"
-	UserNotificationPreferenceNone      UserNotificationPreferenceFlag = "NONE"
+	UserNotificationPreferenceInApp UserNotificationPreferenceFlag = "IN_APP"
+	UserNotificationPreferenceEmail UserNotificationPreferenceFlag = "EMAIL"
 )
 
 // InApp translates notification preferences to a bool. True means the user desires an in app notification for this notification type
-func (unp UserNotificationPreferenceFlag) InApp() bool {
-	return unp == UserNotificationPreferenceAll || unp == UserNotificationPreferenceInAppOnly
+func (unp UserNotificationPreferenceFlags) InApp() bool {
+	return lo.Contains(unp, UserNotificationPreferenceInApp)
 }
 
 // SendEmail translates notification preferences to a bool. True means the user desires an email for this notification type
-func (unp UserNotificationPreferenceFlag) SendEmail() bool {
-	return unp == UserNotificationPreferenceAll || unp == UserNotificationPreferenceEmailOnly
+func (unp UserNotificationPreferenceFlags) SendEmail() bool {
+	return lo.Contains(unp, UserNotificationPreferenceEmail)
+}
+
+// Scan is used by sql.scan to read the values from the DB
+func (unp *UserNotificationPreferenceFlags) Scan(src interface{}) error {
+	return serialization.GenericStringArrayScan(src, unp)
+}
+
+// Value implements the driver.Valuer interface.
+func (unp UserNotificationPreferenceFlags) Value() (driver.Value, error) {
+	return serialization.GenericStringArrayValue(unp)
+
 }

--- a/pkg/notifications/tagged_in_discussion_meta.go
+++ b/pkg/notifications/tagged_in_discussion_meta.go
@@ -42,7 +42,7 @@ func ActivityTaggedInDiscussionCreate(ctx context.Context, np sqlutils.NamedPrep
 				return nil, fmt.Errorf("unable to get user notification preference, Notification not created %w", err)
 			}
 
-			_, err = userNotificationCreate(ctx, np, activity, *mention.EntityUUID, pref.TaggedInDiscussion)
+			_, err = userNotificationCreate(ctx, np, retActivity, *mention.EntityUUID, pref.TaggedInDiscussion)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/notifications/tagged_in_discussion_reply_meta.go
+++ b/pkg/notifications/tagged_in_discussion_reply_meta.go
@@ -41,7 +41,7 @@ func ActivityTaggedInDiscussionReplyCreate(ctx context.Context, np sqlutils.Name
 				return nil, fmt.Errorf("unable to get user notification preference, Notification not created %w", err)
 			}
 
-			_, err = userNotificationCreate(ctx, np, activity, *mention.EntityUUID, pref.TaggedInDiscussionReply)
+			_, err = userNotificationCreate(ctx, np, retActivity, *mention.EntityUUID, pref.TaggedInDiscussionReply)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/notifications/user_notification.go
+++ b/pkg/notifications/user_notification.go
@@ -36,7 +36,7 @@ func userNotificationCreate(
 	// The id of the user the notification is for
 	userID uuid.UUID,
 	// the preference of a user about specific notification types
-	notificationPreference models.UserNotificationPreferenceFlag,
+	notificationPreference models.UserNotificationPreferenceFlags,
 
 ) (*models.UserNotification, error) {
 

--- a/pkg/notifications/user_notification_test.go
+++ b/pkg/notifications/user_notification_test.go
@@ -24,8 +24,8 @@ func (suite *NotificationsSuite) TestUserNotificationCreate() {
 	fakePrinc, err := useraccountstoretestconfigs.GetTestPrincipal(suite.testConfigs.Store, "FAKE")
 	suite.NoError(err)
 
-	preferenceFlag := models.UserNotificationPreferenceInAppOnly
-	notification, err := userNotificationCreate(suite.testConfigs.Context, suite.testConfigs.Store, createdActivity, fakePrinc.Account().ID, preferenceFlag)
+	preferenceFlags := models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp}
+	notification, err := userNotificationCreate(suite.testConfigs.Context, suite.testConfigs.Store, createdActivity, fakePrinc.Account().ID, preferenceFlags)
 	suite.NoError(err)
 	suite.NotNil(notification)
 
@@ -55,16 +55,16 @@ func (suite *NotificationsSuite) TestUserNotificationMarkReadFunctions() {
 	fakePrinc, err := useraccountstoretestconfigs.GetTestPrincipal(suite.testConfigs.Store, "FAKE")
 	suite.NoError(err)
 
-	preferenceFlag := models.UserNotificationPreferenceInAppOnly
-	notification1, err := userNotificationCreate(suite.testConfigs.Context, suite.testConfigs.Store, createdActivity, fakePrinc.Account().ID, preferenceFlag)
+	preferenceFlags := models.UserNotificationPreferenceFlags{models.UserNotificationPreferenceInApp}
+	notification1, err := userNotificationCreate(suite.testConfigs.Context, suite.testConfigs.Store, createdActivity, fakePrinc.Account().ID, preferenceFlags)
 	suite.NoError(err)
 	suite.NotNil(notification1)
 
-	notification2, err := userNotificationCreate(suite.testConfigs.Context, suite.testConfigs.Store, createdActivity, fakePrinc.Account().ID, preferenceFlag)
+	notification2, err := userNotificationCreate(suite.testConfigs.Context, suite.testConfigs.Store, createdActivity, fakePrinc.Account().ID, preferenceFlags)
 	suite.NoError(err)
 	suite.NotNil(notification2)
 
-	notification3, err := userNotificationCreate(suite.testConfigs.Context, suite.testConfigs.Store, createdActivity, fakePrinc.Account().ID, preferenceFlag)
+	notification3, err := userNotificationCreate(suite.testConfigs.Context, suite.testConfigs.Store, createdActivity, fakePrinc.Account().ID, preferenceFlags)
 	suite.NoError(err)
 	suite.NotNil(notification3)
 

--- a/pkg/serialization/array_types.go
+++ b/pkg/serialization/array_types.go
@@ -1,0 +1,209 @@
+package serialization
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"strings"
+
+	"fmt"
+)
+
+// Note: functionality initially explored in EASI-1982/generic_type_array_serialization
+
+// GenericStringArrayScan provides functionality
+func GenericStringArrayScan[ArrayType ~[]memberType, memberType ~string](src interface{}, array *ArrayType) error {
+	switch src := src.(type) {
+	case []byte:
+		return scanStringArrayBytes(src, array)
+	case string:
+		return scanStringArrayBytes([]byte(src), array)
+	case nil:
+		*array = nil
+		return nil
+	}
+	return fmt.Errorf("generic scan: cannot convert %T to an EnumArray", src)
+
+}
+
+// GenericStringArrayValue implements the driver.Valuer interface.
+func GenericStringArrayValue[ArrayType ~[]memberType, memberType ~string](a ArrayType) (driver.Value, error) {
+	if a == nil {
+		return nil, nil
+	}
+
+	if n := len(a); n > 0 {
+		// There will be at least two curly brackets, 2*N bytes of quotes,
+		// and N-1 bytes of delimiters.
+		b := make([]byte, 1, 1+3*n)
+		b[0] = '{'
+
+		b = appendArrayQuotedBytes(b, []byte(a[0]))
+		for i := 1; i < n; i++ {
+			b = append(b, ',')
+			b = appendArrayQuotedBytes(b, []byte(a[i]))
+		}
+
+		return string(append(b, '}')), nil
+	}
+
+	return "{}", nil
+
+}
+
+func scanStringArrayBytes[ArrayType ~[]memberType, memberType ~string](src []byte, a *ArrayType) error {
+	elems, err := scanLinearArray(src, []byte{','}, "StringArray")
+	if err != nil {
+		return err
+	}
+	if a != nil && len(elems) == 0 {
+		*a = (*a)[:0]
+	} else {
+		b := make(ArrayType, len(elems))
+		for i, v := range elems {
+			if b[i] = memberType(v); v == nil {
+				return fmt.Errorf(" parsing array element index %d: cannot convert nil to string", i)
+			}
+		}
+		*a = b
+	}
+	return nil
+}
+func appendArrayQuotedBytes(b, v []byte) []byte {
+	b = append(b, '"')
+	for {
+		i := bytes.IndexAny(v, `"\`)
+		if i < 0 {
+			b = append(b, v...)
+			break
+		}
+		if i > 0 {
+			b = append(b, v[:i]...)
+		}
+		b = append(b, '\\', v[i])
+		v = v[i+1:]
+	}
+	return append(b, '"')
+}
+
+// Taken from pq.string Array
+// parseArray extracts the dimensions and elements of an array represented in
+// text format. Only representations emitted by the backend are supported.
+// Notably, whitespace around brackets and delimiters is significant, and NULL
+// is case-sensitive.
+//
+// See http://www.postgresql.org/docs/current/static/arrays.html#ARRAYS-IO
+func parseArray(src, del []byte) (dims []int, elems [][]byte, err error) {
+	var depth, i int
+
+	if len(src) < 1 || src[0] != '{' {
+		return nil, nil, fmt.Errorf(" unable to parse array; expected %q at offset %d", '{', 0)
+	}
+
+Open:
+	for i < len(src) {
+		switch src[i] {
+		case '{':
+			depth++
+			i++
+		case '}':
+			elems = make([][]byte, 0)
+			goto Close
+		default:
+			break Open
+		}
+	}
+	dims = make([]int, i)
+
+Element:
+	for i < len(src) {
+		switch src[i] {
+		case '{':
+			if depth == len(dims) {
+				break Element
+			}
+			depth++
+			dims[depth-1] = 0
+			i++
+		case '"':
+			var elem = []byte{}
+			var escape bool
+			for i++; i < len(src); i++ {
+				if escape {
+					elem = append(elem, src[i])
+					escape = false
+				} else {
+					switch src[i] {
+					default:
+						elem = append(elem, src[i])
+					case '\\':
+						escape = true
+					case '"':
+						elems = append(elems, elem)
+						i++
+						break Element
+					}
+				}
+			}
+		default:
+			for start := i; i < len(src); i++ {
+				if bytes.HasPrefix(src[i:], del) || src[i] == '}' {
+					elem := src[start:i]
+					if len(elem) == 0 {
+						return nil, nil, fmt.Errorf(" unable to parse array; unexpected %q at offset %d", src[i], i)
+					}
+					if bytes.Equal(elem, []byte("NULL")) {
+						elem = nil
+					}
+					elems = append(elems, elem)
+					break Element
+				}
+			}
+		}
+	}
+
+	for i < len(src) {
+		if bytes.HasPrefix(src[i:], del) && depth > 0 {
+			dims[depth-1]++
+			i += len(del)
+			goto Element
+		} else if src[i] == '}' && depth > 0 {
+			dims[depth-1]++
+			depth--
+			i++
+		} else {
+			return nil, nil, fmt.Errorf(" unable to parse array; unexpected %q at offset %d", src[i], i)
+		}
+	}
+
+Close:
+	for i < len(src) {
+		if src[i] == '}' && depth > 0 {
+			depth--
+			i++
+		} else {
+			return nil, nil, fmt.Errorf(" unable to parse array; unexpected %q at offset %d", src[i], i)
+		}
+	}
+	if depth > 0 {
+		err = fmt.Errorf(" unable to parse array; expected %q at offset %d", '}', i)
+	}
+	if err == nil {
+		for _, d := range dims {
+			if (len(elems) % d) != 0 {
+				err = fmt.Errorf(" multidimensional arrays must have elements with matching dimensions")
+			}
+		}
+	}
+	return
+}
+
+func scanLinearArray(src, del []byte, typ string) (elems [][]byte, err error) {
+	dims, elems, err := parseArray(src, del)
+	if err != nil {
+		return nil, err
+	}
+	if len(dims) > 1 {
+		return nil, fmt.Errorf(" cannot convert ARRAY%s to %s", strings.Replace(fmt.Sprint(dims), " ", "][", -1), typ)
+	}
+	return elems, err
+}

--- a/pkg/serialization/serialization.go
+++ b/pkg/serialization/serialization.go
@@ -1,0 +1,2 @@
+// Package serialization provides utility for serializing and deserializing data
+package serialization

--- a/src/gql/gen/graphql.ts
+++ b/src/gql/gen/graphql.ts
@@ -2785,19 +2785,19 @@ export enum UserNotificationPreferenceFlag {
 /** UserNotificationPreferences represents a users preferences about what type and where to receive a notification */
 export type UserNotificationPreferences = {
   __typename: 'UserNotificationPreferences';
-  addedAsCollaborator?: Maybe<Array<UserNotificationPreferenceFlag>>;
+  addedAsCollaborator: Array<UserNotificationPreferenceFlag>;
   createdBy: Scalars['UUID']['output'];
   createdByUserAccount: UserAccount;
   createdDts: Scalars['Time']['output'];
-  dailyDigestComplete?: Maybe<Array<UserNotificationPreferenceFlag>>;
+  dailyDigestComplete: Array<UserNotificationPreferenceFlag>;
   id: Scalars['UUID']['output'];
-  modelPlanShared?: Maybe<Array<UserNotificationPreferenceFlag>>;
+  modelPlanShared: Array<UserNotificationPreferenceFlag>;
   modifiedBy?: Maybe<Scalars['UUID']['output']>;
   modifiedByUserAccount?: Maybe<UserAccount>;
   modifiedDts?: Maybe<Scalars['Time']['output']>;
-  newDiscussionReply?: Maybe<Array<UserNotificationPreferenceFlag>>;
-  taggedInDiscussion?: Maybe<Array<UserNotificationPreferenceFlag>>;
-  taggedInDiscussionReply?: Maybe<Array<UserNotificationPreferenceFlag>>;
+  newDiscussionReply: Array<UserNotificationPreferenceFlag>;
+  taggedInDiscussion: Array<UserNotificationPreferenceFlag>;
+  taggedInDiscussionReply: Array<UserNotificationPreferenceFlag>;
   userID: Scalars['UUID']['output'];
 };
 

--- a/src/gql/gen/graphql.ts
+++ b/src/gql/gen/graphql.ts
@@ -2778,39 +2778,37 @@ export type UserNotification = {
 };
 
 export enum UserNotificationPreferenceFlag {
-  ALL = 'ALL',
-  EMAIL_ONLY = 'EMAIL_ONLY',
-  IN_APP_ONLY = 'IN_APP_ONLY',
-  NONE = 'NONE'
+  EMAIL = 'EMAIL',
+  IN_APP = 'IN_APP'
 }
 
 /** UserNotificationPreferences represents a users preferences about what type and where to receive a notification */
 export type UserNotificationPreferences = {
   __typename: 'UserNotificationPreferences';
-  addedAsCollaborator: UserNotificationPreferenceFlag;
+  addedAsCollaborator?: Maybe<Array<UserNotificationPreferenceFlag>>;
   createdBy: Scalars['UUID']['output'];
   createdByUserAccount: UserAccount;
   createdDts: Scalars['Time']['output'];
-  dailyDigestComplete: UserNotificationPreferenceFlag;
+  dailyDigestComplete?: Maybe<Array<UserNotificationPreferenceFlag>>;
   id: Scalars['UUID']['output'];
-  modelPlanShared: UserNotificationPreferenceFlag;
+  modelPlanShared?: Maybe<Array<UserNotificationPreferenceFlag>>;
   modifiedBy?: Maybe<Scalars['UUID']['output']>;
   modifiedByUserAccount?: Maybe<UserAccount>;
   modifiedDts?: Maybe<Scalars['Time']['output']>;
-  newDiscussionReply: UserNotificationPreferenceFlag;
-  taggedInDiscussion: UserNotificationPreferenceFlag;
-  taggedInDiscussionReply: UserNotificationPreferenceFlag;
+  newDiscussionReply?: Maybe<Array<UserNotificationPreferenceFlag>>;
+  taggedInDiscussion?: Maybe<Array<UserNotificationPreferenceFlag>>;
+  taggedInDiscussionReply?: Maybe<Array<UserNotificationPreferenceFlag>>;
   userID: Scalars['UUID']['output'];
 };
 
 /** UserNotificationPreferencesChanges represents the ways that a UserNotifications Preferences object can be updated */
 export type UserNotificationPreferencesChanges = {
-  addedAsCollaborator?: InputMaybe<UserNotificationPreferenceFlag>;
-  dailyDigestComplete?: InputMaybe<UserNotificationPreferenceFlag>;
-  modelPlanShared?: InputMaybe<UserNotificationPreferenceFlag>;
-  newDiscussionReply?: InputMaybe<UserNotificationPreferenceFlag>;
-  taggedInDiscussion?: InputMaybe<UserNotificationPreferenceFlag>;
-  taggedInDiscussionReply?: InputMaybe<UserNotificationPreferenceFlag>;
+  addedAsCollaborator?: InputMaybe<Array<UserNotificationPreferenceFlag>>;
+  dailyDigestComplete?: InputMaybe<Array<UserNotificationPreferenceFlag>>;
+  modelPlanShared?: InputMaybe<Array<UserNotificationPreferenceFlag>>;
+  newDiscussionReply?: InputMaybe<Array<UserNotificationPreferenceFlag>>;
+  taggedInDiscussion?: InputMaybe<Array<UserNotificationPreferenceFlag>>;
+  taggedInDiscussionReply?: InputMaybe<Array<UserNotificationPreferenceFlag>>;
 };
 
 /** This is a wrapper for all information for a user  */


### PR DESCRIPTION
# EASI-4043
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

- Migrated user notification preferences to use an array instead of a single enum value
- introduced a serialization package to host helper methods to serialize this enum array (originally prototyped in `EASI-1982/generic_type_array_serialization`
   - We could have used a pq string array, but it seems important to be able to use receiver methods on this preference type. We will be using this value throughout the application.

## How to test this change
1. Use the updated postman collection to update user preferences.
2. Try to remove all preferences, and re-add preferences.
3. Verify the existing logic to not send an email if tagged in a discussion or a reply continues to function as expected.


Note: This code does not enforce that a preference not be duplicated in an entry, for example, IN_APP could be listed twice. The application will still handle this, considering the presence of the enum at least once to be enough to send a notification. 

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [x] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [x] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [x] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
