### PR TITLE
[EASI-4134] Add parent relation for other type questions

### DIFF
--- a/src/i18n/en-US/modelPlan/basics.ts
+++ b/src/i18n/en-US/modelPlan/basics.ts
@@ -172,6 +172,7 @@ export const basics: TranslationBasics = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'modelType',
     filterGroups: [
       ModelViewFilter.DFSDM,
       ModelViewFilter.IPC,

--- a/src/i18n/en-US/modelPlan/beneficiaries.ts
+++ b/src/i18n/en-US/modelPlan/beneficiaries.ts
@@ -93,6 +93,7 @@ export const beneficiaries: TranslationBeneficiaries = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'treatDualElligibleDifferent',
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]
   },
   treatDualElligibleDifferentNote: {
@@ -132,6 +133,7 @@ export const beneficiaries: TranslationBeneficiaries = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'excludeCertainCharacteristics',
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]
   },
   excludeCertainCharacteristicsNote: {
@@ -254,6 +256,7 @@ export const beneficiaries: TranslationBeneficiaries = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'beneficiarySelectionFrequency',
     filterGroups: [ModelViewFilter.CMMI]
   },
   beneficiarySelectionFrequencyOther: {
@@ -264,6 +267,7 @@ export const beneficiaries: TranslationBeneficiaries = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'beneficiarySelectionFrequency',
     filterGroups: [ModelViewFilter.CMMI]
   },
   beneficiarySelectionFrequencyNote: {
@@ -300,6 +304,7 @@ export const beneficiaries: TranslationBeneficiaries = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'beneficiaryRemovalFrequency',
     filterGroups: [ModelViewFilter.CMMI]
   },
   beneficiaryRemovalFrequencyOther: {
@@ -310,6 +315,7 @@ export const beneficiaries: TranslationBeneficiaries = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'beneficiaryRemovalFrequency',
     filterGroups: [ModelViewFilter.CMMI]
   },
   beneficiaryRemovalFrequencyNote: {
@@ -372,6 +378,7 @@ export const beneficiaries: TranslationBeneficiaries = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'precedenceRules',
     filterGroups: [ModelViewFilter.MDM, ModelViewFilter.OACT]
   },
   precedenceRulesNo: {
@@ -382,6 +389,7 @@ export const beneficiaries: TranslationBeneficiaries = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'precedenceRules',
     filterGroups: [ModelViewFilter.MDM, ModelViewFilter.OACT]
   },
   precedenceRulesNote: {

--- a/src/i18n/en-US/modelPlan/generalCharacteristics.ts
+++ b/src/i18n/en-US/modelPlan/generalCharacteristics.ts
@@ -101,7 +101,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'text',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'resemblesExistingModel'
   },
   // Not rendered in any form/ui
   resemblesExistingModelOtherSelected: {
@@ -164,7 +165,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'text',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'participationInModelPrecondition'
   },
   participationInModelPreconditionWhich: {
     gqlField: 'participationInModelPreconditionWhich',
@@ -207,7 +209,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     label: 'Please specify other',
     dataType: 'string',
     formType: 'text',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'participationInModelPreconditionWhich'
   },
   participationInModelPreconditionWhyHow: {
     gqlField: 'participationInModelPreconditionWhyHow',
@@ -253,6 +256,7 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'hasComponentsOrTracks',
     filterGroups: [ModelViewFilter.IPC]
   },
   hasComponentsOrTracksNote: {
@@ -293,7 +297,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'agencyOrStateHelp'
   },
   agencyOrStateHelpNote: {
     gqlField: 'agencyOrStateHelpNote',
@@ -482,7 +487,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     label: 'How so?',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'careCoordinationInvolved'
   },
   careCoordinationInvolvedNote: {
     gqlField: 'careCoordinationInvolvedNote',
@@ -515,7 +521,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     label: 'How so?',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'additionalServicesInvolved'
   },
   additionalServicesInvolvedNote: {
     gqlField: 'additionalServicesInvolvedNote',
@@ -548,7 +555,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     label: 'How so?',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'communityPartnersInvolved'
   },
   communityPartnersInvolvedNote: {
     gqlField: 'communityPartnersInvolvedNote',
@@ -754,6 +762,7 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'geographiesTargetedTypes',
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]
   },
   geographiesTargetedAppliedTo: {
@@ -848,6 +857,7 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'agreementTypes',
     filterGroups: [ModelViewFilter.CMMI]
   },
   multiplePatricipationAgreementsNeeded: {
@@ -939,6 +949,7 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'authorityAllowances',
     filterGroups: [ModelViewFilter.CMMI]
   },
   authorityAllowancesNote: {

--- a/src/i18n/en-US/modelPlan/opsEvalAndLearning.ts
+++ b/src/i18n/en-US/modelPlan/opsEvalAndLearning.ts
@@ -105,6 +105,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'contractorSupport',
     filterGroups: [
       ModelViewFilter.CBOSC,
       ModelViewFilter.IDDOC,
@@ -210,6 +211,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'technicalContactsIdentified',
     filterGroups: [ModelViewFilter.IDDOC]
   },
   technicalContactsIdentifiedNote: {
@@ -350,6 +352,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'dataMonitoringFileTypes',
     filterGroups: [ModelViewFilter.IDDOC]
   },
   dataResponseType: {
@@ -744,6 +747,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'ccmInvolvment',
     filterGroups: [ModelViewFilter.CCW]
   },
   ccmInvolvmentNote: {
@@ -845,6 +849,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'dataToSendParticicipants',
     filterGroups: [ModelViewFilter.CMMI]
   },
   dataToSendParticicipantsNote: {
@@ -931,6 +936,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'appToSendFilesToWhich',
     filterGroups: [ModelViewFilter.CCW]
   },
   appToSendFilesToNote: {
@@ -1016,6 +1022,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'qualityPerformanceImpactsPayment',
     filterGroups: [ModelViewFilter.CMMI]
   },
   qualityPerformanceImpactsPaymentNote: {
@@ -1064,6 +1071,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'dataSharingStarts',
     filterGroups: [ModelViewFilter.IDDOC]
   },
   dataSharingFrequency: {
@@ -1088,6 +1096,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'dataSharingFrequency',
     filterGroups: [ModelViewFilter.CMMI, ModelViewFilter.IDDOC]
   },
   dataSharingFrequencyOther: {
@@ -1098,6 +1107,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'dataSharingFrequency',
     filterGroups: [ModelViewFilter.CMMI, ModelViewFilter.IDDOC]
   },
   dataSharingStartsNote: {
@@ -1141,6 +1151,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'dataCollectionStarts',
     filterGroups: [ModelViewFilter.IDDOC]
   },
   dataCollectionFrequency: {
@@ -1165,6 +1176,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'dataCollectionFrequency',
     filterGroups: [ModelViewFilter.CMMI]
   },
   dataCollectionFrequencyOther: {
@@ -1175,6 +1187,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'dataCollectionFrequency',
     filterGroups: [ModelViewFilter.CMMI]
   },
   dataCollectionFrequencyNote: {
@@ -1206,7 +1219,7 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
       OTHER: 'Other'
     },
     optionsRelatedInfo: {
-      OTHER: ''
+      OTHER: 'qualityReportingStartsOther'
     }
   },
   qualityReportingStartsOther: {
@@ -1216,7 +1229,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'qualityReportingStarts'
   },
   qualityReportingStartsNote: {
     gqlField: 'qualityReportingStartsNote',
@@ -1246,7 +1260,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'qualityReportingFrequency'
   },
   qualityReportingFrequencyOther: {
     gqlField: 'qualityReportingFrequencyOther',
@@ -1255,7 +1270,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'qualityReportingFrequency'
   },
   modelLearningSystems: {
     gqlField: 'modelLearningSystems',
@@ -1286,7 +1302,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'modelLearningSystems'
   },
   modelLearningSystemsNote: {
     gqlField: 'modelLearningSystemsNote',

--- a/src/i18n/en-US/modelPlan/participantsAndProviders.ts
+++ b/src/i18n/en-US/modelPlan/participantsAndProviders.ts
@@ -54,6 +54,7 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'participants',
     filterGroups: [
       ModelViewFilter.CBOSC,
       ModelViewFilter.CMMI,
@@ -231,7 +232,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'recruitmentMethod'
   },
   recruitmentNote: {
     gqlField: 'recruitmentNote',
@@ -322,6 +324,7 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'participantAddedFrequency',
     filterGroups: [ModelViewFilter.IPC]
   },
   participantAddedFrequencyOther: {
@@ -332,6 +335,7 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'participantAddedFrequency',
     filterGroups: [ModelViewFilter.IPC]
   },
   participantAddedFrequencyNote: {
@@ -365,6 +369,7 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'participantRemovedFrequency',
     filterGroups: [ModelViewFilter.IPC]
   },
   participantRemovedFrequencyOther: {
@@ -375,6 +380,7 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'participantRemovedFrequency',
     filterGroups: [ModelViewFilter.IPC]
   },
   participantRemovedFrequencyNote: {
@@ -413,6 +419,7 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'communicationMethod',
     filterGroups: [ModelViewFilter.CBOSC, ModelViewFilter.IPC]
   },
   communicationNote: {
@@ -449,7 +456,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'riskType'
   },
   riskNote: {
     gqlField: 'riskNote',
@@ -565,7 +573,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'text',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'gainsharePaymentsEligibility'
   },
   gainsharePaymentsNote: {
     gqlField: 'gainsharePaymentsNote',
@@ -605,6 +614,7 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'participantsIds',
     filterGroups: [ModelViewFilter.IDDOC]
   },
   participantsIDSNote: {
@@ -639,6 +649,7 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'providerAdditionFrequency',
     filterGroups: [ModelViewFilter.OACT, ModelViewFilter.IPC]
   },
   providerAdditionFrequencyOther: {
@@ -649,6 +660,7 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'providerAdditionFrequency',
     filterGroups: [ModelViewFilter.OACT, ModelViewFilter.IPC]
   },
   providerAdditionFrequencyNote: {
@@ -740,8 +752,9 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'textarea',
-    filterGroups: [ModelViewFilter.IPC, ModelViewFilter.OACT],
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'providerLeaveMethod',
+    filterGroups: [ModelViewFilter.IPC, ModelViewFilter.OACT]
   },
   providerLeaveMethodNote: {
     gqlField: 'providerLeaveMethodNote',
@@ -772,7 +785,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'text',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'providerRemovalFrequency'
   },
   providerRemovalFrequencyOther: {
     gqlField: 'providerRemovalFrequencyOther',
@@ -781,7 +795,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'text',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'providerRemovalFrequency'
   },
   providerRemovalFrequencyNote: {
     gqlField: 'providerRemovalFrequencyNote',

--- a/src/i18n/en-US/modelPlan/payments.ts
+++ b/src/i18n/en-US/modelPlan/payments.ts
@@ -47,6 +47,7 @@ export const payments: TranslationPayments = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'fundingSource',
     filterGroups: [
       ModelViewFilter.DFSDM,
       ModelViewFilter.IPC,
@@ -61,6 +62,7 @@ export const payments: TranslationPayments = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'fundingSource',
     filterGroups: [
       ModelViewFilter.DFSDM,
       ModelViewFilter.IPC,
@@ -137,6 +139,7 @@ export const payments: TranslationPayments = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'fundingSourceR',
     filterGroups: [
       ModelViewFilter.DFSDM,
       ModelViewFilter.IPC,
@@ -151,6 +154,7 @@ export const payments: TranslationPayments = {
     dataType: 'string',
     formType: 'text',
     isOtherType: true,
+    otherParentField: 'fundingSourceR',
     filterGroups: [
       ModelViewFilter.DFSDM,
       ModelViewFilter.IPC,
@@ -403,6 +407,7 @@ export const payments: TranslationPayments = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'affectsMedicareSecondaryPayerClaims',
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]
   },
   affectsMedicareSecondaryPayerClaimsNote: {
@@ -556,6 +561,7 @@ export const payments: TranslationPayments = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'waiveBeneficiaryCostSharingForAnyServices',
     filterGroups: [
       ModelViewFilter.IDDOC,
       ModelViewFilter.OACT,
@@ -787,7 +793,8 @@ export const payments: TranslationPayments = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'text',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'claimsProcessingPrecedence'
   },
   claimsProcessingPrecedenceNote: {
     gqlField: 'claimsProcessingPrecedenceNote',
@@ -824,6 +831,7 @@ export const payments: TranslationPayments = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'canParticipantsSelectBetweenPaymentMechanisms',
     filterGroups: [ModelViewFilter.CMMI]
   },
   canParticipantsSelectBetweenPaymentMechanismsNote: {
@@ -861,6 +869,7 @@ export const payments: TranslationPayments = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'anticipatedPaymentFrequency',
     filterGroups: [
       ModelViewFilter.CMMI,
       ModelViewFilter.DFSDM,
@@ -875,6 +884,7 @@ export const payments: TranslationPayments = {
     dataType: 'string',
     formType: 'textarea',
     isOtherType: true,
+    otherParentField: 'anticipatedPaymentFrequency',
     filterGroups: [
       ModelViewFilter.CMMI,
       ModelViewFilter.DFSDM,
@@ -967,7 +977,8 @@ export const payments: TranslationPayments = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'paymentReconciliationFrequency'
   },
   paymentReconciliationFrequencyOther: {
     gqlField: 'paymentReconciliationFrequencyOther',
@@ -976,7 +987,8 @@ export const payments: TranslationPayments = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'paymentReconciliationFrequency'
   },
   paymentReconciliationFrequencyNote: {
     gqlField: 'paymentReconciliationFrequencyNote',
@@ -1006,7 +1018,8 @@ export const payments: TranslationPayments = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'paymentDemandRecoupmentFrequency'
   },
   paymentDemandRecoupmentFrequencyOther: {
     gqlField: 'paymentDemandRecoupmentFrequencyOther',
@@ -1015,7 +1028,8 @@ export const payments: TranslationPayments = {
     label: 'Please specify',
     dataType: 'string',
     formType: 'textarea',
-    isOtherType: true
+    isOtherType: true,
+    otherParentField: 'paymentDemandRecoupmentFrequency'
   },
   paymentDemandRecoupmentFrequencyNote: {
     gqlField: 'paymentDemandRecoupmentFrequencyNote',

--- a/src/types/translation.ts
+++ b/src/types/translation.ts
@@ -101,7 +101,7 @@ export type TranslationFieldProperties = {
   };
   isOtherType?: boolean; // Is a question a followup to another that doesn't designate it's own readonly question/line,
   hideRelatedQuestionAlert?: boolean; // Ex: CCW and Quality questions do not need to render the alert immediately following the question
-  otherParentField?: string; // gql field name for the parent question for fields that represent Other, Please specify, etc
+  otherParentField?: string; // gql field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context
 };
 
 /* 

--- a/src/types/translation.ts
+++ b/src/types/translation.ts
@@ -101,6 +101,7 @@ export type TranslationFieldProperties = {
   };
   isOtherType?: boolean; // Is a question a followup to another that doesn't designate it's own readonly question/line,
   hideRelatedQuestionAlert?: boolean; // Ex: CCW and Quality questions do not need to render the alert immediately following the question
+  otherParentField?: string; // gql field name for the parent question for fields that represent Other, Please specify, etc
 };
 
 /* 


### PR DESCRIPTION
# EASI-4134
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

Currently questions that read `Please specify` or `How so` have no directly connection to the parent question.  In preparation for Change History, extending the translation type to allow for this optional field that references the parent gql field.

- Added optional type - `otherParentField`  on `TranslationFieldProperties` 
- Populated task list translation sections with `otherParentField` where applicable

Some questions gave enough information, such as `Please specify what the other geography type is.`
In this case, there is enough context and no parent relation would be needed.

<!-- Put a description here! -->

## How to test this change

Nothing should really need to be tested as this is prep work for CH

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
