### PR TITLE
[NOREF] Fixed pluralization 

### DIFF
--- a/src/i18n/en-US/auth.ts
+++ b/src/i18n/en-US/auth.ts
@@ -1,17 +1,17 @@
 const auth = {
   modal: {
     title_minute: 'Your access to MINT will expire in {{count}} minute',
-    title_minute_plural: 'Your access to MINT will expire in {{count}} minutes',
+    title_minute_other: 'Your access to MINT will expire in {{count}} minutes',
     title_second: 'Your access to MINT will expire in {{count}} second',
-    title_second_plural: 'Your access to MINT will expire in {{count}} seconds',
+    title_second_other: 'Your access to MINT will expire in {{count}} seconds',
     dataSaved: 'Your data has been saved.',
     inactivityWarning_minute:
       'If you do not do anything on this page, you will be signed out in {{count}} minute and will need to sign back in. We do this to keep your information secure.',
-    inactivityWarning_minute_plural:
+    inactivityWarning_minute_other:
       'If you do not do anything on this page, you will be signed out in {{count}} minutes and will need to sign back in. We do this to keep your information secure.',
     inactivityWarning_second:
       'If you do not do anything on this page, you will be signed out in {{count}} second and will need to sign back in. We do this to keep your information secure.',
-    inactivityWarning_second_plural:
+    inactivityWarning_second_other:
       'If you do not do anything on this page, you will be signed out in {{count}} seconds and will need to sign back in. We do this to keep your information secure.',
     cta: 'Return to MINT'
   }

--- a/src/i18n/en-US/modelPlan/discussions.ts
+++ b/src/i18n/en-US/modelPlan/discussions.ts
@@ -48,7 +48,7 @@ export const discussionsMisc: Record<string, string | NestedTranslation> = {
   modalHeading: 'Model discussions',
   discussionBanner: {
     discussion: ' discussion',
-    discussion_plural: ' discussions'
+    discussion_other: ' discussions'
   },
   discussionPanelHeading: 'Start a discussion',
   discussionPanelReply: 'Discussion',
@@ -59,7 +59,7 @@ export const discussionsMisc: Record<string, string | NestedTranslation> = {
   askAQuestionLink: 'Start a discussion',
   reply: 'Reply',
   replies: '{{count}} reply',
-  replies_plural: '{{count}} replies',
+  replies_other: '{{count}} replies',
   replies_0: 'No replies',
   typeReply: 'Type your reply',
   save: 'Save discussion',
@@ -68,9 +68,9 @@ export const discussionsMisc: Record<string, string | NestedTranslation> = {
   useLinkAbove:
     'There are no new discussion topics. Start a discussion and it will appear here.',
   newDiscussionTopics: '{{count}} new discussion topic',
-  newDiscussionTopics_plural: '{{count}} new discussion topics',
+  newDiscussionTopics_other: '{{count}} new discussion topics',
   discussionWithCount: '{{count}} discussion',
-  discussionWithCount_plural: '{{count}} discussions',
+  discussionWithCount_other: '{{count}} discussions',
   answered: 'answered question',
   viewDiscussions: 'View discussions',
   success: 'Success! Your discussion topic has been added.',

--- a/src/i18n/en-US/modelPlanTaskList.ts
+++ b/src/i18n/en-US/modelPlanTaskList.ts
@@ -11,7 +11,7 @@ const modelPlanTaskList = {
     heading: 'Documents',
     copy: 'There are no documents added.',
     document: 'document',
-    document_plural: 'documents',
+    document_other: 'documents',
     cta: 'Add a document',
     viewAll: 'View all model documents',
     addAnother: 'Add a document'


### PR DESCRIPTION
# NOREF
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

I believe that the latest upgrade to i18next changed the key for plurals from `_plural` to `_other`

- Changed instances of `_plural` to `_other`

<!-- Put a description here! -->

## How to test this change

Verify plurals work on discussions, documents, etc. - anywhere where we key the translation with a count

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
