### PR TITLE
[EASI-4195] Native browser prompt on app leave

### DIFF
--- a/src/components/ConfirmLeave/index.tsx
+++ b/src/components/ConfirmLeave/index.tsx
@@ -3,9 +3,14 @@ import { useFormikContext } from 'formik';
 
 import useConfirmPageLeave from 'hooks/useConfirmPageLeave';
 
+/**
+ * _ConfirmLeave_
+ *
+ * Util to be used in conjunction with Formik to trigger prompt on dirty form
+ */
 const ConfirmLeave = () => {
   const [isDirty, setIsDirty] = useState<boolean>(false);
-  // Grab values and submitForm from context
+  // Grab dirty value from Formik context
   const { dirty } = useFormikContext();
   useEffect(() => {
     setIsDirty(dirty);

--- a/src/components/ConfirmLeave/index.tsx
+++ b/src/components/ConfirmLeave/index.tsx
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+import { useFormikContext } from 'formik';
+
+import useConfirmPageLeave from 'hooks/useConfirmPageLeave';
+
+const ConfirmLeave = () => {
+  const [isDirty, setIsDirty] = useState<boolean>(false);
+  // Grab values and submitForm from context
+  const { dirty } = useFormikContext();
+  useEffect(() => {
+    setIsDirty(dirty);
+  }, [dirty]);
+
+  useConfirmPageLeave(isDirty);
+  return null;
+};
+
+export default ConfirmLeave;

--- a/src/hooks/useConfirmPageLeave.ts
+++ b/src/hooks/useConfirmPageLeave.ts
@@ -1,0 +1,22 @@
+/* eslint no-param-reassign: "error" */
+import { useEffect } from 'react';
+import i18next from 'i18next';
+
+const confirmationMessage = i18next.t('general:onPageLeaveMessage');
+
+const useConfirmPageLeave = (isUnsafeTabClose: boolean) => {
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (isUnsafeTabClose) {
+        event.returnValue = confirmationMessage;
+        return confirmationMessage;
+      }
+      return '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [isUnsafeTabClose]);
+};
+
+export default useConfirmPageLeave;

--- a/src/hooks/useConfirmPageLeave.ts
+++ b/src/hooks/useConfirmPageLeave.ts
@@ -4,6 +4,14 @@ import i18next from 'i18next';
 
 const confirmationMessage = i18next.t('general:onPageLeaveMessage');
 
+/**
+ * _useConfirmPageLeave_
+ *
+ * Custom hook used to trigger browser prompt on app leave
+ *
+ *
+ * @param {boolean} isUnsafeTabClose
+ */
 const useConfirmPageLeave = (isUnsafeTabClose: boolean) => {
   useEffect(() => {
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {

--- a/src/i18n/en-US/general.ts
+++ b/src/i18n/en-US/general.ts
@@ -32,7 +32,8 @@ const general = {
       'If you have content you don’t want to lose, we recommend saving that content in another format.',
     stay: 'Stay on this page',
     leave: 'Leave this page'
-  }
+  },
+  onPageLeaveMessage: 'You have unsaved changes. Continue?'
 };
 
 export default general;

--- a/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/Milestones/index.tsx
@@ -24,6 +24,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
@@ -218,6 +219,8 @@ const Milestones = () => {
                     })}
                   </ErrorAlert>
                 )}
+
+                <ConfirmLeave />
 
                 <Form
                   className="desktop:grid-col-7 milestone-form margin-top-6"

--- a/src/views/ModelPlan/TaskList/Basics/Overview/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/Overview/index.tsx
@@ -21,6 +21,7 @@ import {
 
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
+import ConfirmLeave from 'components/ConfirmLeave';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
@@ -149,6 +150,8 @@ const Overview = () => {
 
           return (
             <>
+              <ConfirmLeave />
+
               {getKeys(errors).length > 0 && (
                 <ErrorAlert
                   testId="formik-validation-errors"

--- a/src/views/ModelPlan/TaskList/Basics/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/index.tsx
@@ -34,6 +34,7 @@ import {
 } from 'gql/gen/graphql';
 
 import AskAQuestion from 'components/AskAQuestion';
+import ConfirmLeave from 'components/ConfirmLeave';
 import MainContent from 'components/MainContent';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -269,6 +270,8 @@ const BasicsContent = () => {
 
           return (
             <>
+              <ConfirmLeave />
+
               {getKeys(errors).length > 0 && (
                 <ErrorAlert
                   testId="formik-validation-errors"

--- a/src/views/ModelPlan/TaskList/Beneficiaries/BeneficiaryIdentification/index.tsx
+++ b/src/views/ModelPlan/TaskList/Beneficiaries/BeneficiaryIdentification/index.tsx
@@ -24,6 +24,7 @@ import {
 
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
+import ConfirmLeave from 'components/ConfirmLeave';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
@@ -177,6 +178,8 @@ const BeneficiaryIdentification = () => {
 
           return (
             <>
+              <ConfirmLeave />
+
               {getKeys(errors).length > 0 && (
                 <ErrorAlert
                   testId="formik-validation-errors"

--- a/src/views/ModelPlan/TaskList/Beneficiaries/Frequency/index.tsx
+++ b/src/views/ModelPlan/TaskList/Beneficiaries/Frequency/index.tsx
@@ -22,6 +22,7 @@ import {
 
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
+import ConfirmLeave from 'components/ConfirmLeave';
 import FrequencyForm from 'components/FrequencyForm';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
@@ -196,6 +197,8 @@ const Frequency = () => {
 
           return (
             <>
+              <ConfirmLeave />
+
               {getKeys(errors).length > 0 && (
                 <ErrorAlert
                   testId="formik-validation-errors"

--- a/src/views/ModelPlan/TaskList/Beneficiaries/PeopleImpact/index.tsx
+++ b/src/views/ModelPlan/TaskList/Beneficiaries/PeopleImpact/index.tsx
@@ -25,6 +25,7 @@ import {
 
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
+import ConfirmLeave from 'components/ConfirmLeave';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
@@ -162,6 +163,8 @@ const PeopleImpact = () => {
 
           return (
             <>
+              <ConfirmLeave />
+
               {Object.keys(errors).length > 0 && (
                 <ErrorAlert
                   testId="formik-validation-errors"

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/Authority/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/Authority/index.tsx
@@ -22,6 +22,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
 import ReadyForReview from 'components/ReadyForReview';
@@ -219,6 +220,8 @@ const Authority = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <Form
                 className="desktop:grid-col-6 margin-top-6"

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/KeyCharacteristics/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/KeyCharacteristics/index.tsx
@@ -24,6 +24,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -212,6 +213,9 @@ const KeyCharacteristics = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
+
               <Form
                 className="desktop:grid-col-6 margin-top-6"
                 data-testid="plan-characteristics-key-characteristics-form"

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/index.tsx
@@ -49,6 +49,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import MainContent from 'components/MainContent';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -497,6 +498,8 @@ export const CharacteristicsContent = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <Form
                 className="desktop:grid-col-6 margin-top-6"

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/CCWAndQuality/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/CCWAndQuality/index.tsx
@@ -23,6 +23,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -215,6 +216,8 @@ const CCWAndQuality = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <Form
                 className="desktop:grid-col-6 margin-top-6"

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/DataSharing/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/DataSharing/index.tsx
@@ -21,6 +21,7 @@ import {
 
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
+import ConfirmLeave from 'components/ConfirmLeave';
 import FrequencyForm from 'components/FrequencyForm';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -231,6 +232,8 @@ const DataSharing = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <Form
                 className="desktop:grid-col-6 margin-top-6"

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Evaluation/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Evaluation/index.tsx
@@ -25,6 +25,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -228,6 +229,8 @@ const Evaluation = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <Form
                 className="desktop:grid-col-6 margin-top-6"

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOC/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOC/index.tsx
@@ -21,6 +21,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
@@ -207,6 +208,8 @@ const IDDOC = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <Form
                 className="desktop:grid-col-6 margin-top-6"

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCMonitoring/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCMonitoring/index.tsx
@@ -22,6 +22,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
@@ -190,6 +191,8 @@ const IDDOCMonitoring = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <Form
                 className="desktop:grid-col-6 margin-top-6"

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCTesting/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/IDDOCTesting/index.tsx
@@ -21,6 +21,7 @@ import {
 
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
+import ConfirmLeave from 'components/ConfirmLeave';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
@@ -185,6 +186,8 @@ const IDDOCTesting = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <Form
                 className="desktop:grid-col-6 margin-top-6"

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Learning/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Learning/index.tsx
@@ -21,6 +21,7 @@ import {
 
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
+import ConfirmLeave from 'components/ConfirmLeave';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -200,6 +201,8 @@ const Learning = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <Form
                 className="desktop:grid-col-6 margin-top-6"

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Performance/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/Performance/index.tsx
@@ -21,6 +21,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -229,6 +230,8 @@ const Performance = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <Form
                 className="desktop:grid-col-6 margin-top-6"

--- a/src/views/ModelPlan/TaskList/OpsEvalAndLearning/index.tsx
+++ b/src/views/ModelPlan/TaskList/OpsEvalAndLearning/index.tsx
@@ -27,6 +27,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MainContent from 'components/MainContent';
 import MutationErrorModal from 'components/MutationErrorModal';
@@ -272,6 +273,8 @@ export const OpsEvalAndLearningContent = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <Form
                 className="desktop:grid-col-6 margin-top-6"

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/Communication/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/Communication/index.tsx
@@ -23,6 +23,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import FrequencyForm from 'components/FrequencyForm';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
@@ -213,6 +214,8 @@ export const Communication = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <Form
                 className="desktop:grid-col-6 margin-top-6"

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/Coordination/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/Coordination/index.tsx
@@ -24,6 +24,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -213,6 +214,9 @@ export const Coordination = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
+
               <Form
                 className="desktop:grid-col-6 margin-top-6"
                 data-testid="participants-and-providers-coordination-form"

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ParticipantOptions/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ParticipantOptions/index.tsx
@@ -24,6 +24,7 @@ import {
 
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
+import ConfirmLeave from 'components/ConfirmLeave';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -196,6 +197,9 @@ export const ParticipantOptions = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
+
               <Form
                 className="desktop:grid-col-6 margin-top-6"
                 data-testid="participants-and-providers-options-form"

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ProviderOptions/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/ProviderOptions/index.tsx
@@ -24,6 +24,7 @@ import {
 
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
+import ConfirmLeave from 'components/ConfirmLeave';
 import FrequencyForm from 'components/FrequencyForm';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
@@ -227,6 +228,9 @@ export const ProviderOptions = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
+
               <Form
                 className="desktop:grid-col-6 margin-top-6"
                 data-testid="participants-and-providers-providers-form"

--- a/src/views/ModelPlan/TaskList/ParticipantsAndProviders/index.tsx
+++ b/src/views/ModelPlan/TaskList/ParticipantsAndProviders/index.tsx
@@ -26,6 +26,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import MainContent from 'components/MainContent';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -196,6 +197,9 @@ export const ParticipantsAndProvidersContent = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
+
               <GridContainer className="padding-left-0 padding-right-0">
                 <Grid row gap className="participants-and-providers__info">
                   <Grid desktop={{ col: 6 }}>

--- a/src/views/ModelPlan/TaskList/Payment/AnticipateDependencies/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/AnticipateDependencies/index.tsx
@@ -24,6 +24,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
@@ -204,6 +205,9 @@ const AnticipateDependencies = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
+
               <GridContainer className="padding-left-0 padding-right-0">
                 <Grid row gap>
                   <Grid desktop={{ col: 6 }}>

--- a/src/views/ModelPlan/TaskList/Payment/BeneficiaryCostSharing/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/BeneficiaryCostSharing/index.tsx
@@ -24,6 +24,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
 import PageNumber from 'components/PageNumber';
@@ -193,6 +194,9 @@ const BeneficiaryCostSharing = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
+
               <GridContainer className="padding-left-0 padding-right-0">
                 <Grid row gap>
                   <Grid desktop={{ col: 6 }}>

--- a/src/views/ModelPlan/TaskList/Payment/ClaimsBasedPayment/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/ClaimsBasedPayment/index.tsx
@@ -24,6 +24,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -208,6 +209,8 @@ const ClaimsBasedPayment = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <GridContainer className="padding-left-0 padding-right-0">
                 <Grid row gap>

--- a/src/views/ModelPlan/TaskList/Payment/Complexity/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/Complexity/index.tsx
@@ -26,6 +26,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import FrequencyForm from 'components/FrequencyForm';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -230,6 +231,9 @@ const Complexity = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
+
               <GridContainer className="padding-left-0 padding-right-0">
                 <Grid row gap>
                   <Grid desktop={{ col: 6 }}>

--- a/src/views/ModelPlan/TaskList/Payment/FundingSource/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/FundingSource/index.tsx
@@ -23,6 +23,7 @@ import {
 
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
+import ConfirmLeave from 'components/ConfirmLeave';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -351,6 +352,9 @@ const FundingSource = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
+
               <GridContainer className="padding-left-0 padding-right-0">
                 <Grid row gap>
                   <Grid desktop={{ col: 6 }}>

--- a/src/views/ModelPlan/TaskList/Payment/NonClaimsBasedPayment/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/NonClaimsBasedPayment/index.tsx
@@ -25,6 +25,7 @@ import {
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
 import PageHeading from 'components/PageHeading';
@@ -226,6 +227,8 @@ const NonClaimsBasedPayment = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <GridContainer className="padding-left-0 padding-right-0">
                 <Grid row gap>

--- a/src/views/ModelPlan/TaskList/Payment/Recover/index.tsx
+++ b/src/views/ModelPlan/TaskList/Payment/Recover/index.tsx
@@ -25,6 +25,7 @@ import { useFlags } from 'launchdarkly-react-client-sdk';
 import AddNote from 'components/AddNote';
 import AskAQuestion from 'components/AskAQuestion';
 import BooleanRadio from 'components/BooleanRadioForm';
+import ConfirmLeave from 'components/ConfirmLeave';
 import FrequencyForm from 'components/FrequencyForm';
 import ITSolutionsWarning from 'components/ITSolutionsWarning';
 import MutationErrorModal from 'components/MutationErrorModal';
@@ -247,6 +248,8 @@ const Recover = () => {
                   })}
                 </ErrorAlert>
               )}
+
+              <ConfirmLeave />
 
               <GridContainer className="padding-left-0 padding-right-0">
                 <Grid row gap>


### PR DESCRIPTION
# EASI-4195
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

This PR covers scenarios where uses may want to save data on tab close, refresh, etc.  This requires native browser support. We cannot create custom component for this, only text

TODO:  Natasha is formulating the text for this prompt

- Created `useConfirmPageLeave` hook to trigger the browser prompt
- Create util `ConfirmLeave`  for incorporating Formik context 's `dirty` state, to indicate if prompt should be rendered
- Implemented `<ConfirmLeave />` on all forms that previously had autosave
- Added a few spots where mutation handler was missing

<!-- Put a description here! -->

## How to test this change

- Navigate to nay form page
- Touch/fill out a field
- Attempt to refresh, close tab, etc
- Verify prompt appears and allows you to stay if selected

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
