### PR TITLE
EASI-4179: temporarily disable main dev deploy

### DIFF
--- a/.github/workflows/change_history_dev_deploy.yml
+++ b/.github/workflows/change_history_dev_deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy Change History Pipeline
+
+on:
+  push:
+    branches:
+      - feature/EASI-2771_model_plan_change_history
+      
+concurrency:
+  group: change-history-dev-deploy
+
+jobs:
+  run_tests:
+    uses: ./.github/workflows/run_tests.yml
+    secrets: inherit
+
+  build_frontend_assets:
+    strategy:
+      matrix:
+        env: [dev]
+    uses: ./.github/workflows/build_frontend_assets.yml
+    with:
+      env: ${{ matrix.env }}
+    secrets: inherit
+
+  build_application_images:
+    uses: ./.github/workflows/build_application_images.yml
+    needs: run_tests
+    secrets: inherit
+
+  deploy_dev:
+    needs: [build_application_images, build_frontend_assets]
+    uses: ./.github/workflows/deploy_to_environment.yml
+    with:
+      env: dev
+    secrets: inherit

--- a/.github/workflows/deploy_pipeline.yml
+++ b/.github/workflows/deploy_pipeline.yml
@@ -27,12 +27,13 @@ jobs:
     needs: run_tests
     secrets: inherit
 
-  deploy_dev:
-    needs: [build_application_images, build_frontend_assets]
-    uses: ./.github/workflows/deploy_to_environment.yml
-    with:
-      env: dev
-    secrets: inherit
+  # EASI-4179: Temporary disable deploy_dev
+  # deploy_dev:
+  #   needs: [build_application_images, build_frontend_assets]
+  #   uses: ./.github/workflows/deploy_to_environment.yml
+  #   with:
+  #     env: dev
+  #   secrets: inherit
 
   deploy_test:
     needs: [build_application_images, build_frontend_assets]
@@ -42,7 +43,9 @@ jobs:
     secrets: inherit
 
   deploy_impl:
-    needs: [deploy_dev, deploy_test]
+    # EASI-4179: Temporary disable needs deploy_dev
+    # needs: [deploy_dev, deploy_test]
+    needs: deploy_test
     uses: ./.github/workflows/deploy_to_environment.yml
     with:
       env: impl

--- a/.github/workflows/deploy_pipeline.yml
+++ b/.github/workflows/deploy_pipeline.yml
@@ -16,7 +16,9 @@ jobs:
   build_frontend_assets:
     strategy:
       matrix:
-        env: [dev, test, impl, prod]
+        # EASI-4179: Temporary disable dev build
+        # env: [dev, test, impl, prod]
+        env: [test, impl, prod]
     uses: ./.github/workflows/build_frontend_assets.yml
     with:
       env: ${{ matrix.env }}

--- a/.github/workflows/deploy_to_environment.yml
+++ b/.github/workflows/deploy_to_environment.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           ./scripts/rds-snapshot-app-db.sh    
       - name: Clean the database
-        if: contains(inputs.env, 'dev')
+        if:  ${{ contains(inputs.env, 'dev') && vars.ENABLE_DEV_DB_CLEAN == '1' }}
         env:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
           ECR_REPOSITORY: mint-db-clean


### PR DESCRIPTION
# EASI-4179

## Changes and Description

- Temporarily disable main deploy to dev
- Introduce temporary pipeline to deploy change history branch to dev
- add variable ENABLE_DEV_DB_CLEAN to enable/disable DB clean in dev


## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
