### PR TITLE
NOREF: Notification Preferences Fix

### DIFF
--- a/pkg/graph/resolvers/user_notification_preferences.go
+++ b/pkg/graph/resolvers/user_notification_preferences.go
@@ -18,6 +18,7 @@ func UserNotificationPreferencesGetByUserID(ctx context.Context, userID uuid.UUI
 }
 
 // UserNotificationPreferencesUpdate updates a user notification preferences object for a user
+// Notice: The specific UserNotificationPreference is inferred from the principal object. It will only update the notification preference for the current user.
 func UserNotificationPreferencesUpdate(ctx context.Context, logger *zap.Logger, principal authentication.Principal, store *storage.Store, changes map[string]interface{}) (*models.UserNotificationPreferences, error) {
 	existingPreferences, err := UserNotificationPreferencesGetByUserID(ctx, principal.Account().ID)
 	if err != nil {

--- a/pkg/sqlqueries/SQL/user_notification_preferences/update.sql
+++ b/pkg/sqlqueries/SQL/user_notification_preferences/update.sql
@@ -9,7 +9,7 @@ SET
     modified_by = :modified_by,
     modified_dts = CURRENT_TIMESTAMP
 WHERE 
-    id = :id AND created_by = :modified_by
+    id = :id
 RETURNING
 id,
 user_id,

--- a/pkg/storage/user_notification_preferencesStore.go
+++ b/pkg/storage/user_notification_preferencesStore.go
@@ -53,6 +53,13 @@ func UserNotificationPreferencesGetByUserIDLoader(np sqlutils.NamedPreparer, par
 
 // UserNotificationPreferencesUpdate updates a new UserNotificationPreferences in the database
 func UserNotificationPreferencesUpdate(np sqlutils.NamedPreparer, userNotificationPreferences *models.UserNotificationPreferences) (*models.UserNotificationPreferences, error) {
+	if userNotificationPreferences.ModifiedBy == nil {
+		return nil, fmt.Errorf(" modified not set for notification preference, unable to update")
+	}
+
+	if userNotificationPreferences.UserID != *userNotificationPreferences.ModifiedBy {
+		return nil, fmt.Errorf("a user may only update their own notification preference, %s attempted to modify  preference for %s", userNotificationPreferences.UserID, userNotificationPreferences.ModifiedBy)
+	}
 
 	retUserNotificationPref, procErr := sqlutils.GetProcedure[models.UserNotificationPreferences](np, sqlqueries.UserNotificationPreferences.Update, userNotificationPreferences)
 	if procErr != nil {

--- a/pkg/storage/user_notification_preferencesStore.go
+++ b/pkg/storage/user_notification_preferencesStore.go
@@ -53,14 +53,6 @@ func UserNotificationPreferencesGetByUserIDLoader(np sqlutils.NamedPreparer, par
 
 // UserNotificationPreferencesUpdate updates a new UserNotificationPreferences in the database
 func UserNotificationPreferencesUpdate(np sqlutils.NamedPreparer, userNotificationPreferences *models.UserNotificationPreferences) (*models.UserNotificationPreferences, error) {
-	if userNotificationPreferences.ModifiedBy == nil {
-		return nil, fmt.Errorf(" modified not set for notification preference, unable to update")
-	}
-
-	if userNotificationPreferences.UserID != *userNotificationPreferences.ModifiedBy {
-		return nil, fmt.Errorf("a user may only update their own notification preference, %s attempted to modify  preference for %s", userNotificationPreferences.UserID, userNotificationPreferences.ModifiedBy)
-	}
-
 	retUserNotificationPref, procErr := sqlutils.GetProcedure[models.UserNotificationPreferences](np, sqlqueries.UserNotificationPreferences.Update, userNotificationPreferences)
 	if procErr != nil {
 		return nil, fmt.Errorf("issue updating UserNotificationPreferences object: %w", procErr)


### PR DESCRIPTION

## Changes and Description

- Update the check to see if a notification belongs to a user in the app code to make an error clearer. Take the check out of the SQL and make it an app code responsibility.


## How to test this change
 This will be easiest to test in a deployed environment. A smoke test might be sufficient for now here! If you do want to test this locally,
 
 1. Comment out all notification migrations,
 2.  Do some queries or log into the app to make a user account reference
 3. Run the migrations to add preference for existing user accounts
 4. Verify that updating the notification preference for that user doesn't fail.

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
