### PR TITLE
[NOREF] - Fixed previous names readonly render to now render in bullet

### DIFF
--- a/src/components/ShareExport/__snapshots__/index.test.tsx.snap
+++ b/src/components/ShareExport/__snapshots__/index.test.tsx.snap
@@ -207,11 +207,22 @@ exports[`ShareExportModal > matches the snapshot 1`] = `
                 >
                   Previous names
                 </p>
-                <div
-                  class="margin-y-0 font-body-md line-height-sans-4 text-pre-line"
+                <ul
+                  class="margin-y-0 padding-left-3"
                 >
-                  First NameSecond Name
-                </div>
+                  <li
+                    class="font-sans-md line-height-sans-4"
+                  >
+                    First Name
+                  </li>
+                  <ul />
+                  <li
+                    class="font-sans-md line-height-sans-4"
+                  >
+                    Second Name
+                  </li>
+                  <ul />
+                </ul>
               </div>
             </div>
             <div
@@ -8240,11 +8251,22 @@ exports[`ShareExportModal > matches the snapshot 2`] = `
                 >
                   Previous names
                 </p>
-                <div
-                  class="margin-y-0 font-body-md line-height-sans-4 text-pre-line"
+                <ul
+                  class="margin-y-0 padding-left-3"
                 >
-                  First NameSecond Name
-                </div>
+                  <li
+                    class="font-sans-md line-height-sans-4"
+                  >
+                    First Name
+                  </li>
+                  <ul />
+                  <li
+                    class="font-sans-md line-height-sans-4"
+                  >
+                    Second Name
+                  </li>
+                  <ul />
+                </ul>
               </div>
             </div>
             <div

--- a/src/views/ModelPlan/ReadOnly/ModelBasics/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/ModelBasics/__snapshots__/index.test.tsx.snap
@@ -37,11 +37,22 @@ exports[`Read Only Model Plan Summary -- Model Basics > matches snapshot 1`] = `
         >
           Previous names
         </p>
-        <div
-          class="margin-y-0 font-body-md line-height-sans-4 text-pre-line"
+        <ul
+          class="margin-y-0 padding-left-3"
         >
-          First NameSecond Name
-        </div>
+          <li
+            class="font-sans-md line-height-sans-4"
+          >
+            First Name
+          </li>
+          <ul />
+          <li
+            class="font-sans-md line-height-sans-4"
+          >
+            Second Name
+          </li>
+          <ul />
+        </ul>
       </div>
     </div>
     <div

--- a/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
@@ -530,11 +530,22 @@ exports[`Read Only Model Plan Summary > matches snapshot 1`] = `
                           >
                             Previous names
                           </p>
-                          <div
-                            class="margin-y-0 font-body-md line-height-sans-4 text-pre-line"
+                          <ul
+                            class="margin-y-0 padding-left-3"
                           >
-                            First NameSecond Name
-                          </div>
+                            <li
+                              class="font-sans-md line-height-sans-4"
+                            >
+                              First Name
+                            </li>
+                            <ul />
+                            <li
+                              class="font-sans-md line-height-sans-4"
+                            >
+                              Second Name
+                            </li>
+                            <ul />
+                          </ul>
                         </div>
                       </div>
                       <div

--- a/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.tsx
@@ -141,7 +141,8 @@ const RenderReadonlyValue = <
   // Renders a single value
   if (
     isTranslationFieldProperties(config) &&
-    !isTranslationFieldPropertiesWithOptions(config)
+    !isTranslationFieldPropertiesWithOptions(config) &&
+    !config.isArray
   ) {
     return <SingleValue value={value} />;
   }

--- a/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/util.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/util.tsx
@@ -28,9 +28,9 @@ export const formatListValues = <
     | TranslationFieldPropertiesWithOptions<T>, // Translation config
   value: T[] | undefined // field value/enum array
 ): string[] => {
-  if (!isTranslationFieldPropertiesWithOptions(config)) return [];
+  if (config.isArray || config.isModelLinks) return value as string[];
 
-  if (config.isModelLinks) return value as string[];
+  if (!isTranslationFieldPropertiesWithOptions(config)) return [];
 
   return getKeys(config.options)
     .filter(option => Array.isArray(value) && value?.includes(option))


### PR DESCRIPTION
# NOREF

![Screenshot 2024-02-29 at 1 32 54 PM](https://github.com/CMSgov/mint-app/assets/95709965/733ae6c7-e588-4449-bed7-c09ec61f95c7)

## Changes and Description

- Changed ReadonlySection to render `previousNames` in bullet, rather than plain string
- Updated snapshots

<!-- Put a description here! -->

## How to test this change

Verify that previous names now render in bullet for Basics and filter views

[Figma](https://www.figma.com/file/6tkIhfNfcsKEAkqXo1qvXH/MINT---Read-Only-View?type=design&node-id=4307-15843&mode=design&t=KpnkYWyv4SVorZBm-0)

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
