### PR TITLE
[Easi 4345] Generic translated audit meta data, discussion reply meta data

### DIFF
--- a/migrations/V155__Translated_Audit.sql
+++ b/migrations/V155__Translated_Audit.sql
@@ -24,14 +24,24 @@ CREATE TABLE translated_audit (
     primary_key UUID NOT NULL,
     action DATABASE_OPERATION NOT NULL, 
 
-    meta_data_type TRANSLATED_AUDIT_META_DATA_TYPE NOT NULL, -- This could be whatever
-    meta_data JSONB NOT NULL, -- This could be whatever
+    meta_data_type TRANSLATED_AUDIT_META_DATA_TYPE,
+    meta_data JSONB, 
     model_name ZERO_STRING NOT NULL,
     created_by UUID NOT NULL REFERENCES user_account(id),
     created_dts TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     modified_by UUID REFERENCES user_account(id),
     modified_dts TIMESTAMP WITH TIME ZONE
 );
+
+
+ALTER TABLE translated_audit
+ADD CONSTRAINT meta_data_type_requires_meta_data CHECK (
+    (meta_data_type IS NOT NULL AND meta_data IS NOT NULL)
+    OR
+    (meta_data_type IS NULL AND meta_data IS NULL)
+);
+
+COMMENT ON CONSTRAINT meta_data_type_requires_meta_data ON translated_audit IS 'This requires that either the meta data and the meta data type or null, or they are both not null';
 
 -- Changes: (Serialization) Decide if we want to normalize the references that duplicate data, eg, actor_name, model_name etc. All of this is technically already in the audit.change table...
 

--- a/migrations/V155__Translated_Audit.sql
+++ b/migrations/V155__Translated_Audit.sql
@@ -5,6 +5,12 @@ CREATE TYPE DATABASE_OPERATION AS ENUM (
 COMMENT ON TYPE DATABASE_OPERATION IS 'The possible types of operations that can cause an audit entry.
 Currently they are represented in the audit.change table as the first letter of the action EG I, D, U, T.';
 
+CREATE TYPE TRANSLATED_AUDIT_META_DATA_TYPE AS ENUM (
+    'BASE', 'GENERIC'
+);
+
+COMMENT ON TYPE TRANSLATED_AUDIT_META_DATA_TYPE IS 'The possible meta data types that can be stored on a translated audit entry';
+
 CREATE TABLE translated_audit (
     id UUID PRIMARY KEY,
     model_plan_id UUID NOT NULL REFERENCES model_plan(id),
@@ -18,6 +24,7 @@ CREATE TABLE translated_audit (
     primary_key UUID NOT NULL,
     action DATABASE_OPERATION NOT NULL, 
 
+    meta_data_type TRANSLATED_AUDIT_META_DATA_TYPE NOT NULL, -- This could be whatever
     meta_data JSONB NOT NULL, -- This could be whatever
     model_name ZERO_STRING NOT NULL,
     created_by UUID NOT NULL REFERENCES user_account(id),

--- a/pkg/graph/schema/types/translated_audit.graphql
+++ b/pkg/graph/schema/types/translated_audit.graphql
@@ -1,13 +1,23 @@
 """
 TranslatedAuditMetaData is a type that represents all the data that can be captured in a Translated audit
 """
-union TranslatedAuditMetaData = TranslatedAuditMetaBaseStruct 
+union TranslatedAuditMetaData = TranslatedAuditMetaBaseStruct | TranslatedAuditMetaGeneric
 
 
 type TranslatedAuditMetaBaseStruct {
     version: Int!
     tableName: String
 
+}
+type TranslatedAuditMetaGeneric {
+    version: Int!
+    tableName: String
+    relation: String!
+    relationContent: String!
+}
+enum TranslatedAuditMetaDataType {
+    GENERIC
+    BASE
 }
 
 enum DatabaseOperation {
@@ -35,6 +45,7 @@ type TranslatedAudit {
     actorID: UUID!
     actorName: String!  #Changes: (Serialization) This could live in the actor account, but this is meant to facilitate search
     changeID: Int! # This points to a specific audit change.
+    metaDataType: TranslatedAuditMetaDataType! #The type of meta data stored in this record
     metaData: TranslatedAuditMetaData!
 
     """

--- a/pkg/graph/schema/types/translated_audit.graphql
+++ b/pkg/graph/schema/types/translated_audit.graphql
@@ -6,12 +6,11 @@ union TranslatedAuditMetaData = TranslatedAuditMetaBaseStruct | TranslatedAuditM
 
 type TranslatedAuditMetaBaseStruct {
     version: Int!
-    tableName: String
-
+    tableName: String!
 }
 type TranslatedAuditMetaGeneric {
     version: Int!
-    tableName: String
+    tableName: String!
     relation: String!
     relationContent: String!
 }
@@ -44,9 +43,18 @@ type TranslatedAudit {
 
     actorID: UUID!
     actorName: String!  #Changes: (Serialization) This could live in the actor account, but this is meant to facilitate search
+    """
+    The id of the audit.Change record that was translated.
+    """
     changeID: Int! # This points to a specific audit change.
-    metaDataType: TranslatedAuditMetaDataType! #The type of meta data stored in this record
-    metaData: TranslatedAuditMetaData!
+    """
+    The type of meta data that is stored for this record
+    """
+    metaDataType: TranslatedAuditMetaDataType 
+    """
+    The actual meta data stored for this record
+    """
+    metaData: TranslatedAuditMetaData
 
     """
     The specific fields that were changed by the transaction

--- a/pkg/models/translated_audit.go
+++ b/pkg/models/translated_audit.go
@@ -48,9 +48,9 @@ type TranslatedAudit struct {
 	ActorName string    `json:"actorName" db:"actor_name"` //Changes (Structure) Maybe normalize this?
 	ChangeID  int       `json:"changeID" db:"change_id"`
 
-	MetaDataRaw  interface{}                 `db:"meta_data"`
-	MetaDataType TranslatedAuditMetaDataType `db:"meta_data_type"`
-	MetaData     TranslatedAuditMetaData     `json:"metaData"`
+	MetaDataRaw  interface{}                  `db:"meta_data"`
+	MetaDataType *TranslatedAuditMetaDataType `db:"meta_data_type"`
+	MetaData     TranslatedAuditMetaData      `json:"metaData"`
 }
 
 // NewTranslatedAuditChange
@@ -67,8 +67,8 @@ func NewTranslatedAuditChange(
 	primaryKey uuid.UUID,
 	action DatabaseOperation,
 ) TranslatedAudit {
-	version := 0
-	baseMeta := NewTranslatedAuditMetaBaseStruct(tableName, version)
+	// version := 0
+	// baseMeta := NewTranslatedAuditMetaBaseStruct(tableName, version)
 	return TranslatedAudit{
 		baseStruct:        NewBaseStruct(createdBy),
 		ActorID:           actorID,
@@ -82,8 +82,8 @@ func NewTranslatedAuditChange(
 		PrimaryKey:        primaryKey,
 		Action:            action,
 
-		MetaData:     &baseMeta,
-		MetaDataType: TAMetaBase,
+		// MetaData:     &baseMeta,
+		// MetaDataType: TAMetaBase,
 	}
 
 }

--- a/pkg/models/translated_audit_field.go
+++ b/pkg/models/translated_audit_field.go
@@ -57,6 +57,7 @@ type TranslatedAuditField struct {
 
 	MetaDataRaw interface{}                  `db:"meta_data"`
 	MetaData    TranslatedAuditFieldMetaData `json:"metaData"`
+	// Changes: (Structure) Revisit meta Data. Give it the same treatment as the translated audit table, or perhaps remove it from the fields table if it is completely not needed?
 }
 
 // NewTranslatedAuditField

--- a/pkg/models/translated_audit_meta_base.go
+++ b/pkg/models/translated_audit_meta_base.go
@@ -61,9 +61,12 @@ func (hmb *TranslatedAuditMetaBaseStruct) Scan(src interface{}) error {
 }
 
 // parseRawTranslatedAuditMetaData conditionally parses meta data from JSON to a specific meta data type
-func parseRawTranslatedAuditMetaData(metaDataType TranslatedAuditMetaDataType, rawMetaDataJSON interface{}) (TranslatedAuditMetaData, error) {
+func parseRawTranslatedAuditMetaData(metaDataType *TranslatedAuditMetaDataType, rawMetaDataJSON interface{}) (TranslatedAuditMetaData, error) {
 	//Changes: (Meta) Figure out how we distinguish meta data type. This should be specific to a field / table, but that isn't here..... \
 	// We might need to partially deserialize this to a map, then cast to a type? OR! We could store more data about it in another column.
+	if metaDataType == nil {
+		return nil, nil
+	}
 
 	var rawData []byte
 
@@ -80,7 +83,7 @@ func parseRawTranslatedAuditMetaData(metaDataType TranslatedAuditMetaDataType, r
 	}
 
 	// Add on additional types if they get added.
-	switch metaDataType {
+	switch *metaDataType {
 	case TAMetaBase:
 		{
 			// Return a default implementation or handle unsupported types
@@ -100,7 +103,7 @@ func parseRawTranslatedAuditMetaData(metaDataType TranslatedAuditMetaDataType, r
 		}
 
 	default:
-		return nil, fmt.Errorf("metaDataType %s is not supported. There is no defined deserialization method", metaDataType)
+		return nil, fmt.Errorf("metaDataType %s is not supported. There is no defined deserialization method", *metaDataType)
 	}
 
 }

--- a/pkg/models/translated_audit_meta_base.go
+++ b/pkg/models/translated_audit_meta_base.go
@@ -61,7 +61,7 @@ func (hmb *TranslatedAuditMetaBaseStruct) Scan(src interface{}) error {
 }
 
 // parseRawTranslatedAuditMetaData conditionally parses meta data from JSON to a specific meta data type
-func parseRawTranslatedAuditMetaData(metaDataType string, rawMetaDataJSON interface{}) (TranslatedAuditMetaData, error) {
+func parseRawTranslatedAuditMetaData(metaDataType TranslatedAuditMetaDataType, rawMetaDataJSON interface{}) (TranslatedAuditMetaData, error) {
 	//Changes: (Meta) Figure out how we distinguish meta data type. This should be specific to a field / table, but that isn't here..... \
 	// We might need to partially deserialize this to a map, then cast to a type? OR! We could store more data about it in another column.
 
@@ -79,16 +79,28 @@ func parseRawTranslatedAuditMetaData(metaDataType string, rawMetaDataJSON interf
 		return nil, fmt.Errorf("unsupported type for TranslatedAuditField Meta Data: %T", rawMetaDataJSON)
 	}
 
+	// Add on additional types if they get added.
 	switch metaDataType {
+	case TAMetaBase:
+		{
+			// Return a default implementation or handle unsupported types
+			meta := TranslatedAuditMetaBaseStruct{}
+			if err := json.Unmarshal(rawData, &meta); err != nil {
+				return nil, err
+			}
+			return &meta, nil
+		}
+	case TAMetaGeneric:
+		{
+			meta := TranslatedAuditMetaGeneric{}
+			if err := json.Unmarshal(rawData, &meta); err != nil {
+				return nil, err
+			}
+			return &meta, nil
+		}
 
 	default:
-		// Return a default implementation or handle unsupported types
-		meta := TranslatedAuditMetaBaseStruct{}
-		if err := json.Unmarshal(rawData, &meta); err != nil {
-			return nil, err
-		}
-		return &meta, nil
-		// return nil, fmt.Errorf("unsupported table type: %s", tableName)
+		return nil, fmt.Errorf("metaDataType %s is not supported. There is no defined deserialization method", metaDataType)
 	}
 
 }

--- a/pkg/models/translated_audit_meta_generic.go
+++ b/pkg/models/translated_audit_meta_generic.go
@@ -14,10 +14,12 @@ type TranslatedAuditMetaGeneric struct {
 }
 
 // NewTranslatedAuditMetaGeneric creates a New TranslatedAuditMetaGeneric
-func NewTranslatedAuditMetaGeneric(tableName string, version int) TranslatedAuditMetaGeneric {
+func NewTranslatedAuditMetaGeneric(tableName string, version int, relation string, relationContent string) TranslatedAuditMetaGeneric {
 
 	return TranslatedAuditMetaGeneric{
 		TranslatedAuditMetaBaseStruct: NewTranslatedAuditMetaBaseStruct(tableName, version),
+		Relation:                      relation,
+		RelationContent:               relationContent,
 	}
 }
 

--- a/pkg/models/translated_audit_meta_generic.go
+++ b/pkg/models/translated_audit_meta_generic.go
@@ -1,0 +1,48 @@
+package models
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+)
+
+// TranslatedAuditMetaGeneric represents the shared data in common between all HumanizedAuditChanges
+type TranslatedAuditMetaGeneric struct {
+	TranslatedAuditMetaBaseStruct
+	Relation        string `json:"relation"`
+	RelationContent string `json:"relationContent"`
+}
+
+// NewTranslatedAuditMetaGeneric creates a New TranslatedAuditMetaGeneric
+func NewTranslatedAuditMetaGeneric(tableName string, version int) TranslatedAuditMetaGeneric {
+
+	return TranslatedAuditMetaGeneric{
+		TranslatedAuditMetaBaseStruct: NewTranslatedAuditMetaBaseStruct(tableName, version),
+	}
+}
+
+// isActivityMetaData implements the IActivityMetaGeneric
+func (hmb TranslatedAuditMetaGeneric) isAuditMetaData() {}
+
+// Value allows us to satisfy the valuer interface so we can write to the database
+func (hmb TranslatedAuditMetaGeneric) Value() (driver.Value, error) {
+	j, err := json.Marshal(hmb)
+	return j, err
+}
+
+// Scan implements the scanner interface so we can translate the JSONb from the db to an object in GO
+func (hmb *TranslatedAuditMetaGeneric) Scan(src interface{}) error {
+	if src == nil {
+		return nil
+	}
+	source, ok := src.([]byte)
+	if !ok {
+		return errors.New("type assertion .([]byte) failed")
+	}
+	err := json.Unmarshal(source, hmb)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/sqlqueries/SQL/translated_audit/collection_get_by_model_plan_ids.sql
+++ b/pkg/sqlqueries/SQL/translated_audit/collection_get_by_model_plan_ids.sql
@@ -9,6 +9,7 @@ SELECT
     table_name,
     primary_key,
     action,
+    meta_data_type,
     meta_data,
     model_name,
     created_by,

--- a/pkg/sqlqueries/SQL/translated_audit/create.sql
+++ b/pkg/sqlqueries/SQL/translated_audit/create.sql
@@ -9,6 +9,7 @@ INSERT INTO translated_audit(
     table_name,
     primary_key,
     action,
+    meta_data_type,
     meta_data,
     model_name,
     created_by
@@ -24,6 +25,7 @@ VALUES (
     :table_name,
     :primary_key,
     :action,
+    :meta_data_type,
     :meta_data,
     :model_name,
     :created_by
@@ -39,6 +41,7 @@ table_id,
 table_name,
 primary_key,
 action,
+meta_data_type,
 meta_data,
 model_name,
 created_by,

--- a/pkg/storage/translated_auditStore.go
+++ b/pkg/storage/translated_auditStore.go
@@ -17,7 +17,9 @@ func TranslatedAuditCreate(np sqlutils.NamedPreparer, translatedAudit *models.Tr
 	}
 
 	// Set the raw data as the humanizedAuditChangeData
-	translatedAudit.MetaDataRaw = translatedAudit.MetaData
+	if translatedAudit.MetaData != nil {
+		translatedAudit.MetaDataRaw = &translatedAudit.MetaData
+	}
 
 	retHumanizedChange, procError := sqlutils.GetProcedure[models.TranslatedAudit](np, sqlqueries.TranslatedAudit.Create, translatedAudit)
 	if procError != nil {

--- a/pkg/translatedaudit/translated_audit.go
+++ b/pkg/translatedaudit/translated_audit.go
@@ -222,13 +222,12 @@ func genericAuditTranslation(ctx context.Context, store *storage.Store, plan *mo
 	}
 
 	// Changes: (Translations) refactor this, perhaps this should be a receiver method on the translated audit? That way we set if not nil, instead of the default implementation?
-	metaData, err := TranslatedAuditMetaData(ctx, store, audit)
+	metaData, metaDataType, err := TranslatedAuditMetaData(ctx, store, audit)
 	if err != nil {
 		return nil, fmt.Errorf("unable to translate meta data. err %w", err)
 	}
-	if metaData != nil {
-		translatedAudit.MetaData = metaData
-	}
+	translatedAudit.MetaData = metaData
+	translatedAudit.MetaDataType = metaDataType
 
 	return &translatedAudit, nil
 }

--- a/pkg/translatedaudit/translated_audit.go
+++ b/pkg/translatedaudit/translated_audit.go
@@ -221,11 +221,15 @@ func genericAuditTranslation(ctx context.Context, store *storage.Store, plan *mo
 
 	}
 
+	// Changes: (Translations) refactor this, perhaps this should be a receiver method on the translated audit? That way we set if not nil, instead of the default implementation?
 	metaData, err := TranslatedAuditMetaData(ctx, store, audit)
 	if err != nil {
 		return nil, fmt.Errorf("unable to translate meta data. err %w", err)
 	}
-	translatedAudit.MetaData = metaData
+	if metaData != nil {
+		translatedAudit.MetaData = metaData
+	}
+
 	return &translatedAudit, nil
 }
 

--- a/pkg/translatedaudit/translated_audit.go
+++ b/pkg/translatedaudit/translated_audit.go
@@ -220,6 +220,12 @@ func genericAuditTranslation(ctx context.Context, store *storage.Store, plan *mo
 		translatedAudit.TranslatedFields = append(translatedAudit.TranslatedFields, transField)
 
 	}
+
+	metaData, err := TranslatedAuditMetaData(ctx, store, audit)
+	if err != nil {
+		return nil, fmt.Errorf("unable to translate meta data. err %w", err)
+	}
+	translatedAudit.MetaData = metaData
 	return &translatedAudit, nil
 }
 

--- a/pkg/translatedaudit/translated_audit_meta_data.go
+++ b/pkg/translatedaudit/translated_audit_meta_data.go
@@ -20,18 +20,21 @@ func DiscussionReplyMetaDataGet(ctx context.Context, store *storage.Store, reply
 	if err != nil {
 		return nil, fmt.Errorf("unable to get discussion by provided discussion ID for discussion reply translation metadata. err %w", err)
 	}
-	metaGeneric := models.NewTranslatedAuditMetaGeneric("discussion_reply", 0, "discussion_name", discussion.Content.RawContent.String())
+	metaGeneric := models.NewTranslatedAuditMetaGeneric("discussion_reply", 0, "discussion_content", discussion.Content.RawContent.String())
 	return &metaGeneric, nil
 
 }
 
-func TranslatedAuditMetaData(ctx context.Context, store *storage.Store, audit *models.AuditChange) (models.TranslatedAuditMetaData, error) {
+func TranslatedAuditMetaData(ctx context.Context, store *storage.Store, audit *models.AuditChange) (models.TranslatedAuditMetaData, *models.TranslatedAuditMetaDataType, error) {
 	switch audit.TableName {
 	case "discussion_reply":
-		return DiscussionReplyMetaDataGet(ctx, store, audit.PrimaryKey, audit.ForeignKey)
+		metaData, err := DiscussionReplyMetaDataGet(ctx, store, audit.PrimaryKey, audit.ForeignKey)
+		metaDataType := models.TAMetaGeneric
+		return metaData, &metaDataType, err
 
 	default:
-		return nil, nil
+		// Tables that aren't configured to generate meta data will return nil
+		return nil, nil, nil
 	}
 
 }

--- a/pkg/translatedaudit/translated_audit_meta_data.go
+++ b/pkg/translatedaudit/translated_audit_meta_data.go
@@ -1,0 +1,37 @@
+package translatedaudit
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cmsgov/mint-app/pkg/appcontext"
+	"github.com/cmsgov/mint-app/pkg/models"
+	"github.com/cmsgov/mint-app/pkg/storage"
+)
+
+func DiscussionReplyMetaDataGet(ctx context.Context, store *storage.Store, replyID interface{}, discussionID interface{}) (*models.TranslatedAuditMetaGeneric, error) {
+	logger := appcontext.ZLogger(ctx)
+	discussionUUID, err := parseInterfaceToUUID(discussionID)
+	if err != nil {
+		return nil, err
+	}
+
+	discussion, err := store.PlanDiscussionByID(logger, discussionUUID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get discussion by provided discussion ID for discussion reply translation metadata. err %w", err)
+	}
+	metaGeneric := models.NewTranslatedAuditMetaGeneric("discussion_reply", 0, "discussion_name", discussion.Content.RawContent.String())
+	return &metaGeneric, nil
+
+}
+
+func TranslatedAuditMetaData(ctx context.Context, store *storage.Store, audit *models.AuditChange) (models.TranslatedAuditMetaData, error) {
+	switch audit.TableName {
+	case "discussion_reply":
+		return DiscussionReplyMetaDataGet(ctx, store, audit.PrimaryKey, audit.ForeignKey)
+
+	default:
+		return nil, nil
+	}
+
+}

--- a/src/gql/gen/graphql.ts
+++ b/src/gql/gen/graphql.ts
@@ -3400,6 +3400,7 @@ export type TranslatedAudit = {
   date: Scalars['Time']['output'];
   id: Scalars['UUID']['output'];
   metaData: TranslatedAuditMetaData;
+  metaDataType: TranslatedAuditMetaDataType;
   modelName: Scalars['String']['output'];
   modifiedBy?: Maybe<Scalars['UUID']['output']>;
   modifiedByUserAccount?: Maybe<UserAccount>;
@@ -3454,7 +3455,20 @@ export type TranslatedAuditMetaBaseStruct = {
 };
 
 /** TranslatedAuditMetaData is a type that represents all the data that can be captured in a Translated audit */
-export type TranslatedAuditMetaData = TranslatedAuditMetaBaseStruct;
+export type TranslatedAuditMetaData = TranslatedAuditMetaBaseStruct | TranslatedAuditMetaGeneric;
+
+export enum TranslatedAuditMetaDataType {
+  BASE = 'BASE',
+  GENERIC = 'GENERIC'
+}
+
+export type TranslatedAuditMetaGeneric = {
+  __typename: 'TranslatedAuditMetaGeneric';
+  relation: Scalars['String']['output'];
+  relationContent: Scalars['String']['output'];
+  tableName?: Maybe<Scalars['String']['output']>;
+  version: Scalars['Int']['output'];
+};
 
 /** Represents the data type of the translation field */
 export enum TranslationDataType {

--- a/src/gql/gen/graphql.ts
+++ b/src/gql/gen/graphql.ts
@@ -3393,14 +3393,17 @@ export type TranslatedAudit = {
   action: DatabaseOperation;
   actorID: Scalars['UUID']['output'];
   actorName: Scalars['String']['output'];
+  /** The id of the audit.Change record that was translated. */
   changeID: Scalars['Int']['output'];
   createdBy: Scalars['UUID']['output'];
   createdByUserAccount: UserAccount;
   createdDts: Scalars['Time']['output'];
   date: Scalars['Time']['output'];
   id: Scalars['UUID']['output'];
-  metaData: TranslatedAuditMetaData;
-  metaDataType: TranslatedAuditMetaDataType;
+  /** The actual meta data stored for this record */
+  metaData?: Maybe<TranslatedAuditMetaData>;
+  /** The type of meta data that is stored for this record */
+  metaDataType?: Maybe<TranslatedAuditMetaDataType>;
   modelName: Scalars['String']['output'];
   modifiedBy?: Maybe<Scalars['UUID']['output']>;
   modifiedByUserAccount?: Maybe<UserAccount>;
@@ -3450,7 +3453,7 @@ export type TranslatedAuditFieldMetaData = TranslatedAuditFieldMetaBaseStruct;
 
 export type TranslatedAuditMetaBaseStruct = {
   __typename: 'TranslatedAuditMetaBaseStruct';
-  tableName?: Maybe<Scalars['String']['output']>;
+  tableName: Scalars['String']['output'];
   version: Scalars['Int']['output'];
 };
 
@@ -3466,7 +3469,7 @@ export type TranslatedAuditMetaGeneric = {
   __typename: 'TranslatedAuditMetaGeneric';
   relation: Scalars['String']['output'];
   relationContent: Scalars['String']['output'];
-  tableName?: Maybe<Scalars['String']['output']>;
+  tableName: Scalars['String']['output'];
   version: Scalars['Int']['output'];
 };
 


### PR DESCRIPTION
# EASI-4345

## Changes and Description

- Added a generic audit meta data type 
   -  All meta data to be null in the DB
   - Add a meta data type to the table
- Fill out the meta data for a discussion reply


NOTE: This meta data work will continue for additional types. PR is being created now to unblock front end work. 

<!-- Put a description here! -->

## How to test this change
1. Make a discussion
2. Make a reply
3. Translate the audits
4. Verify the data is as expected.
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
