### PR TITLE
[EASI-4291] Fixed locked section with history block

### DIFF
--- a/src/hooks/useHandleMutation.ts
+++ b/src/hooks/useHandleMutation.ts
@@ -58,7 +58,11 @@ function useHandleMutation<TData = any, TVariables = OperationVariables>(
       const unblock = history.block(destination => {
         // Don't call mutation if attempting to access a locked section
         if (destination.pathname.includes('locked-task-list-section')) {
-          history.push(destination.pathname);
+          unblock();
+          history.push({
+            pathname: destination.pathname,
+            state: destination.state
+          });
           return false;
         }
 

--- a/src/views/ModelPlan/TaskList/Basics/index.tsx
+++ b/src/views/ModelPlan/TaskList/Basics/index.tsx
@@ -111,21 +111,25 @@ const BasicsContent = () => {
   useEffect(() => {
     if (!isModalOpen && modelID) {
       const unblock = history.block(destination => {
+        // Don't call mutation if attempting to access a locked section
+        if (destination.pathname.includes('locked-task-list-section')) {
+          unblock();
+          history.push({
+            pathname: destination.pathname,
+            state: destination.state
+          });
+          return false;
+        }
+
+        if (destination.pathname === location.pathname) {
+          return false;
+        }
+
         if (!formikRef.current?.values.modelName) {
           formikRef?.current?.setFieldError(
             'modelName',
             'Enter the Model name'
           );
-          return false;
-        }
-
-        // Don't call mutation if attempting to access a locked section
-        if (destination.pathname.includes('locked-task-list-section')) {
-          history.push(destination.pathname);
-          return false;
-        }
-
-        if (destination.pathname === location.pathname) {
           return false;
         }
 

--- a/src/views/ModelPlan/TaskList/GeneralCharacteristics/index.tsx
+++ b/src/views/ModelPlan/TaskList/GeneralCharacteristics/index.tsx
@@ -261,7 +261,11 @@ export const CharacteristicsContent = () => {
       const unblock = history.block(destination => {
         // Don't call mutation if attempting to access a locked section
         if (destination.pathname.includes('locked-task-list-section')) {
-          history.push(destination.pathname);
+          unblock();
+          history.push({
+            pathname: destination.pathname,
+            state: destination.state
+          });
           return false;
         }
 


### PR DESCRIPTION
# EASI-4291
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

- Fixed locked section with history block
  - Moved order of redirect, unblock history

<!-- Put a description here! -->

## How to test this change

Verify cypress tests pass
Verify you get redirected to locked section page if attempting to navigate to a page that is locked

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
