### PR TITLE
[EASI-4167] Moved Additional Notes outside of the Conditional Render for the Geography Question

### DIFF
--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/TargetsAndOptions/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/TargetsAndOptions/index.tsx
@@ -467,13 +467,12 @@ const TargetsAndOptions = () => {
                             );
                           })}
                         </FieldGroup>
-
-                        <AddNote
-                          id="plan-characteristics-geographies-targeted-note"
-                          field="geographiesTargetedNote"
-                        />
                       </>
                     )}
+                    <AddNote
+                      id="plan-characteristics-geographies-targeted-note"
+                      field="geographiesTargetedNote"
+                    />
                   </FieldGroup>
 
                   <FieldGroup


### PR DESCRIPTION
# EASI-4167

## Changes and Description

- Moved the additional note outside of the boolean conditional

<!-- Put a description here! -->

## How to test this change

1. Navigate to page 4 of Geography questions
2. `Add an additional note` is visible/accessible regardless of answer to `Is the model targeted at specific geographies?`
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
