### PR TITLE
[EASI-4302, EASI-4300] Sticky Filter Bar and Scroll to Top on Read Only Pages

### DIFF
--- a/src/components/shared/SectionWrapper/index.tsx
+++ b/src/components/shared/SectionWrapper/index.tsx
@@ -9,6 +9,7 @@ type SectionWrapperProps = {
   border?: boolean;
   borderBottom?: boolean;
   borderTop?: boolean;
+  id?: string;
 };
 
 const SectionWrapper = ({
@@ -16,7 +17,8 @@ const SectionWrapper = ({
   children,
   border,
   borderBottom,
-  borderTop
+  borderTop,
+  id
 }: SectionWrapperProps) => {
   const classNames = classnames(
     'mint-section',
@@ -28,7 +30,7 @@ const SectionWrapper = ({
     className
   );
   return (
-    <div data-testid="section-wrapper" className={classNames}>
+    <div data-testid="section-wrapper" className={classNames} id={id}>
       {children}
     </div>
   );

--- a/src/views/ModelPlan/ReadOnly/Beneficiaries/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/Beneficiaries/index.tsx
@@ -62,7 +62,9 @@ const ReadOnlyBeneficiaries = ({
       )}
 
       {loading && !data ? (
-        <PageLoading />
+        <div className="height-viewport">
+          <PageLoading />
+        </div>
       ) : (
         <ReadOnlyBody
           data={allbeneficiariesData}

--- a/src/views/ModelPlan/ReadOnly/GeneralCharacteristics/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/GeneralCharacteristics/index.tsx
@@ -108,7 +108,9 @@ const ReadOnlyGeneralCharacteristics = ({
       )}
 
       {loading && !data ? (
-        <PageLoading />
+        <div className="height-viewport">
+          <PageLoading />
+        </div>
       ) : (
         <ReadOnlyBody
           data={formattedGeneralCharacteristicsData}

--- a/src/views/ModelPlan/ReadOnly/ModelBasics/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/ModelBasics/index.tsx
@@ -140,7 +140,9 @@ const ReadOnlyModelBasics = ({
       )}
 
       {loading && !data ? (
-        <PageLoading testId="basics-page-loading" />
+        <div className="height-viewport">
+          <PageLoading />
+        </div>
       ) : (
         <>
           <ReadOnlySection

--- a/src/views/ModelPlan/ReadOnly/OpsEvalAndLearning/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/OpsEvalAndLearning/index.tsx
@@ -296,7 +296,13 @@ const ReadOnlyOpsEvalAndLearning = ({
         </p>
       )}
 
-      {loading && !data ? <PageLoading /> : renderContent()}
+      {loading && !data ? (
+        <div className="height-viewport">
+          <PageLoading />
+        </div>
+      ) : (
+        renderContent()
+      )}
     </div>
   );
 };

--- a/src/views/ModelPlan/ReadOnly/ParticipantsAndProviders/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/ParticipantsAndProviders/index.tsx
@@ -66,7 +66,9 @@ const ReadOnlyParticipantsAndProviders = ({
       )}
 
       {loading && !data ? (
-        <PageLoading />
+        <div className="height-viewport">
+          <PageLoading />
+        </div>
       ) : (
         <ReadOnlyBody
           data={allparticipantsAndProvidersData}

--- a/src/views/ModelPlan/ReadOnly/Payments/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/Payments/index.tsx
@@ -191,7 +191,9 @@ const ReadOnlyPayments = ({
       )}
 
       {loading && !data ? (
-        <PageLoading />
+        <div className="height-viewport">
+          <PageLoading />
+        </div>
       ) : (
         <>
           {/* First few sections of Payments data that can be automated */}

--- a/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
@@ -434,7 +434,7 @@ exports[`Read Only Model Plan Summary > matches snapshot 1`] = `
           data-testid="grid"
         >
           <div
-            class="desktop:grid-col-3 padding-right-4 sticky-nav sticky-nav__collaborator"
+            class="desktop:grid-col-3 padding-right-4 sticky-nav"
             data-testid="grid"
           >
             <div
@@ -1323,7 +1323,7 @@ exports[`Read Only Model Plan Summary > matches snapshot 1`] = `
                     </div>
                   </div>
                   <div
-                    class="desktop:grid-col-4 sticky-nav sticky-nav__collaborator"
+                    class="desktop:grid-col-4 sticky-nav"
                     data-testid="grid"
                   >
                     <div

--- a/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
+++ b/src/views/ModelPlan/ReadOnly/__snapshots__/index.test.tsx.snap
@@ -423,6 +423,7 @@ exports[`Read Only Model Plan Summary > matches snapshot 1`] = `
     <div
       class="mint-section model-plan__body-content margin-top-4"
       data-testid="section-wrapper"
+      id="scroll-element"
     >
       <div
         class="grid-container"

--- a/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
@@ -12,20 +12,36 @@ interface SideNavProps {
   isHelpArticle: boolean | undefined;
   solutionNavigation?: boolean;
   paramActive?: boolean;
-  clickHandler?: () => void;
 }
 
 const SideNav = ({
   subComponents,
   isHelpArticle,
   solutionNavigation,
-  paramActive,
-  clickHandler
+  paramActive
 }: SideNavProps) => {
-  const { t } = useTranslation('modelSummary');
-  const { t: h } = useTranslation('helpAndKnowledge');
+  const { t: modelSumamryT } = useTranslation('modelSummary');
+  const { t: helpAndKnowledgeT } = useTranslation('helpAndKnowledge');
 
-  const translationKey = solutionNavigation ? h : t;
+  const translationKey = solutionNavigation ? helpAndKnowledgeT : modelSumamryT;
+
+  const scrollToAboveReadOnlyBodyContent = () => {
+    const filterBannerHeight = document.querySelector(
+      '[data-testid="group-filter-banner"'
+    )?.clientHeight!;
+
+    // element is the SectionWrapper component, everything below the ModelWarning
+    const element = document.querySelector('#scroll-element')!;
+
+    // find the margin-top value of the element
+    const marginTopValue = parseFloat(
+      window.getComputedStyle(element).marginTop
+    );
+    const { top } = element?.getBoundingClientRect()!;
+    const distanceFromTopOfPage =
+      top + window.scrollY - filterBannerHeight - marginTopValue;
+    window.scroll(0, distanceFromTopOfPage);
+  };
 
   // Mapping of all sub navigation links
   const subNavigationLinks: React.ReactNode[] = Object.keys(subComponents).map(
@@ -46,7 +62,7 @@ const SideNav = ({
         }}
         activeClassName="usa-current"
         className={key === 'it-solutions' ? 'nav-group-border' : ''}
-        onClick={clickHandler}
+        onClick={scrollToAboveReadOnlyBodyContent}
       >
         {translationKey(`navigation.${key}`)}
       </NavLink>

--- a/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
@@ -12,15 +12,13 @@ interface SideNavProps {
   isHelpArticle: boolean | undefined;
   solutionNavigation?: boolean;
   paramActive?: boolean;
-  openFilterModal?: () => void;
 }
 
 const SideNav = ({
   subComponents,
   isHelpArticle,
   solutionNavigation,
-  paramActive,
-  openFilterModal
+  paramActive
 }: SideNavProps) => {
   const { t } = useTranslation('modelSummary');
   const { t: h } = useTranslation('helpAndKnowledge');

--- a/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
@@ -12,13 +12,15 @@ interface SideNavProps {
   isHelpArticle: boolean | undefined;
   solutionNavigation?: boolean;
   paramActive?: boolean;
+  clickHandler?: () => void;
 }
 
 const SideNav = ({
   subComponents,
   isHelpArticle,
   solutionNavigation,
-  paramActive
+  paramActive,
+  clickHandler
 }: SideNavProps) => {
   const { t } = useTranslation('modelSummary');
   const { t: h } = useTranslation('helpAndKnowledge');
@@ -44,6 +46,7 @@ const SideNav = ({
         }}
         activeClassName="usa-current"
         className={key === 'it-solutions' ? 'nav-group-border' : ''}
+        onClick={clickHandler}
       >
         {translationKey(`navigation.${key}`)}
       </NavLink>

--- a/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
@@ -30,14 +30,18 @@ const SideNav = ({
       '[data-testid="group-filter-banner"'
     )?.clientHeight!;
 
-    // element is the SectionWrapper component, everything below the ModelWarning
+    // `element` is the SectionWrapper component, everything below the ModelWarning
     const element = document.querySelector('#scroll-element')!;
 
-    // find the margin-top value of the element
+    // Find the margin-top value of the element
     const marginTopValue = parseFloat(
       window.getComputedStyle(element).marginTop
     );
+
+    // Find the top of the element
     const { top } = element?.getBoundingClientRect()!;
+
+    // Calculate all the things
     const distanceFromTopOfPage =
       top + window.scrollY - filterBannerHeight - marginTopValue;
     window.scroll(0, distanceFromTopOfPage);

--- a/src/views/ModelPlan/ReadOnly/index.scss
+++ b/src/views/ModelPlan/ReadOnly/index.scss
@@ -38,16 +38,7 @@
   .sticky-nav {
     align-self: start;
     position: sticky;
-    top: 68px;
-    padding-top: 1rem;
-
-    &__collaborator {
-      top: 4rem !important;
-    }
-
-    @media screen and (min-width: $desktop) {
-      margin-top: -1rem;
-    }
+    top: 100px;
   }
 
   .model-plan__model-leads__wrapper {

--- a/src/views/ModelPlan/ReadOnly/index.scss
+++ b/src/views/ModelPlan/ReadOnly/index.scss
@@ -38,7 +38,7 @@
   .sticky-nav {
     align-self: start;
     position: sticky;
-    top: 0;
+    top: 68px;
     padding-top: 1rem;
 
     &__collaborator {

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -484,7 +484,6 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
                     <SideNav
                       subComponents={subComponents}
                       isHelpArticle={isHelpArticle}
-                      openFilterModal={() => setIsFilterViewModalOpen(true)}
                     />
                   </Grid>
                 )}

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -480,9 +480,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
                 {!isMobile && (
                   <Grid
                     desktop={{ col: 3 }}
-                    className={classnames('padding-right-4 sticky-nav', {
-                      'sticky-nav__collaborator': hasEditAccess
-                    })}
+                    className="padding-right-4 sticky-nav"
                   >
                     <SideNav
                       subComponents={subComponents}
@@ -515,8 +513,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
                             <Grid
                               desktop={{ col: 4 }}
                               className={classnames({
-                                'sticky-nav': !isMobile,
-                                'sticky-nav__collaborator': hasEditAccess
+                                'sticky-nav': !isMobile
                               })}
                             >
                               <ContactInfo

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -317,7 +317,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
       '[data-testid="group-filter-banner"]'
     );
 
-    element?.scrollIntoView({ behavior: 'instant', block: 'start' });
+    element?.scrollIntoView(true);
   };
 
   const Summary = (

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -312,6 +312,14 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
     return <NotFound />;
   }
 
+  const scrollToTheFilterBanner = () => {
+    const element = document.querySelector(
+      '[data-testid="group-filter-banner"]'
+    );
+
+    element?.scrollIntoView({ behavior: 'instant', block: 'start' });
+  };
+
   const Summary = (
     <SummaryBox
       className="padding-y-6 padding-x-2 border-0 bg-primary-lighter radius-0 margin-top-0"
@@ -484,6 +492,7 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
                     <SideNav
                       subComponents={subComponents}
                       isHelpArticle={isHelpArticle}
+                      clickHandler={scrollToTheFilterBanner}
                     />
                   </Grid>
                 )}

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -312,14 +312,6 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
     return <NotFound />;
   }
 
-  const scrollToTheFilterBanner = () => {
-    const element = document.querySelector(
-      '[data-testid="group-filter-banner"]'
-    );
-
-    element?.scrollIntoView(true);
-  };
-
   const Summary = (
     <SummaryBox
       className="padding-y-6 padding-x-2 border-0 bg-primary-lighter radius-0 margin-top-0"
@@ -492,7 +484,6 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
                     <SideNav
                       subComponents={subComponents}
                       isHelpArticle={isHelpArticle}
-                      clickHandler={scrollToTheFilterBanner}
                     />
                   </Grid>
                 )}

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -465,7 +465,10 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
           {ModelWarning}
         </GridContainer>
 
-        <SectionWrapper className="model-plan__body-content margin-top-4">
+        <SectionWrapper
+          className="model-plan__body-content margin-top-4"
+          id="scroll-element"
+        >
           <GridContainer>
             {isViewingFilteredGroup ? (
               <FilteredViewBodyContent


### PR DESCRIPTION
# EASI-4302, EASI-4300
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

- Adjusted css to make sure sticky filter bar does not hide things behind it
- Created new `scrollToTheFilterBanner` function and passed it down to `SideNav` component
- Add `height-viewpoint` to each of the read only `PageLoading` components to address scroll jitter

<!-- Put a description here! -->

## How to test this change

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
