### PR TITLE
[Easi 4278] Change history foreign key fields for User account

### DIFF
--- a/pkg/models/translation_field.go
+++ b/pkg/models/translation_field.go
@@ -117,6 +117,15 @@ func (tfb TranslationFieldBase) GetQuestionType() *TranslationQuestionType {
 	return nil
 
 }
+func (tfb TranslationFieldBase) GetTableReference() (string, bool) {
+	if tfb.TableReference == nil {
+		return "", false
+	}
+
+	// Changes: (fk) Make this return a type enum instead of a string, for possible table references
+	return *tfb.TableReference, true
+
+}
 
 // TranslationFieldWithOptions Represents a TranslationField that has options
 type TranslationFieldWithOptions struct {
@@ -147,6 +156,8 @@ type ITranslationField interface {
 	//Changes: (Translations) Note, the children could be other types (Eg with options, or with parent), but this allows us to have a typed deserialization
 
 	GetQuestionType() *TranslationQuestionType
+
+	GetTableReference() (string, bool)
 }
 
 //Changes: (Translations) Define the Translation Parent better

--- a/pkg/translatedaudit/translate_foreign_key.go
+++ b/pkg/translatedaudit/translate_foreign_key.go
@@ -1,0 +1,70 @@
+package translatedaudit
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/cmsgov/mint-app/pkg/storage"
+)
+
+//Changes: (fk) Should this be moved into it's own package?
+
+func translateForeignKey(store *storage.Store, value interface{}, tableReference string) (interface{}, error) {
+	if value == nil {
+		return nil, nil
+	}
+	if store == nil {
+		return nil, fmt.Errorf("the store was nil, but is required to translate foreign key fields ")
+	}
+
+	//Changes: (fk) Refactor this, and handle errors etc
+	switch tableReference {
+	case "user_account":
+		{
+			return getUserAccountForeignKeyTranslation(store, value)
+		}
+	default:
+		return nil, fmt.Errorf("there is no configured method to return the table reference for %s", tableReference)
+	}
+}
+
+func getUserAccountForeignKeyTranslation(store *storage.Store, key interface{}) (string, error) {
+	// cast interface to UUID
+	uuidKey, err := parseInterfaceToUUID(key)
+	if err != nil {
+		return "", fmt.Errorf("unable to convert the provided key to a UUID to get the user account reference. err %w", err)
+	}
+
+	// get the account
+	account, err := storage.UserAccountGetByID(store, uuidKey)
+	if err != nil {
+		return "", fmt.Errorf("there was an issue translating the user account foreign key reference. err %w", err)
+	}
+	// can update the translation as needed.
+	return account.CommonName, nil
+
+}
+
+// parseInterfaceToUUID is a utility value to try and cast an interface to a UUID
+// it first attempts to parse the value directly to a UUID, and then while try to parse a string to UUID
+// If neither is possible, it will return uuid.Nil and an error
+func parseInterfaceToUUID(val interface{}) (uuid.UUID, error) {
+	uuidKey, isUUID := val.(uuid.UUID)
+	if isUUID {
+		return uuidKey, nil
+	}
+
+	stringKey, isString := val.(string)
+	if isString {
+		// Changes: (fk) Should we validate the id of the key? parse only tries to parse, it doesn't actually validate the string
+		parsedUUID, err := uuid.Parse(stringKey)
+		if err != nil {
+			return uuid.Nil, fmt.Errorf("unable to parse string to UUID. err %w", err)
+		}
+		return parsedUUID, nil
+	}
+
+	return uuid.Nil, fmt.Errorf("there was an issue casting the provided value (%v) to UUID. It is of type %T", val, val)
+
+}

--- a/pkg/translatedaudit/translate_foreign_key_test.go
+++ b/pkg/translatedaudit/translate_foreign_key_test.go
@@ -1,0 +1,76 @@
+package translatedaudit
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/cmsgov/mint-app/pkg/constants"
+)
+
+func (suite *TAuditSuite) TestTranslateForeignKey() {
+	suite.Run("user_account returns a user account", func() {
+
+		tableName := "user_account"
+		translatedPrincipal, err := translateForeignKey(suite.testConfigs.Store, suite.testConfigs.Principal.UserAccount.ID.String(), tableName)
+		suite.NoError(err)
+		suite.EqualValues(suite.testConfigs.Principal.UserAccount.CommonName, translatedPrincipal)
+
+	})
+	suite.Run("unknown table returns an error", func() {
+
+		tableName := "unknown_fake_table"
+		translatedPrincipal, err := translateForeignKey(suite.testConfigs.Store, suite.testConfigs.Principal.UserAccount.ID.String(), tableName)
+		suite.Error(err)
+		suite.EqualValues(uuid.Nil, translatedPrincipal)
+
+	})
+
+	suite.Run("nil store returns an error", func() {
+
+		tableName := "user_account"
+		translatedPrincipal, err := translateForeignKey(nil, suite.testConfigs.Principal.UserAccount.ID.String(), tableName)
+		suite.Error(err)
+		suite.EqualValues(uuid.Nil, translatedPrincipal)
+
+	})
+
+}
+
+func (suite *TAuditSuite) TestGetUserAccountForeignKeyTranslation() {
+	translatedPrincipal, err := getUserAccountForeignKeyTranslation(suite.testConfigs.Store, suite.testConfigs.Principal.UserAccount.ID.String())
+	suite.NoError(err)
+	suite.EqualValues(suite.testConfigs.Principal.UserAccount.CommonName, translatedPrincipal)
+
+}
+
+func (suite *TAuditSuite) TestParseInterfaceToUUID() {
+
+	suite.Run("Unparsable string uuid returns an error", func() {
+		val := "unparsable UUID"
+		retUUID, err := parseInterfaceToUUID(val)
+		suite.Error(err)
+		suite.EqualValues(uuid.Nil, retUUID)
+	})
+
+	suite.Run("Parsable string is parsed", func() {
+		systemAccountUUID := constants.GetSystemAccountUUID()
+		val := systemAccountUUID.String()
+		retUUID, err := parseInterfaceToUUID(val)
+		suite.NoError(err)
+		suite.EqualValues(systemAccountUUID, retUUID)
+	})
+	suite.Run("uuid is parsed", func() {
+		systemAccountUUID := constants.GetSystemAccountUUID()
+		val := systemAccountUUID
+		retUUID, err := parseInterfaceToUUID(val)
+		suite.NoError(err)
+		suite.EqualValues(systemAccountUUID, retUUID)
+	})
+
+	suite.Run("Unparsable anything returns an error", func() {
+		val := map[string]interface{}{}
+		retUUID, err := parseInterfaceToUUID(val)
+		suite.Error(err)
+		suite.EqualValues(uuid.Nil, retUUID)
+	})
+
+}

--- a/pkg/translatedaudit/translated_audit_test.go
+++ b/pkg/translatedaudit/translated_audit_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cmsgov/mint-app/pkg/authentication"
 	"github.com/cmsgov/mint-app/pkg/models"
+	"github.com/cmsgov/mint-app/pkg/storage"
 )
 
 func TestHumanizeAuditsForModelPlan(t *testing.T) {
@@ -86,7 +87,8 @@ func TestTranslateField(t *testing.T) {
 	plan := models.ModelPlan{}
 
 	t.Run("Form Type is present when there is a translation", func(t *testing.T) {
-		translatedField, err := translateField(translationFieldKey, testAuditField, &testAuditChange, &testAccount, models.DBOpUpdate, &plan, testTranslationMap)
+		var store *storage.Store //nil store
+		translatedField, err := translateField(store, translationFieldKey, testAuditField, &testAuditChange, &testAccount, models.DBOpUpdate, &plan, testTranslationMap)
 		assert.NoError(t, err)
 		assert.NotNil(t, translatedField.FormType)
 		assert.NotNil(t, translatedField.FormType)
@@ -101,7 +103,8 @@ func TestTranslateField(t *testing.T) {
 	})
 
 	t.Run("Form Type is not present when there is not a translation", func(t *testing.T) {
-		translatedField, err := translateField("there is no translation for this", testAuditField, &testAuditChange, &testAccount, models.DBOpUpdate, &plan, testTranslationMap)
+		var store *storage.Store //nil store
+		translatedField, err := translateField(store, "there is no translation for this", testAuditField, &testAuditChange, &testAccount, models.DBOpUpdate, &plan, testTranslationMap)
 		assert.NoError(t, err)
 		assert.Nil(t, translatedField.FormType)
 		assert.Nil(t, translatedField.FormType)

--- a/pkg/translatedaudit/translated_audit_test_suite.go
+++ b/pkg/translatedaudit/translated_audit_test_suite.go
@@ -1,0 +1,29 @@
+package translatedaudit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/cmsgov/mint-app/pkg/testconfig"
+	useraccounthelperstestconfigs "github.com/cmsgov/mint-app/pkg/testconfig/useraccountstoretestconfigs"
+)
+
+// TAuditSuite is the testify suite for the translated audit package
+type TAuditSuite struct {
+	suite.Suite
+	testConfigs *testconfig.Base
+}
+
+// SetupTest clears the database between each test
+func (suite *TAuditSuite) SetupTest() {
+	err := suite.testConfigs.GenericSetupTests()
+	suite.NoError(err)
+}
+
+func TestNotificationsSuite(t *testing.T) {
+	auditSuite := new(TAuditSuite)
+	auditSuite.testConfigs = testconfig.GetDefaultTestConfigs(useraccounthelperstestconfigs.GetTestPrincipal)
+
+	suite.Run(t, auditSuite)
+}


### PR DESCRIPTION
# EASI-4278

## Changes and Description

- Generic entry point to translate a foreign key field
   -  Implementation for the user_account table reference
   - Unit test for user_account table
   
- Skip translating user_account_preferences table (this will be expanded, but for now just skip the table).

<!-- Put a description here! -->

## How to test this change
1. Make a plan collaborator
2. Generate audits
3. Verify that user names are the translated value instead of the UUID string FK value.

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
