### PR TITLE
[EASI-4335] Configuration to inser a

### DIFF
--- a/migrations/V157__Audit_Job_Writes_To_Translated_Audit_Queue.sql
+++ b/migrations/V157__Audit_Job_Writes_To_Translated_Audit_Queue.sql
@@ -49,9 +49,13 @@ BEGIN
     h_new= hstore(NEW.*);
     h_old= hstore(OLD.*);
 
-    diff_keys = (akeys(h_new - insert_cols)); --these are the keys to subract from all the keys on insert or deleted
+    diff_keys = (akeys(h_new - insert_cols)); --these are the keys to subtract from all the keys on insert or deleted
     IF TG_OP = 'INSERT' OR TG_OP = 'DELETE' THEN
+        IF insert_cols = '{*}' THEN 
+            h_changed = (h_new - h_old) - array_append(excluded_cols, pkey_f); --remove matching values and primary key
+        ELSE
         h_changed = (h_new -h_old) -diff_keys; --remove matching values, and only  show specific columns for insert /delete
+        END IF;
     ELSE
         h_changed = (h_new - h_old) - excluded_cols; --remove matching values and excluded columns
     END If;

--- a/migrations/V157__Audit_Job_Writes_To_Translated_Audit_Queue.sql
+++ b/migrations/V157__Audit_Job_Writes_To_Translated_Audit_Queue.sql
@@ -129,4 +129,4 @@ $audit_table$ LANGUAGE plpgsql
 SECURITY DEFINER --Run trigger as the creator of the trigger
 SET search_path = pg_catalog, public;
 
-COMMENT ON FUNCTION audit.if_modified IS 'This trigger function is responsible for writing entries to the audit.change, and the translated_audit_queue if a record set has been modified. It will look for a diff between the old and new values, and if so write an entry. It starts with hStores to do the diff comparison, but converts the changes to a jsonB that has the name of the field, as well as the old and new values.';
+COMMENT ON FUNCTION audit.if_modified IS 'This trigger function is responsible for writing entries to the audit.change, and the translated_audit_queue if a record set has been modified. It will look for a diff between the old and new values, and if so write an entry. It starts with hStores to do the diff comparison, but converts the changes to a jsonB that has the name of the field, as well as the old and new values. If a table is configured with insert columns *, it will insert every column except the primary key and those that were explicitly marked to ignore.';

--- a/migrations/V158__Update_Audit_Config_For_Table_Insert.sql
+++ b/migrations/V158__Update_Audit_Config_For_Table_Insert.sql
@@ -18,4 +18,10 @@ WHERE name IN (
     'plan_tdl',
     'plan_collaborator'
 );
---Changes (table) update this to remove it_tools as a table, and add user_account and insert all fields at insert
+
+/* Enable Auditing for user account table*/
+SELECT audit.AUDIT_TABLE('public', 'user_account', 'id',  NULL, '{created_by,created_dts,modified_by,modified_dts}'::TEXT[], '{*}'::TEXT[]);
+
+
+/* remove it_tools table config as the table no longer exists*/
+DELETE FROM audit.table_config WHERE name = 'plan_it_tools';

--- a/migrations/V158__Update_Audit_Config_For_Table_Insert.sql
+++ b/migrations/V158__Update_Audit_Config_For_Table_Insert.sql
@@ -1,0 +1,21 @@
+UPDATE audit.table_config
+SET 
+    insert_fields = '{*}',
+    modified_by = '00000001-0001-0001-0001-000000000001', -- system account
+    modified_dts = CURRENT_TIMESTAMP
+
+
+WHERE name IN (
+    'plan_discussion',
+    'discussion_reply',
+    'plan_document',
+    'existing_model_link',
+    'plan_document_solution_link',
+    'operational_solution_subtask',
+    'operational_solution',
+    'operational_need',
+    'plan_cr',
+    'plan_tdl',
+    'plan_collaborator'
+);
+--Changes (table) update this to remove it_tools as a table, and add user_account and insert all fields at insert


### PR DESCRIPTION
# EASI-4335
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

- update audit.if_modified() to check if the insert fields = {*}, if so, insert all fields besides the primary key. This is useful for tables that insert specific fields data on insert
- add auditing to the user_account table
- remove audit_table_config for plan_it_solutions (since it doesn't exist anymore)

- Update audit config for the following tables.
    - 'plan_discussion',
    - 'discussion_reply',
    - 'plan_document',
    - 'existing_model_link',
    - 'plan_document_solution_link',
    - 'operational_solution_subtask',
    - 'operational_solution',
    - 'operational_need',
    - 'plan_cr',
    - 'plan_tdl',
    - 'plan_collaborator'
<!-- Put a description here! -->

## How to test this change
1. Make some of the updated.
2. Ensure that all fields are inserted as expected.

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
