### PR TITLE
[EASI-4194] Note translations

### DIFF
--- a/mappings/export/exportTranslation.test.ts
+++ b/mappings/export/exportTranslation.test.ts
@@ -239,7 +239,9 @@ describe('exportTranslation Util', () => {
         gqlField: 'phasedInNote',
         goField: 'PhasedInNote',
         dbField: 'phased_in_note',
-        label: 'Notes'
+        label: 'Notes',
+        isNote: true,
+        otherParentField: 'phased_in'
       },
       status: {
         gqlField: 'status',

--- a/mappings/export/exportTranslation.test.ts
+++ b/mappings/export/exportTranslation.test.ts
@@ -156,7 +156,9 @@ describe('exportTranslation Util', () => {
         gqlField: 'note',
         goField: 'Note',
         dbField: 'note',
-        label: 'Notes'
+        label: 'Notes',
+        isNote: true,
+        parentReferencesLabel: 'Model basics'
       },
       completeICIP: {
         gqlField: 'completeICIP',
@@ -210,7 +212,9 @@ describe('exportTranslation Util', () => {
         gqlField: 'highLevelNote',
         goField: 'HighLevelNote',
         dbField: 'high_level_note',
-        label: 'Notes'
+        label: 'Notes',
+        isNote: true,
+        parentReferencesLabel: 'Timeline'
       },
       wrapUpEnds: {
         gqlField: 'wrapUpEnds',

--- a/mappings/translation/plan_basics.json
+++ b/mappings/translation/plan_basics.json
@@ -113,7 +113,9 @@
     "gqlField": "note",
     "goField": "Note",
     "dbField": "note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "parentReferencesLabel": "Model basics"
   },
   "completeICIP": {
     "gqlField": "completeICIP",
@@ -167,7 +169,9 @@
     "gqlField": "highLevelNote",
     "goField": "HighLevelNote",
     "dbField": "high_level_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "parentReferencesLabel": "Timeline"
   },
   "wrapUpEnds": {
     "gqlField": "wrapUpEnds",

--- a/mappings/translation/plan_basics.json
+++ b/mappings/translation/plan_basics.json
@@ -194,7 +194,9 @@
     "gqlField": "phasedInNote",
     "goField": "PhasedInNote",
     "dbField": "phased_in_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "phased_in"
   },
   "status": {
     "gqlField": "status",

--- a/mappings/translation/plan_beneficiaries.json
+++ b/mappings/translation/plan_beneficiaries.json
@@ -39,7 +39,9 @@
     "gqlField": "beneficiariesNote",
     "goField": "BeneficiariesNote",
     "dbField": "beneficiaries_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "beneficiaries"
   },
   "treatDualElligibleDifferent": {
     "gqlField": "treatDualElligibleDifferent",
@@ -65,7 +67,9 @@
     "gqlField": "treatDualElligibleDifferentNote",
     "goField": "TreatDualElligibleDifferentNote",
     "dbField": "treat_dual_elligible_different_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "treat_dual_elligible_different"
   },
   "excludeCertainCharacteristics": {
     "gqlField": "excludeCertainCharacteristics",
@@ -91,7 +95,9 @@
     "gqlField": "excludeCertainCharacteristicsNote",
     "goField": "ExcludeCertainCharacteristicsNote",
     "dbField": "exclude_certain_characteristics_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "exclude_certain_characteristics"
   },
   "numberPeopleImpacted": {
     "gqlField": "numberPeopleImpacted",
@@ -115,7 +121,9 @@
     "gqlField": "confidenceNote",
     "goField": "ConfidenceNote",
     "dbField": "confidence_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "number_people_impacted"
   },
   "beneficiarySelectionMethod": {
     "gqlField": "beneficiarySelectionMethod",
@@ -145,7 +153,9 @@
     "gqlField": "beneficiarySelectionNote",
     "goField": "BeneficiarySelectionNote",
     "dbField": "beneficiary_selection_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "beneficiary_selection_method"
   },
   "beneficiarySelectionFrequency": {
     "gqlField": "beneficiarySelectionFrequency",
@@ -181,7 +191,9 @@
     "gqlField": "beneficiarySelectionFrequencyNote",
     "goField": "BeneficiarySelectionFrequencyNote",
     "dbField": "beneficiary_selection_frequency_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "beneficiary_selection_frequency"
   },
   "beneficiaryRemovalFrequency": {
     "gqlField": "beneficiaryRemovalFrequency",
@@ -217,7 +229,9 @@
     "gqlField": "beneficiaryRemovalFrequencyNote",
     "goField": "BeneficiaryRemovalFrequencyNote",
     "dbField": "beneficiary_removal_frequency_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "beneficiary_removal_frequency"
   },
   "beneficiaryOverlap": {
     "gqlField": "beneficiaryOverlap",
@@ -234,7 +248,9 @@
     "gqlField": "beneficiaryOverlapNote",
     "goField": "BeneficiaryOverlapNote",
     "dbField": "beneficiary_overlap_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "beneficiary_overlap"
   },
   "precedenceRules": {
     "gqlField": "precedenceRules",
@@ -267,7 +283,9 @@
     "gqlField": "precedenceRulesNote",
     "goField": "PrecedenceRulesNote",
     "dbField": "precedence_rules_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "precedence_rules"
   },
   "status": {
     "gqlField": "status",

--- a/mappings/translation/plan_general_characteristics.json
+++ b/mappings/translation/plan_general_characteristics.json
@@ -160,7 +160,9 @@
     "gqlField": "resemblesExistingModelNote",
     "goField": "ResemblesExistingModelNote",
     "dbField": "resembles_existing_model_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "resembles_existing_model"
   },
   "participationInModelPrecondition": {
     "gqlField": "participationInModelPrecondition",
@@ -266,7 +268,9 @@
     "gqlField": "participationInModelPreconditionNote",
     "goField": "ParticipationInModelPreconditionNote",
     "dbField": "participation_in_model_precondition_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "participation_in_model_precondition"
   },
   "hasComponentsOrTracks": {
     "gqlField": "hasComponentsOrTracks",
@@ -291,7 +295,9 @@
     "gqlField": "hasComponentsOrTracksNote",
     "goField": "HasComponentsOrTracksNote",
     "dbField": "has_components_or_tracks_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "has_components_or_tracks"
   },
   "agencyOrStateHelp": {
     "gqlField": "agencyOrStateHelp",
@@ -319,7 +325,9 @@
     "gqlField": "agencyOrStateHelpNote",
     "goField": "AgencyOrStateHelpNote",
     "dbField": "agency_or_state_help_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "agency_or_state_help"
   },
   "alternativePaymentModelTypes": {
     "gqlField": "alternativePaymentModelTypes",
@@ -338,7 +346,9 @@
     "gqlField": "alternativePaymentModelNote",
     "goField": "AlternativePaymentModelNote",
     "dbField": "alternative_payment_model_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "alternative_payment_model_types"
   },
   "keyCharacteristics": {
     "gqlField": "keyCharacteristics",
@@ -438,7 +448,9 @@
     "gqlField": "keyCharacteristicsNote",
     "goField": "KeyCharacteristicsNote",
     "dbField": "key_characteristics_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "key_characteristics"
   },
   "collectPlanBids": {
     "gqlField": "collectPlanBids",
@@ -475,7 +487,9 @@
     "gqlField": "collectPlanBidsNote",
     "goField": "CollectPlanBidsNote",
     "dbField": "collect_plan_bids_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "collect_plan_bids"
   },
   "managePartCDEnrollment": {
     "gqlField": "managePartCDEnrollment",
@@ -512,7 +526,9 @@
     "gqlField": "managePartCDEnrollmentNote",
     "goField": "ManagePartCDEnrollmentNote",
     "dbField": "manage_part_c_d_enrollment_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "manage_part_c_d_enrollment"
   },
   "planContractUpdated": {
     "gqlField": "planContractUpdated",
@@ -549,7 +565,9 @@
     "gqlField": "planContractUpdatedNote",
     "goField": "PlanContractUpdatedNote",
     "dbField": "plan_contract_updated_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "plan_contract_updated"
   },
   "careCoordinationInvolved": {
     "gqlField": "careCoordinationInvolved",
@@ -574,7 +592,9 @@
     "gqlField": "careCoordinationInvolvedNote",
     "goField": "CareCoordinationInvolvedNote",
     "dbField": "care_coordination_involved_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "care_coordination_involved"
   },
   "additionalServicesInvolved": {
     "gqlField": "additionalServicesInvolved",
@@ -599,7 +619,9 @@
     "gqlField": "additionalServicesInvolvedNote",
     "goField": "AdditionalServicesInvolvedNote",
     "dbField": "additional_services_involved_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "additional_services_involved"
   },
   "communityPartnersInvolved": {
     "gqlField": "communityPartnersInvolved",
@@ -624,7 +646,9 @@
     "gqlField": "communityPartnersInvolvedNote",
     "goField": "CommunityPartnersInvolvedNote",
     "dbField": "community_partners_involved_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "community_partners_involved"
   },
   "geographiesTargeted": {
     "gqlField": "geographiesTargeted",
@@ -1173,7 +1197,9 @@
     "gqlField": "geographiesTargetedNote",
     "goField": "GeographiesTargetedNote",
     "dbField": "geographies_targeted_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "geographies_targeted"
   },
   "participationOptions": {
     "gqlField": "participationOptions",
@@ -1189,7 +1215,9 @@
     "gqlField": "participationOptionsNote",
     "goField": "ParticipationOptionsNote",
     "dbField": "participation_options_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "participation_options"
   },
   "agreementTypes": {
     "gqlField": "agreementTypes",
@@ -1253,7 +1281,9 @@
     "gqlField": "multiplePatricipationAgreementsNeededNote",
     "goField": "MultiplePatricipationAgreementsNeededNote",
     "dbField": "multiple_patricipation_agreements_needed_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "multiple_patricipation_agreements_needed"
   },
   "rulemakingRequired": {
     "gqlField": "rulemakingRequired",
@@ -1277,7 +1307,9 @@
     "gqlField": "rulemakingRequiredNote",
     "goField": "RulemakingRequiredNote",
     "dbField": "rulemaking_required_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "rulemaking_required"
   },
   "authorityAllowances": {
     "gqlField": "authorityAllowances",
@@ -1303,7 +1335,9 @@
     "gqlField": "authorityAllowancesNote",
     "goField": "AuthorityAllowancesNote",
     "dbField": "authority_allowances_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "authority_allowances"
   },
   "waiversRequired": {
     "gqlField": "waiversRequired",
@@ -1338,7 +1372,9 @@
     "gqlField": "waiversRequiredNote",
     "goField": "WaiversRequiredNote",
     "dbField": "waivers_required_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "waivers_required"
   },
   "status": {
     "gqlField": "status",

--- a/mappings/translation/plan_ops_eval_and_learning.json
+++ b/mappings/translation/plan_ops_eval_and_learning.json
@@ -26,7 +26,9 @@
     "gqlField": "stakeholdersNote",
     "goField": "StakeholdersNote",
     "dbField": "stakeholders_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "stakeholders"
   },
   "helpdeskUse": {
     "gqlField": "helpdeskUse",
@@ -42,7 +44,9 @@
     "gqlField": "helpdeskUseNote",
     "goField": "HelpdeskUseNote",
     "dbField": "helpdesk_use_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "helpdesk_use"
   },
   "contractorSupport": {
     "gqlField": "contractorSupport",
@@ -116,7 +120,9 @@
     "gqlField": "contractorSupportNote",
     "goField": "ContractorSupportNote",
     "dbField": "contractor_support_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "contractor_support"
   },
   "iddocSupport": {
     "gqlField": "iddocSupport",
@@ -271,7 +277,9 @@
     "gqlField": "iddocSupportNote",
     "goField": "IddocSupportNote",
     "dbField": "iddoc_support_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "iddoc_support"
   },
   "technicalContactsIdentified": {
     "gqlField": "technicalContactsIdentified",
@@ -306,7 +314,9 @@
     "gqlField": "technicalContactsIdentifiedNote",
     "goField": "TechnicalContactsIdentifiedNote",
     "dbField": "technical_contacts_identified_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "technical_contacts_identified"
   },
   "captureParticipantInfo": {
     "gqlField": "captureParticipantInfo",
@@ -334,7 +344,9 @@
     "gqlField": "captureParticipantInfoNote",
     "goField": "CaptureParticipantInfoNote",
     "dbField": "capture_participant_info_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "capture_participant_info"
   },
   "icdOwner": {
     "gqlField": "icdOwner",
@@ -375,6 +387,8 @@
     "goField": "IcdNote",
     "dbField": "icd_note",
     "label": "Notes",
+    "isNote": true,
+    "parentReferencesLabel": "Interface Control Document (IDC) questions",
     "parentRelation": {
       "gqlField": "iddocSupport",
       "goField": "IddocSupport",
@@ -442,7 +456,9 @@
     "gqlField": "testingNote",
     "goField": "TestingNote",
     "dbField": "testing_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "parentReferencesLabel": "Testing questions"
   },
   "dataMonitoringFileTypes": {
     "gqlField": "dataMonitoringFileTypes",
@@ -638,7 +654,9 @@
     "gqlField": "dataMonitoringNote",
     "goField": "DataMonitoringNote",
     "dbField": "data_monitoring_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "parentReferencesLabel": "Data monitoring questions"
   },
   "benchmarkForPerformance": {
     "gqlField": "benchmarkForPerformance",
@@ -655,7 +673,9 @@
     "gqlField": "benchmarkForPerformanceNote",
     "goField": "BenchmarkForPerformanceNote",
     "dbField": "benchmark_for_performance_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "benchmark_for_performance"
   },
   "computePerformanceScores": {
     "gqlField": "computePerformanceScores",
@@ -671,7 +691,9 @@
     "gqlField": "computePerformanceScoresNote",
     "goField": "ComputePerformanceScoresNote",
     "dbField": "compute_performance_scores_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "compute_performance_scores"
   },
   "riskAdjustPerformance": {
     "gqlField": "riskAdjustPerformance",
@@ -721,7 +743,9 @@
     "gqlField": "riskAdjustNote",
     "goField": "RiskAdjustNote",
     "dbField": "risk_adjust_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "parentReferencesLabel": "Risk adjustment questions"
   },
   "appealPerformance": {
     "gqlField": "appealPerformance",
@@ -771,7 +795,9 @@
     "gqlField": "appealNote",
     "goField": "AppealNote",
     "dbField": "appeal_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "parentReferencesLabel": "Participant appeal questions"
   },
   "evaluationApproaches": {
     "gqlField": "evaluationApproaches",
@@ -798,7 +824,9 @@
     "gqlField": "evalutaionApproachNote",
     "goField": "EvalutaionApproachNote",
     "dbField": "evalutaion_approach_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "evaluation_approaches"
   },
   "ccmInvolvment": {
     "gqlField": "ccmInvolvment",
@@ -893,7 +921,9 @@
     "gqlField": "ccmInvolvmentNote",
     "goField": "CcmInvolvmentNote",
     "dbField": "ccm_involvment_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "ccm_involvment"
   },
   "dataNeededForMonitoring": {
     "gqlField": "dataNeededForMonitoring",
@@ -977,7 +1007,9 @@
     "gqlField": "dataNeededForMonitoringNote",
     "goField": "DataNeededForMonitoringNote",
     "dbField": "data_needed_for_monitoring_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "data_needed_for_monitoring"
   },
   "dataToSendParticicipants": {
     "gqlField": "dataToSendParticicipants",
@@ -1007,7 +1039,9 @@
     "gqlField": "dataToSendParticicipantsNote",
     "goField": "DataToSendParticicipantsNote",
     "dbField": "data_to_send_particicipants_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "data_to_send_particicipants"
   },
   "shareCclfData": {
     "gqlField": "shareCclfData",
@@ -1023,7 +1057,9 @@
     "gqlField": "shareCclfDataNote",
     "goField": "ShareCclfDataNote",
     "dbField": "share_cclf_data_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "share_cclf_data"
   },
   "sendFilesBetweenCcw": {
     "gqlField": "sendFilesBetweenCcw",
@@ -1052,7 +1088,9 @@
     "gqlField": "sendFilesBetweenCcwNote",
     "goField": "SendFilesBetweenCcwNote",
     "dbField": "send_files_between_ccw_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "send_files_between_ccw"
   },
   "appToSendFilesToKnown": {
     "gqlField": "appToSendFilesToKnown",
@@ -1090,7 +1128,9 @@
     "gqlField": "appToSendFilesToNote",
     "goField": "AppToSendFilesToNote",
     "dbField": "app_to_send_files_to_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "app_to_send_files_to_known"
   },
   "useCcwForFileDistribiutionToParticipants": {
     "gqlField": "useCcwForFileDistribiutionToParticipants",
@@ -1119,7 +1159,9 @@
     "gqlField": "useCcwForFileDistribiutionToParticipantsNote",
     "goField": "UseCcwForFileDistribiutionToParticipantsNote",
     "dbField": "use_ccw_for_file_distribiution_to_participants_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "use_ccw_for_file_distribiution_to_participants"
   },
   "developNewQualityMeasures": {
     "gqlField": "developNewQualityMeasures",
@@ -1158,7 +1200,9 @@
     "gqlField": "developNewQualityMeasuresNote",
     "goField": "DevelopNewQualityMeasuresNote",
     "dbField": "develop_new_quality_measures_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "develop_new_quality_measures"
   },
   "qualityPerformanceImpactsPayment": {
     "gqlField": "qualityPerformanceImpactsPayment",
@@ -1206,7 +1250,9 @@
     "gqlField": "qualityPerformanceImpactsPaymentNote",
     "goField": "QualityPerformanceImpactsPaymentNote",
     "dbField": "quality_performance_impacts_payment_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "quality_performance_impacts_payment"
   },
   "dataSharingStarts": {
     "gqlField": "dataSharingStarts",
@@ -1267,7 +1313,9 @@
     "gqlField": "dataSharingStartsNote",
     "goField": "DataSharingStartsNote",
     "dbField": "data_sharing_starts_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "parentReferencesLabel": "Data sharing timing and frequency questions"
   },
   "dataCollectionStarts": {
     "gqlField": "dataCollectionStarts",
@@ -1327,7 +1375,9 @@
     "gqlField": "dataCollectionFrequencyNote",
     "goField": "DataCollectionFrequencyNote",
     "dbField": "data_collection_frequency_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "parentReferencesLabel": "Data collection timing and frequency questions"
   },
   "qualityReportingStarts": {
     "gqlField": "qualityReportingStarts",
@@ -1357,7 +1407,9 @@
     "gqlField": "qualityReportingStartsNote",
     "goField": "QualityReportingStartsNote",
     "dbField": "quality_reporting_starts_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "parentReferencesLabel": "Quality reporting timing and frequency questions"
   },
   "qualityReportingFrequency": {
     "gqlField": "qualityReportingFrequency",
@@ -1415,7 +1467,9 @@
     "gqlField": "modelLearningSystemsNote",
     "goField": "ModelLearningSystemsNote",
     "dbField": "model_learning_systems_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "model_learning_systems"
   },
   "anticipatedChallenges": {
     "gqlField": "anticipatedChallenges",

--- a/mappings/translation/plan_participants_and_providers.json
+++ b/mappings/translation/plan_participants_and_providers.json
@@ -50,7 +50,9 @@
     "gqlField": "participantsNote",
     "goField": "ParticipantsNote",
     "dbField": "participants_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "participants"
   },
   "participantsCurrentlyInModels": {
     "gqlField": "participantsCurrentlyInModels",
@@ -67,7 +69,9 @@
     "gqlField": "participantsCurrentlyInModelsNote",
     "goField": "ParticipantsCurrentlyInModelsNote",
     "dbField": "participants_currently_in_models_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "participants_currently_in_models"
   },
   "modelApplicationLevel": {
     "gqlField": "modelApplicationLevel",
@@ -99,7 +103,9 @@
     "gqlField": "confidenceNote",
     "goField": "ConfidenceNote",
     "dbField": "confidence_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "estimate_confidence"
   },
   "recruitmentMethod": {
     "gqlField": "recruitmentMethod",
@@ -129,13 +135,15 @@
     "gqlField": "recruitmentNote",
     "goField": "RecruitmentNote",
     "dbField": "recruitment_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "recruitment_method"
   },
   "selectionMethod": {
     "gqlField": "selectionMethod",
     "goField": "SelectionMethod",
     "dbField": "selection_method",
-    "label": "How will you select participants? Select all that appy.",
+    "label": "How will you select participants? Select all that apply.",
     "readonlyLabel": "How will you select participants?",
     "multiSelectLabel": "Selected participants",
     "options": {
@@ -160,7 +168,9 @@
     "gqlField": "selectionNote",
     "goField": "SelectionNote",
     "dbField": "selection_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "selection_method"
   },
   "participantAddedFrequency": {
     "gqlField": "participantAddedFrequency",
@@ -196,7 +206,9 @@
     "gqlField": "participantAddedFrequencyNote",
     "goField": "ParticipantAddedFrequencyNote",
     "dbField": "participant_added_frequency_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "participant_added_frequency"
   },
   "participantRemovedFrequency": {
     "gqlField": "participantRemovedFrequency",
@@ -232,7 +244,9 @@
     "gqlField": "participantRemovedFrequencyNote",
     "goField": "ParticipantRemovedFrequencyNote",
     "dbField": "participant_removed_frequency_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "participant_removed_frequency"
   },
   "communicationMethod": {
     "gqlField": "communicationMethod",
@@ -258,7 +272,9 @@
     "gqlField": "communicationNote",
     "goField": "CommunicationNote",
     "dbField": "communication_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "communication_method"
   },
   "riskType": {
     "gqlField": "riskType",
@@ -285,7 +301,9 @@
     "gqlField": "riskNote",
     "goField": "RiskNote",
     "dbField": "risk_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "risk_type"
   },
   "willRiskChange": {
     "gqlField": "willRiskChange",
@@ -301,7 +319,50 @@
     "gqlField": "willRiskChangeNote",
     "goField": "WillRiskChangeNote",
     "dbField": "will_risk_change_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "will_risk_change"
+  },
+  "participantRequireFinancialGuarantee": {
+    "gqlField": "participantRequireFinancialGuarantee",
+    "goField": "ParticipantRequireFinancialGuarantee",
+    "dbField": "participant_require_financial_guarantee",
+    "label": "Are participants required to retain a financial guarantee?",
+    "sublabel": "Note: Remember to include financial guarantee requirements when drafting your Participation Agreement.",
+    "questionTooltip": "Financial guarantees are commitments made by one party, typically a financial institution or a company, to assume responsibility for the payment of a debt or the performance of an obligation if the debtor or obligor fails to fulfill their obligations.",
+    "readonlyLabel": "Are participants required to retain a financial guarantee? If so, are there any limitations on the type?",
+    "options": {
+      "true": "Yes",
+      "false": "No"
+    }
+  },
+  "participantRequireFinancialGuaranteeType": {
+    "gqlField": "participantRequireFinancialGuaranteeType",
+    "goField": "ParticipantRequireFinancialGuaranteeType",
+    "dbField": "participant_require_financial_guarantee_type",
+    "label": "If so, are there any limitations on the type?",
+    "options": {
+      "SURETY_BOND": "Surety Bond",
+      "LETTER_OF_CREDIT": "Letter of Credit",
+      "ESCROW": "Escrow",
+      "OTHER": "Other"
+    },
+    "isOtherType": true
+  },
+  "participantRequireFinancialGuaranteeOther": {
+    "gqlField": "participantRequireFinancialGuaranteeOther",
+    "goField": "ParticipantRequireFinancialGuaranteeOther",
+    "dbField": "participant_require_financial_guarantee_other",
+    "label": "Please specify",
+    "isOtherType": true
+  },
+  "participantRequireFinancialGuaranteeNote": {
+    "gqlField": "participantRequireFinancialGuaranteeNote",
+    "goField": "ParticipantRequireFinancialGuaranteeNote",
+    "dbField": "participant_require_financial_guarantee_note",
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "participant_require_financial_guarantee_type"
   },
   "coordinateWork": {
     "gqlField": "coordinateWork",
@@ -318,7 +379,9 @@
     "gqlField": "coordinateWorkNote",
     "goField": "CoordinateWorkNote",
     "dbField": "coordinate_work_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "coordinate_work"
   },
   "gainsharePayments": {
     "gqlField": "gainsharePayments",
@@ -410,7 +473,9 @@
     "gqlField": "gainsharePaymentsNote",
     "goField": "GainsharePaymentsNote",
     "dbField": "gainshare_payments_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "gainshare_payments_eligibility"
   },
   "participantsIds": {
     "gqlField": "participantsIds",
@@ -439,7 +504,9 @@
     "gqlField": "participantsIDSNote",
     "goField": "ParticipantsIDSNote",
     "dbField": "participants_ids_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "participants_ids"
   },
   "providerAdditionFrequency": {
     "gqlField": "providerAdditionFrequency",
@@ -475,7 +542,9 @@
     "gqlField": "providerAdditionFrequencyNote",
     "goField": "ProviderAdditionFrequencyNote",
     "dbField": "provider_addition_frequency_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "provider_addition_frequency"
   },
   "providerAddMethod": {
     "gqlField": "providerAddMethod",
@@ -506,7 +575,9 @@
     "gqlField": "providerAddMethodNote",
     "goField": "ProviderAddMethodNote",
     "dbField": "provider_add_method_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "provider_add_method"
   },
   "providerLeaveMethod": {
     "gqlField": "providerLeaveMethod",
@@ -536,7 +607,9 @@
     "gqlField": "providerLeaveMethodNote",
     "goField": "ProviderLeaveMethodNote",
     "dbField": "provider_leave_method_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "provider_leave_method"
   },
   "providerRemovalFrequency": {
     "gqlField": "providerRemovalFrequency",
@@ -572,7 +645,9 @@
     "gqlField": "providerRemovalFrequencyNote",
     "goField": "ProviderRemovalFrequencyNote",
     "dbField": "provider_removal_frequency_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "provider_removal_frequency"
   },
   "providerOverlap": {
     "gqlField": "providerOverlap",
@@ -624,7 +699,9 @@
     "gqlField": "providerOverlapNote",
     "goField": "ProviderOverlapNote",
     "dbField": "provider_overlap_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "provider_overlap"
   },
   "status": {
     "gqlField": "status",

--- a/mappings/translation/plan_payments.json
+++ b/mappings/translation/plan_payments.json
@@ -39,7 +39,9 @@
     "gqlField": "fundingSourceNote",
     "goField": "FundingSourceNote",
     "dbField": "funding_source_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "funding_source"
   },
   "fundingSourceR": {
     "gqlField": "fundingSourceR",
@@ -81,7 +83,9 @@
     "gqlField": "fundingSourceRNote",
     "goField": "FundingSourceRNote",
     "dbField": "funding_source_r_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "funding_source_r"
   },
   "payRecipients": {
     "gqlField": "payRecipients",
@@ -107,7 +111,9 @@
     "gqlField": "payRecipientsNote",
     "goField": "PayRecipientsNote",
     "dbField": "pay_recipients_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "pay_recipients"
   },
   "payType": {
     "gqlField": "payType",
@@ -314,7 +320,9 @@
     "gqlField": "payTypeNote",
     "goField": "PayTypeNote",
     "dbField": "pay_type_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "pay_type"
   },
   "payClaims": {
     "gqlField": "payClaims",
@@ -389,7 +397,9 @@
     "gqlField": "payClaimsNote",
     "goField": "PayClaimsNote",
     "dbField": "pay_claims_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "pay_claims"
   },
   "shouldAnyProvidersExcludedFFSSystems": {
     "gqlField": "shouldAnyProvidersExcludedFFSSystems",
@@ -417,7 +427,9 @@
     "gqlField": "shouldAnyProviderExcludedFFSSystemsNote",
     "goField": "ShouldAnyProviderExcludedFFSSystemsNote",
     "dbField": "should_any_providers_excluded_ffs_systems_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "should_any_providers_excluded_ffs_systems"
   },
   "changesMedicarePhysicianFeeSchedule": {
     "gqlField": "changesMedicarePhysicianFeeSchedule",
@@ -446,7 +458,9 @@
     "gqlField": "changesMedicarePhysicianFeeScheduleNote",
     "goField": "ChangesMedicarePhysicianFeeScheduleNote",
     "dbField": "changes_medicare_physician_fee_schedule_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "changes_medicare_physician_fee_schedule"
   },
   "affectsMedicareSecondaryPayerClaims": {
     "gqlField": "affectsMedicareSecondaryPayerClaims",
@@ -483,7 +497,9 @@
     "gqlField": "affectsMedicareSecondaryPayerClaimsNote",
     "goField": "AffectsMedicareSecondaryPayerClaimsNote",
     "dbField": "affects_medicare_secondary_payer_claims_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "affects_medicare_secondary_payer_claims"
   },
   "payModelDifferentiation": {
     "gqlField": "payModelDifferentiation",
@@ -530,7 +546,9 @@
     "gqlField": "creatingDependenciesBetweenServicesNote",
     "goField": "CreatingDependenciesBetweenServicesNote",
     "dbField": "creating_dependencies_between_services_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "creating_dependencies_between_services"
   },
   "needsClaimsDataCollection": {
     "gqlField": "needsClaimsDataCollection",
@@ -559,7 +577,9 @@
     "gqlField": "needsClaimsDataCollectionNote",
     "goField": "NeedsClaimsDataCollectionNote",
     "dbField": "needs_claims_data_collection_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "needs_claims_data_collection"
   },
   "providingThirdPartyFile": {
     "gqlField": "providingThirdPartyFile",
@@ -699,7 +719,9 @@
     "gqlField": "waiveBeneficiaryCostSharingNote",
     "goField": "WaiveBeneficiaryCostSharingNote",
     "dbField": "waive_beneficiary_cost_sharing_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "parentReferencesLabel": "Beneficiary cost-sharing questions"
   },
   "nonClaimsPayments": {
     "gqlField": "nonClaimsPayments",
@@ -743,7 +765,9 @@
     "gqlField": "nonClaimsPaymentsNote",
     "goField": "NonClaimsPaymentsNote",
     "dbField": "non_claims_payments_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "non_claims_payments"
   },
   "paymentCalculationOwner": {
     "gqlField": "paymentCalculationOwner",
@@ -786,7 +810,9 @@
     "gqlField": "numberPaymentsPerPayCycleNote",
     "goField": "NumberPaymentsPerPayCycleNote",
     "dbField": "number_payments_per_pay_cycle_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "number_payments_per_pay_cycle"
   },
   "sharedSystemsInvolvedAdditionalClaimPayment": {
     "gqlField": "sharedSystemsInvolvedAdditionalClaimPayment",
@@ -814,7 +840,9 @@
     "gqlField": "sharedSystemsInvolvedAdditionalClaimPaymentNote",
     "goField": "SharedSystemsInvolvedAdditionalClaimPaymentNote",
     "dbField": "shared_systems_involved_additional_claim_payment_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "shared_systems_involved_additional_claim_payment"
   },
   "planningToUseInnovationPaymentContractor": {
     "gqlField": "planningToUseInnovationPaymentContractor",
@@ -843,7 +871,9 @@
     "gqlField": "planningToUseInnovationPaymentContractorNote",
     "goField": "PlanningToUseInnovationPaymentContractorNote",
     "dbField": "planning_to_use_innovation_payment_contractor_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "planning_to_use_innovation_payment_contractor"
   },
   "expectedCalculationComplexityLevel": {
     "gqlField": "expectedCalculationComplexityLevel",
@@ -860,7 +890,9 @@
     "gqlField": "expectedCalculationComplexityLevelNote",
     "goField": "ExpectedCalculationComplexityLevelNote",
     "dbField": "expected_calculation_complexity_level_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "expected_calculation_complexity_level"
   },
   "claimsProcessingPrecedence": {
     "gqlField": "claimsProcessingPrecedence",
@@ -885,7 +917,9 @@
     "gqlField": "claimsProcessingPrecedenceNote",
     "goField": "ClaimsProcessingPrecedenceNote",
     "dbField": "claims_processing_precedence_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "claims_processing_precedence"
   },
   "canParticipantsSelectBetweenPaymentMechanisms": {
     "gqlField": "canParticipantsSelectBetweenPaymentMechanisms",
@@ -910,7 +944,9 @@
     "gqlField": "canParticipantsSelectBetweenPaymentMechanismsNote",
     "goField": "CanParticipantsSelectBetweenPaymentMechanismsNote",
     "dbField": "can_participants_select_between_payment_mechanisms_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "can_participants_select_between_payment_mechanisms"
   },
   "anticipatedPaymentFrequency": {
     "gqlField": "anticipatedPaymentFrequency",
@@ -946,7 +982,9 @@
     "gqlField": "anticipatedPaymentFrequencyNote",
     "goField": "AnticipatedPaymentFrequencyNote",
     "dbField": "anticipated_payment_frequency_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "anticipated_payment_frequency"
   },
   "willRecoverPayments": {
     "gqlField": "willRecoverPayments",
@@ -962,7 +1000,9 @@
     "gqlField": "willRecoverPaymentsNote",
     "goField": "WillRecoverPaymentsNote",
     "dbField": "will_recover_payments_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "will_recover_payments"
   },
   "anticipateReconcilingPaymentsRetrospectively": {
     "gqlField": "anticipateReconcilingPaymentsRetrospectively",
@@ -978,7 +1018,9 @@
     "gqlField": "anticipateReconcilingPaymentsRetrospectivelyNote",
     "goField": "AnticipateReconcilingPaymentsRetrospectivelyNote",
     "dbField": "anticipate_reconciling_payments_retrospectively_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "anticipate_reconciling_payments_retrospectively"
   },
   "paymentReconciliationFrequency": {
     "gqlField": "paymentReconciliationFrequency",
@@ -1014,7 +1056,9 @@
     "gqlField": "paymentReconciliationFrequencyNote",
     "goField": "PaymentReconciliationFrequencyNote",
     "dbField": "payment_reconciliation_frequency_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "payment_reconciliation_frequency"
   },
   "paymentDemandRecoupmentFrequency": {
     "gqlField": "paymentDemandRecoupmentFrequency",
@@ -1050,7 +1094,9 @@
     "gqlField": "paymentDemandRecoupmentFrequencyNote",
     "goField": "PaymentReconciliationFrequencyNote",
     "dbField": "payment_demand_recoupment_frequency_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "payment_demand_recoupment_frequency"
   },
   "paymentStartDate": {
     "gqlField": "paymentStartDate",
@@ -1064,7 +1110,9 @@
     "gqlField": "paymentStartDateNote",
     "goField": "PaymentStartDateNote",
     "dbField": "payment_start_date_note",
-    "label": "Notes"
+    "label": "Notes",
+    "isNote": true,
+    "otherParentField": "payment_start_date"
   },
   "status": {
     "gqlField": "status",

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -545,10 +545,13 @@ type TranslationField struct {
 	IsArray          *bool               `json:"isArray,omitempty"`
 	DataType         TranslationDataType `json:"dataType"`
 	FormType         TranslationFormType `json:"formType"`
+	IsNote           *bool               `json:"isNote,omitempty"`
 	// Is a question a followup to another that doesn't designate it's own readonly question/line
 	IsOtherType *bool `json:"isOtherType,omitempty"`
 	// Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context
 	OtherParentField *string `json:"otherParentField,omitempty"`
+	// Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics'
+	ParentReferencesLabel *string `json:"parentReferencesLabel,omitempty"`
 }
 
 // Represents a translation question with options
@@ -563,11 +566,14 @@ type TranslationFieldWithOptions struct {
 	IsArray          *bool               `json:"isArray,omitempty"`
 	DataType         TranslationDataType `json:"dataType"`
 	FormType         TranslationFormType `json:"formType"`
+	IsNote           *bool               `json:"isNote,omitempty"`
 	// Is a question a followup to another that doesn't designate it's own readonly question/line
 	IsOtherType *bool `json:"isOtherType,omitempty"`
 	// Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context
-	OtherParentField *string                `json:"otherParentField,omitempty"`
-	Options          map[string]interface{} `json:"options"`
+	OtherParentField *string `json:"otherParentField,omitempty"`
+	// Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics'
+	ParentReferencesLabel *string                `json:"parentReferencesLabel,omitempty"`
+	Options               map[string]interface{} `json:"options"`
 }
 
 // Represents a translation question with options and child/children
@@ -582,12 +588,15 @@ type TranslationFieldWithOptionsAndChildren struct {
 	IsArray          *bool               `json:"isArray,omitempty"`
 	DataType         TranslationDataType `json:"dataType"`
 	FormType         TranslationFormType `json:"formType"`
+	IsNote           *bool               `json:"isNote,omitempty"`
 	// Is a question a followup to another that doesn't designate it's own readonly question/line
 	IsOtherType *bool `json:"isOtherType,omitempty"`
 	// Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context
-	OtherParentField *string                `json:"otherParentField,omitempty"`
-	Options          map[string]interface{} `json:"options"`
-	ChildRelation    map[string]interface{} `json:"childRelation"`
+	OtherParentField *string `json:"otherParentField,omitempty"`
+	// Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics'
+	ParentReferencesLabel *string                `json:"parentReferencesLabel,omitempty"`
+	Options               map[string]interface{} `json:"options"`
+	ChildRelation         map[string]interface{} `json:"childRelation"`
 }
 
 // Represents a translation question with options and parent
@@ -602,12 +611,15 @@ type TranslationFieldWithOptionsAndParent struct {
 	IsArray          *bool               `json:"isArray,omitempty"`
 	DataType         TranslationDataType `json:"dataType"`
 	FormType         TranslationFormType `json:"formType"`
+	IsNote           *bool               `json:"isNote,omitempty"`
 	// Is a question a followup to another that doesn't designate it's own readonly question/line
 	IsOtherType *bool `json:"isOtherType,omitempty"`
 	// Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context
-	OtherParentField *string                                 `json:"otherParentField,omitempty"`
-	Options          map[string]interface{}                  `json:"options"`
-	ParentRelation   *TranslationFieldWithOptionsAndChildren `json:"parentRelation"`
+	OtherParentField *string `json:"otherParentField,omitempty"`
+	// Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics'
+	ParentReferencesLabel *string                                 `json:"parentReferencesLabel,omitempty"`
+	Options               map[string]interface{}                  `json:"options"`
+	ParentRelation        *TranslationFieldWithOptionsAndChildren `json:"parentRelation"`
 }
 
 // Represents a translation question with no options and a parent
@@ -622,11 +634,14 @@ type TranslationFieldWithParent struct {
 	IsArray          *bool               `json:"isArray,omitempty"`
 	DataType         TranslationDataType `json:"dataType"`
 	FormType         TranslationFormType `json:"formType"`
+	IsNote           *bool               `json:"isNote,omitempty"`
 	// Is a question a followup to another that doesn't designate it's own readonly question/line
 	IsOtherType *bool `json:"isOtherType,omitempty"`
 	// Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context
-	OtherParentField *string           `json:"otherParentField,omitempty"`
-	ParentRelation   *TranslationField `json:"parentRelation"`
+	OtherParentField *string `json:"otherParentField,omitempty"`
+	// Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics'
+	ParentReferencesLabel *string           `json:"parentReferencesLabel,omitempty"`
+	ParentRelation        *TranslationField `json:"parentRelation"`
 }
 
 // Represents a translation question with options and parent and children
@@ -641,13 +656,16 @@ type TranslationFieldWithParentAndChildren struct {
 	IsArray          *bool               `json:"isArray,omitempty"`
 	DataType         TranslationDataType `json:"dataType"`
 	FormType         TranslationFormType `json:"formType"`
+	IsNote           *bool               `json:"isNote,omitempty"`
 	// Is a question a followup to another that doesn't designate it's own readonly question/line
 	IsOtherType *bool `json:"isOtherType,omitempty"`
 	// Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context
-	OtherParentField *string                                 `json:"otherParentField,omitempty"`
-	Options          map[string]interface{}                  `json:"options"`
-	ParentRelation   *TranslationFieldWithOptionsAndChildren `json:"parentRelation"`
-	ChildRelation    map[string]interface{}                  `json:"childRelation"`
+	OtherParentField *string `json:"otherParentField,omitempty"`
+	// Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics'
+	ParentReferencesLabel *string                                 `json:"parentReferencesLabel,omitempty"`
+	Options               map[string]interface{}                  `json:"options"`
+	ParentRelation        *TranslationFieldWithOptionsAndChildren `json:"parentRelation"`
+	ChildRelation         map[string]interface{}                  `json:"childRelation"`
 }
 
 type UpdateOperationalSolutionSubtaskInput struct {

--- a/pkg/graph/schema/types/translation.graphql
+++ b/pkg/graph/schema/types/translation.graphql
@@ -44,6 +44,7 @@ type TranslationField {
   isArray: Boolean
   dataType: TranslationDataType!
   formType: TranslationFormType!
+  isNote: Boolean
   """
   Is a question a followup to another that doesn't designate it's own readonly question/line
   """
@@ -52,6 +53,10 @@ type TranslationField {
   Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context
   """
   otherParentField: String
+  """
+  Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics'
+  """
+  parentReferencesLabel: String
 }
 
 """
@@ -68,6 +73,7 @@ type TranslationFieldWithOptions {
   isArray: Boolean
   dataType: TranslationDataType!
   formType: TranslationFormType!
+  isNote: Boolean
   """
   Is a question a followup to another that doesn't designate it's own readonly question/line
   """
@@ -76,6 +82,10 @@ type TranslationFieldWithOptions {
   Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context
   """
   otherParentField: String
+  """
+  Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics'
+  """
+  parentReferencesLabel: String
   options: Map!
 }
 
@@ -93,6 +103,7 @@ type TranslationFieldWithParent {
   isArray: Boolean
   dataType: TranslationDataType!
   formType: TranslationFormType!
+  isNote: Boolean
   """
   Is a question a followup to another that doesn't designate it's own readonly question/line
   """
@@ -101,6 +112,10 @@ type TranslationFieldWithParent {
   Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context
   """
   otherParentField: String
+  """
+  Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics'
+  """
+  parentReferencesLabel: String
   parentRelation: TranslationField!
 }
 
@@ -118,6 +133,7 @@ type TranslationFieldWithOptionsAndChildren {
   isArray: Boolean
   dataType: TranslationDataType!
   formType: TranslationFormType!
+  isNote: Boolean
   """
   Is a question a followup to another that doesn't designate it's own readonly question/line
   """
@@ -126,6 +142,10 @@ type TranslationFieldWithOptionsAndChildren {
   Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context
   """
   otherParentField: String
+  """
+  Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics'
+  """
+  parentReferencesLabel: String
   options: Map!
   childRelation: Map!
 }
@@ -144,6 +164,7 @@ type TranslationFieldWithOptionsAndParent {
   isArray: Boolean
   dataType: TranslationDataType!
   formType: TranslationFormType!
+  isNote: Boolean
   """
   Is a question a followup to another that doesn't designate it's own readonly question/line
   """
@@ -152,6 +173,10 @@ type TranslationFieldWithOptionsAndParent {
   Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context
   """
   otherParentField: String
+  """
+  Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics'
+  """
+  parentReferencesLabel: String
   options: Map!
   parentRelation: TranslationFieldWithOptionsAndChildren!
 }
@@ -170,6 +195,7 @@ type TranslationFieldWithParentAndChildren {
   isArray: Boolean
   dataType: TranslationDataType!
   formType: TranslationFormType!
+  isNote: Boolean
   """
   Is a question a followup to another that doesn't designate it's own readonly question/line
   """
@@ -178,6 +204,10 @@ type TranslationFieldWithParentAndChildren {
   Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context
   """
   otherParentField: String
+  """
+  Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics'
+  """
+  parentReferencesLabel: String
   options: Map!
   parentRelation: TranslationFieldWithOptionsAndChildren!
   childRelation: Map!

--- a/src/gql/gen/graphql.ts
+++ b/src/gql/gen/graphql.ts
@@ -3330,12 +3330,15 @@ export type TranslationField = {
   goField: Scalars['String']['output'];
   gqlField: Scalars['String']['output'];
   isArray?: Maybe<Scalars['Boolean']['output']>;
+  isNote?: Maybe<Scalars['Boolean']['output']>;
   /** Is a question a followup to another that doesn't designate it's own readonly question/line */
   isOtherType?: Maybe<Scalars['Boolean']['output']>;
   label: Scalars['String']['output'];
   multiSelectLabel?: Maybe<Scalars['String']['output']>;
   /** Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context */
   otherParentField?: Maybe<Scalars['String']['output']>;
+  /** Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics' */
+  parentReferencesLabel?: Maybe<Scalars['String']['output']>;
   readonlyLabel?: Maybe<Scalars['String']['output']>;
   sublabel?: Maybe<Scalars['String']['output']>;
 };
@@ -3349,6 +3352,7 @@ export type TranslationFieldWithOptions = {
   goField: Scalars['String']['output'];
   gqlField: Scalars['String']['output'];
   isArray?: Maybe<Scalars['Boolean']['output']>;
+  isNote?: Maybe<Scalars['Boolean']['output']>;
   /** Is a question a followup to another that doesn't designate it's own readonly question/line */
   isOtherType?: Maybe<Scalars['Boolean']['output']>;
   label: Scalars['String']['output'];
@@ -3356,6 +3360,8 @@ export type TranslationFieldWithOptions = {
   options: Scalars['Map']['output'];
   /** Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context */
   otherParentField?: Maybe<Scalars['String']['output']>;
+  /** Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics' */
+  parentReferencesLabel?: Maybe<Scalars['String']['output']>;
   readonlyLabel?: Maybe<Scalars['String']['output']>;
   sublabel?: Maybe<Scalars['String']['output']>;
 };
@@ -3370,6 +3376,7 @@ export type TranslationFieldWithOptionsAndChildren = {
   goField: Scalars['String']['output'];
   gqlField: Scalars['String']['output'];
   isArray?: Maybe<Scalars['Boolean']['output']>;
+  isNote?: Maybe<Scalars['Boolean']['output']>;
   /** Is a question a followup to another that doesn't designate it's own readonly question/line */
   isOtherType?: Maybe<Scalars['Boolean']['output']>;
   label: Scalars['String']['output'];
@@ -3377,6 +3384,8 @@ export type TranslationFieldWithOptionsAndChildren = {
   options: Scalars['Map']['output'];
   /** Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context */
   otherParentField?: Maybe<Scalars['String']['output']>;
+  /** Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics' */
+  parentReferencesLabel?: Maybe<Scalars['String']['output']>;
   readonlyLabel?: Maybe<Scalars['String']['output']>;
   sublabel?: Maybe<Scalars['String']['output']>;
 };
@@ -3390,6 +3399,7 @@ export type TranslationFieldWithOptionsAndParent = {
   goField: Scalars['String']['output'];
   gqlField: Scalars['String']['output'];
   isArray?: Maybe<Scalars['Boolean']['output']>;
+  isNote?: Maybe<Scalars['Boolean']['output']>;
   /** Is a question a followup to another that doesn't designate it's own readonly question/line */
   isOtherType?: Maybe<Scalars['Boolean']['output']>;
   label: Scalars['String']['output'];
@@ -3397,6 +3407,8 @@ export type TranslationFieldWithOptionsAndParent = {
   options: Scalars['Map']['output'];
   /** Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context */
   otherParentField?: Maybe<Scalars['String']['output']>;
+  /** Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics' */
+  parentReferencesLabel?: Maybe<Scalars['String']['output']>;
   parentRelation: TranslationFieldWithOptionsAndChildren;
   readonlyLabel?: Maybe<Scalars['String']['output']>;
   sublabel?: Maybe<Scalars['String']['output']>;
@@ -3411,12 +3423,15 @@ export type TranslationFieldWithParent = {
   goField: Scalars['String']['output'];
   gqlField: Scalars['String']['output'];
   isArray?: Maybe<Scalars['Boolean']['output']>;
+  isNote?: Maybe<Scalars['Boolean']['output']>;
   /** Is a question a followup to another that doesn't designate it's own readonly question/line */
   isOtherType?: Maybe<Scalars['Boolean']['output']>;
   label: Scalars['String']['output'];
   multiSelectLabel?: Maybe<Scalars['String']['output']>;
   /** Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context */
   otherParentField?: Maybe<Scalars['String']['output']>;
+  /** Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics' */
+  parentReferencesLabel?: Maybe<Scalars['String']['output']>;
   parentRelation: TranslationField;
   readonlyLabel?: Maybe<Scalars['String']['output']>;
   sublabel?: Maybe<Scalars['String']['output']>;
@@ -3432,6 +3447,7 @@ export type TranslationFieldWithParentAndChildren = {
   goField: Scalars['String']['output'];
   gqlField: Scalars['String']['output'];
   isArray?: Maybe<Scalars['Boolean']['output']>;
+  isNote?: Maybe<Scalars['Boolean']['output']>;
   /** Is a question a followup to another that doesn't designate it's own readonly question/line */
   isOtherType?: Maybe<Scalars['Boolean']['output']>;
   label: Scalars['String']['output'];
@@ -3439,6 +3455,8 @@ export type TranslationFieldWithParentAndChildren = {
   options: Scalars['Map']['output'];
   /** Field name for the parent question for fields that represent Other, Please specify, etc.  Used in change history to render parent question for context */
   otherParentField?: Maybe<Scalars['String']['output']>;
+  /** Label for fields that reference more than one parent - Ex: Notes - 'Note for Model Basics' */
+  parentReferencesLabel?: Maybe<Scalars['String']['output']>;
   parentRelation: TranslationFieldWithOptionsAndChildren;
   readonlyLabel?: Maybe<Scalars['String']['output']>;
   sublabel?: Maybe<Scalars['String']['output']>;

--- a/src/i18n/en-US/modelPlan/basics.ts
+++ b/src/i18n/en-US/modelPlan/basics.ts
@@ -374,6 +374,8 @@ export const basics: TranslationBasics = {
     goField: 'PhasedInNote',
     dbField: 'phased_in_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'phasedIn',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]

--- a/src/i18n/en-US/modelPlan/basics.ts
+++ b/src/i18n/en-US/modelPlan/basics.ts
@@ -221,6 +221,8 @@ export const basics: TranslationBasics = {
     goField: 'Note',
     dbField: 'note',
     label: 'Notes',
+    isNote: true,
+    parentReferencesLabel: 'Model basics',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -336,6 +338,8 @@ export const basics: TranslationBasics = {
     goField: 'HighLevelNote',
     dbField: 'high_level_note',
     label: 'Notes',
+    isNote: true,
+    parentReferencesLabel: 'Timeline',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },

--- a/src/i18n/en-US/modelPlan/beneficiaries.ts
+++ b/src/i18n/en-US/modelPlan/beneficiaries.ts
@@ -65,6 +65,8 @@ export const beneficiaries: TranslationBeneficiaries = {
     goField: 'BeneficiariesNote',
     dbField: 'beneficiaries_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'beneficiaries',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.MDM]
@@ -105,6 +107,8 @@ export const beneficiaries: TranslationBeneficiaries = {
     goField: 'TreatDualElligibleDifferentNote',
     dbField: 'treat_dual_elligible_different_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'treatDualElligibleDifferent',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]
@@ -145,6 +149,8 @@ export const beneficiaries: TranslationBeneficiaries = {
     goField: 'ExcludeCertainCharacteristicsNote',
     dbField: 'exclude_certain_characteristics_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'excludeCertainCharacteristics',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]
@@ -187,6 +193,8 @@ export const beneficiaries: TranslationBeneficiaries = {
     goField: 'ConfidenceNote',
     dbField: 'confidence_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'numberPeopleImpacted',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.MDM]
@@ -229,6 +237,8 @@ export const beneficiaries: TranslationBeneficiaries = {
     goField: 'BeneficiarySelectionNote',
     dbField: 'beneficiary_selection_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'beneficiarySelectionMethod',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI]
@@ -279,6 +289,8 @@ export const beneficiaries: TranslationBeneficiaries = {
     goField: 'BeneficiarySelectionFrequencyNote',
     dbField: 'beneficiary_selection_frequency_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'beneficiarySelectionFrequency',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXT,
     filterGroups: [ModelViewFilter.CMMI]
@@ -327,6 +339,8 @@ export const beneficiaries: TranslationBeneficiaries = {
     goField: 'BeneficiaryRemovalFrequencyNote',
     dbField: 'beneficiary_removal_frequency_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'beneficiaryRemovalFrequency',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXT,
     filterGroups: [ModelViewFilter.CMMI]
@@ -351,6 +365,8 @@ export const beneficiaries: TranslationBeneficiaries = {
     goField: 'BeneficiaryOverlapNote',
     dbField: 'beneficiary_overlap_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'beneficiaryOverlap',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.MDM]
@@ -401,6 +417,8 @@ export const beneficiaries: TranslationBeneficiaries = {
     goField: 'PrecedenceRulesNote',
     dbField: 'precedence_rules_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'precedenceRules',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.MDM, ModelViewFilter.OACT]

--- a/src/i18n/en-US/modelPlan/generalCharacteristics.ts
+++ b/src/i18n/en-US/modelPlan/generalCharacteristics.ts
@@ -136,6 +136,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'ResemblesExistingModelNote',
     dbField: 'resembles_existing_model_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'resemblesExistingModel',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -231,6 +233,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'ParticipationInModelPreconditionNote',
     dbField: 'participation_in_model_precondition_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'participationInModelPrecondition',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -268,6 +272,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'HasComponentsOrTracksNote',
     dbField: 'has_components_or_tracks_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'hasComponentsOrTracks',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -309,6 +315,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'AgencyOrStateHelpNote',
     dbField: 'agency_or_state_help_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'agencyOrStateHelp',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -335,6 +343,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'AlternativePaymentModelNote',
     dbField: 'alternative_payment_model_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'alternativePaymentModelTypes',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI, ModelViewFilter.OACT]
@@ -396,6 +406,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'KeyCharacteristicsNote',
     dbField: 'key_characteristics_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'keyCharacteristics',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [
@@ -422,6 +434,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'CollectPlanBidsNote',
     dbField: 'collect_plan_bids_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'collectPlanBids',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -443,6 +457,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'ManagePartCDEnrollmentNote',
     dbField: 'manage_part_c_d_enrollment_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'managePartCDEnrollment',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -464,6 +480,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'PlanContractUpdatedNote',
     dbField: 'plan_contract_updated_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'planContractUpdated',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -499,6 +517,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'CareCoordinationInvolvedNote',
     dbField: 'care_coordination_involved_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'careCoordinationInvolved',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -533,6 +553,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'AdditionalServicesInvolvedNote',
     dbField: 'additional_services_involved_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'additionalServicesInvolved',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -567,6 +589,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'CommunityPartnersInvolvedNote',
     dbField: 'community_partners_involved_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'communityPartnersInvolved',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -803,6 +827,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'GeographiesTargetedNote',
     dbField: 'geographies_targeted_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'geographiesTargeted',
     dataType: TranslationDataType.BOOLEAN,
     formType: TranslationFormType.RADIO,
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]
@@ -825,6 +851,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'ParticipationOptionsNote',
     dbField: 'participation_options_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'participationOptions',
     dataType: TranslationDataType.BOOLEAN,
     formType: TranslationFormType.RADIO,
     filterGroups: [ModelViewFilter.CMMI]
@@ -885,6 +913,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'MultiplePatricipationAgreementsNeededNote',
     dbField: 'multiple_patricipation_agreements_needed_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'multiplePatricipationAgreementsNeeded',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI]
@@ -923,6 +953,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'RulemakingRequiredNote',
     dbField: 'rulemaking_required_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'rulemakingRequired',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -961,6 +993,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'AuthorityAllowancesNote',
     dbField: 'authority_allowances_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'authorityAllowances',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI]
@@ -1009,6 +1043,8 @@ export const generalCharacteristics: TranslationGeneralCharacteristics = {
     goField: 'WaiversRequiredNote',
     dbField: 'waivers_required_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'waiversRequired',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI]

--- a/src/i18n/en-US/modelPlan/opsEvalAndLearning.ts
+++ b/src/i18n/en-US/modelPlan/opsEvalAndLearning.ts
@@ -47,6 +47,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'StakeholdersNote',
     dbField: 'stakeholders_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'stakeholders',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CBOSC]
@@ -69,6 +71,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'HelpdeskUseNote',
     dbField: 'helpdesk_use_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'helpdeskUse',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CBOSC]
@@ -136,6 +140,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'ContractorSupportNote',
     dbField: 'contractor_support_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'contractorSupport',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [
@@ -186,6 +192,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'IddocSupportNote',
     dbField: 'iddoc_support_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'iddocSupport',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC]
@@ -223,6 +231,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'TechnicalContactsIdentifiedNote',
     dbField: 'technical_contacts_identified_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'technicalContactsIdentified',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC]
@@ -248,6 +258,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'CaptureParticipantInfoNote',
     dbField: 'capture_participant_info_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'captureParticipantInfo',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC]
@@ -279,6 +291,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'IcdNote',
     dbField: 'icd_note',
     label: 'Notes',
+    isNote: true,
+    parentReferencesLabel: 'Interface Control Document (IDC) questions',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     parentRelation: () => opsEvalAndLearning.iddocSupport,
@@ -321,6 +335,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'TestingNote',
     dbField: 'testing_note',
     label: 'Notes',
+    isNote: true,
+    parentReferencesLabel: 'Testing questions',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC]
@@ -466,6 +482,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'DataMonitoringNote',
     dbField: 'data_monitoring_note',
     label: 'Notes',
+    isNote: true,
+    parentReferencesLabel: 'Data monitoring questions',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC]
@@ -491,6 +509,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'BenchmarkForPerformanceNote',
     dbField: 'benchmark_for_performance_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'benchmarkForPerformance',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI]
@@ -513,6 +533,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'ComputePerformanceScoresNote',
     dbField: 'compute_performance_scores_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'computePerformanceScores',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI]
@@ -592,6 +614,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'RiskAdjustNote',
     dbField: 'risk_adjust_note',
     label: 'Notes',
+    isNote: true,
+    parentReferencesLabel: 'Risk adjustment questions',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -668,6 +692,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'AppealNote',
     dbField: 'appeal_note',
     label: 'Notes',
+    isNote: true,
+    parentReferencesLabel: 'Participant appeal questions',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -707,6 +733,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'EvalutaionApproachNote',
     dbField: 'evalutaion_approach_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'evaluationApproaches',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -759,6 +787,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'CcmInvolvmentNote',
     dbField: 'ccm_involvment_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'ccmInvolvment',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CCW]
@@ -819,6 +849,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'DataNeededForMonitoringNote',
     dbField: 'data_needed_for_monitoring_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'dataNeededForMonitoring',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI, ModelViewFilter.IDDOC]
@@ -861,6 +893,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'DataToSendParticicipantsNote',
     dbField: 'data_to_send_particicipants_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'dataToSendParticicipants',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI]
@@ -884,6 +918,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'ShareCclfDataNote',
     dbField: 'share_cclf_data_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'shareCclfData',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI]
@@ -908,6 +944,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'SendFilesBetweenCcwNote',
     dbField: 'send_files_between_ccw_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'sendFilesBetweenCcw',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CCW]
@@ -948,6 +986,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'AppToSendFilesToNote',
     dbField: 'app_to_send_files_to_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'appToSendFilesToKnown',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CCW]
@@ -972,6 +1012,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'UseCcwForFileDistribiutionToParticipantsNote',
     dbField: 'use_ccw_for_file_distribiution_to_participants_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'useCcwForFileDistribiutionToParticipants',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CCW]
@@ -996,6 +1038,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'DevelopNewQualityMeasuresNote',
     dbField: 'develop_new_quality_measures_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'developNewQualityMeasures',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI]
@@ -1034,6 +1078,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'QualityPerformanceImpactsPaymentNote',
     dbField: 'quality_performance_impacts_payment_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'qualityPerformanceImpactsPayment',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXT,
     filterGroups: [ModelViewFilter.CMMI]
@@ -1119,6 +1165,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'DataSharingStartsNote',
     dbField: 'data_sharing_starts_note',
     label: 'Notes',
+    isNote: true,
+    parentReferencesLabel: 'Data sharing timing and frequency questions',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI, ModelViewFilter.IDDOC]
@@ -1199,6 +1247,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'DataCollectionFrequencyNote',
     dbField: 'data_collection_frequency_note',
     label: 'Notes',
+    isNote: true,
+    parentReferencesLabel: 'Data collection timing and frequency questions',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI]
@@ -1241,6 +1291,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'QualityReportingStartsNote',
     dbField: 'quality_reporting_starts_note',
     label: 'Notes',
+    isNote: true,
+    parentReferencesLabel: 'Quality reporting timing and frequency questions',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -1314,6 +1366,8 @@ export const opsEvalAndLearning: TranslationOpsEvalAndLearning = {
     goField: 'ModelLearningSystemsNote',
     dbField: 'model_learning_systems_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'modelLearningSystems',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },

--- a/src/i18n/en-US/modelPlan/participantsAndProviders.ts
+++ b/src/i18n/en-US/modelPlan/participantsAndProviders.ts
@@ -104,6 +104,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'ParticipantsNote',
     dbField: 'participants_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'participants',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [
@@ -133,6 +135,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'ParticipantsCurrentlyInModelsNote',
     dbField: 'participants_currently_in_models_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'participantsCurrentlyInModels',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -198,6 +202,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'ConfidenceNote',
     dbField: 'confidence_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'estimateConfidence',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [
@@ -244,6 +250,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'RecruitmentNote',
     dbField: 'recruitment_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'recruitmentMethod',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -297,6 +305,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'SelectionNote',
     dbField: 'selection_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'selectionMethod',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [
@@ -347,6 +357,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'ParticipantAddedFrequencyNote',
     dbField: 'participant_added_frequency_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'participantAddedFrequency',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXT,
     filterGroups: [ModelViewFilter.IPC]
@@ -392,6 +404,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'ParticipantRemovedFrequencyNote',
     dbField: 'participant_removed_frequency_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'participantRemovedFrequency',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXT,
     filterGroups: [ModelViewFilter.IPC]
@@ -431,6 +445,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'CommunicationNote',
     dbField: 'communication_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'communicationMethod',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CBOSC, ModelViewFilter.IPC]
@@ -468,6 +484,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'RiskNote',
     dbField: 'risk_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'riskType',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -488,6 +506,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'WillRiskChangeNote',
     dbField: 'will_risk_change_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'willRiskChange',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -548,6 +568,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'ParticipantRequireFinancialGuaranteeNote',
     dbField: 'participant_require_financial_guarantee_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'participantRequireFinancialGuaranteeType',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IPC]
@@ -570,6 +592,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'CoordinateWorkNote',
     dbField: 'coordinate_work_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'coordinateWork',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -645,6 +669,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'GainsharePaymentsNote',
     dbField: 'gainshare_payments_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'gainsharePaymentsEligibility',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -686,6 +712,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'ParticipantsIDSNote',
     dbField: 'participants_ids_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'participantsIds',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC]
@@ -732,6 +760,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'ProviderAdditionFrequencyNote',
     dbField: 'provider_addition_frequency_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'providerAdditionFrequency',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.OACT, ModelViewFilter.IPC]
@@ -780,6 +810,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'ProviderAddMethodNote',
     dbField: 'provider_add_method_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'providerAddMethod',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IPC, ModelViewFilter.OACT]
@@ -825,6 +857,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'ProviderLeaveMethodNote',
     dbField: 'provider_leave_method_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'providerLeaveMethod',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IPC, ModelViewFilter.OACT]
@@ -867,6 +901,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'ProviderRemovalFrequencyNote',
     dbField: 'provider_removal_frequency_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'providerRemovalFrequency',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -907,6 +943,8 @@ export const participantsAndProviders: TranslationParticipantsAndProviders = {
     goField: 'ProviderOverlapNote',
     dbField: 'provider_overlap_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'providerOverlap',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]

--- a/src/i18n/en-US/modelPlan/payments.ts
+++ b/src/i18n/en-US/modelPlan/payments.ts
@@ -92,6 +92,8 @@ export const payments: TranslationPayments = {
     goField: 'FundingSourceNote',
     dbField: 'funding_source_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'fundingSource',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [
@@ -184,6 +186,8 @@ export const payments: TranslationPayments = {
     goField: 'FundingSourceRNote',
     dbField: 'funding_source_r_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'fundingSourceR',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [
@@ -221,6 +225,8 @@ export const payments: TranslationPayments = {
     goField: 'PayRecipientsNote',
     dbField: 'pay_recipients_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'payRecipients',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -267,6 +273,8 @@ export const payments: TranslationPayments = {
     goField: 'PayTypeNote',
     dbField: 'pay_type_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'payType',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI, ModelViewFilter.IPC]
@@ -331,6 +339,8 @@ export const payments: TranslationPayments = {
     goField: 'PayClaimsNote',
     dbField: 'pay_claims_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'payClaims',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI, ModelViewFilter.OACT]
@@ -355,6 +365,8 @@ export const payments: TranslationPayments = {
     goField: 'ShouldAnyProviderExcludedFFSSystemsNote',
     dbField: 'should_any_providers_excluded_ffs_systems_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'shouldAnyProvidersExcludedFFSSystems',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]
@@ -380,6 +392,8 @@ export const payments: TranslationPayments = {
     goField: 'ChangesMedicarePhysicianFeeScheduleNote',
     dbField: 'changes_medicare_physician_fee_schedule_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'changesMedicarePhysicianFeeSchedule',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]
@@ -419,6 +433,8 @@ export const payments: TranslationPayments = {
     goField: 'AffectsMedicareSecondaryPayerClaimsNote',
     dbField: 'affects_medicare_secondary_payer_claims_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'affectsMedicareSecondaryPayerClaims',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]
@@ -455,6 +471,8 @@ export const payments: TranslationPayments = {
     goField: 'CreatingDependenciesBetweenServicesNote',
     dbField: 'creating_dependencies_between_services_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'creatingDependenciesBetweenServices',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]
@@ -480,6 +498,8 @@ export const payments: TranslationPayments = {
     goField: 'NeedsClaimsDataCollectionNote',
     dbField: 'needs_claims_data_collection_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'needsClaimsDataCollection',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.IDDOC, ModelViewFilter.PBG]
@@ -593,6 +613,8 @@ export const payments: TranslationPayments = {
     goField: 'WaiveBeneficiaryCostSharingNote',
     dbField: 'waive_beneficiary_cost_sharing_note',
     label: 'Notes',
+    isNote: true,
+    parentReferencesLabel: 'Beneficiary cost-sharing questions',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [
@@ -654,6 +676,8 @@ export const payments: TranslationPayments = {
     goField: 'NonClaimsPaymentsNote',
     dbField: 'non_claims_payments_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'nonClaimsPayments',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [
@@ -688,6 +712,8 @@ export const payments: TranslationPayments = {
     goField: 'NumberPaymentsPerPayCycleNote',
     dbField: 'number_payments_per_pay_cycle_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'numberPaymentsPerPayCycle',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.DFSDM, ModelViewFilter.IPC]
@@ -712,6 +738,8 @@ export const payments: TranslationPayments = {
     goField: 'SharedSystemsInvolvedAdditionalClaimPaymentNote',
     dbField: 'shared_systems_involved_additional_claim_payment_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'sharedSystemsInvolvedAdditionalClaimPayment',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CCW]
@@ -741,6 +769,8 @@ export const payments: TranslationPayments = {
     goField: 'PlanningToUseInnovationPaymentContractorNote',
     dbField: 'planning_to_use_innovation_payment_contractor_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'planningToUseInnovationPaymentContractor',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [
@@ -769,6 +799,8 @@ export const payments: TranslationPayments = {
     goField: 'ExpectedCalculationComplexityLevelNote',
     dbField: 'expected_calculation_complexity_level_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'expectedCalculationComplexityLevel',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -805,6 +837,8 @@ export const payments: TranslationPayments = {
     goField: 'ClaimsProcessingPrecedenceNote',
     dbField: 'claims_processing_precedence_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'claimsProcessingPrecedence',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXT
   },
@@ -843,6 +877,8 @@ export const payments: TranslationPayments = {
     goField: 'CanParticipantsSelectBetweenPaymentMechanismsNote',
     dbField: 'can_participants_select_between_payment_mechanisms_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'canParticipantsSelectBetweenPaymentMechanisms',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI]
@@ -900,6 +936,8 @@ export const payments: TranslationPayments = {
     goField: 'AnticipatedPaymentFrequencyNote',
     dbField: 'anticipated_payment_frequency_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'anticipatedPaymentFrequency',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [
@@ -927,6 +965,8 @@ export const payments: TranslationPayments = {
     goField: 'WillRecoverPaymentsNote',
     dbField: 'will_recover_payments_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'willRecoverPayments',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [ModelViewFilter.CMMI, ModelViewFilter.IPC]
@@ -953,6 +993,8 @@ export const payments: TranslationPayments = {
     goField: 'AnticipateReconcilingPaymentsRetrospectivelyNote',
     dbField: 'anticipate_reconciling_payments_retrospectively_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'anticipateReconcilingPaymentsRetrospectively',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA,
     filterGroups: [
@@ -999,6 +1041,8 @@ export const payments: TranslationPayments = {
     goField: 'PaymentReconciliationFrequencyNote',
     dbField: 'payment_reconciliation_frequency_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'paymentReconciliationFrequency',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -1040,6 +1084,8 @@ export const payments: TranslationPayments = {
     goField: 'PaymentReconciliationFrequencyNote',
     dbField: 'payment_demand_recoupment_frequency_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'paymentDemandRecoupmentFrequency',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },
@@ -1060,6 +1106,8 @@ export const payments: TranslationPayments = {
     goField: 'PaymentStartDateNote',
     dbField: 'payment_start_date_note',
     label: 'Notes',
+    isNote: true,
+    otherParentField: 'paymentStartDate',
     dataType: TranslationDataType.STRING,
     formType: TranslationFormType.TEXTAREA
   },

--- a/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/index.tsx
@@ -46,8 +46,6 @@ const ReadOnlySection = <
   values,
   filteredView
 }: ReadOnlySectionProps<T, C>): React.ReactElement | null => {
-  const { t: miscellaneousT } = useTranslation('miscellaneous');
-
   const config = translations[field];
 
   const value = values[config.gqlField];
@@ -77,7 +75,7 @@ const ReadOnlySection = <
   const sectionName = formatID(heading);
 
   // If no notes are written, do not render
-  if (heading === miscellaneousT('notes') && !value) {
+  if (config.isNote && !value) {
     return null;
   }
 


### PR DESCRIPTION
# EASI-4194
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

- Added translation schema field `isNote` to designate if note
- Added translation schema field `parentReferenceLabel` to denote a label that pertains to multiple parent questions
- Mapped notes accordingly to new schema
- Updated readonly component to use new `isNote` field rather than the `label`

If a note does not have `parentReferenceLabel`, `otherParentField` is used to reference the parent question

<!-- Put a description here! -->

## How to test this change

Verify no changes affected readonly notes
Tests pass
Schema and mappings look good
Otherwise no visible app changes

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
