### PR TITLE
[EASI-4361] Export options, linking table translation

### DIFF
--- a/graphql-schema-linter.config.js
+++ b/graphql-schema-linter.config.js
@@ -42,6 +42,8 @@ module.exports = {
       'OperationalNeedTranslation',
       'OperationalSolutionTranslation',
       'OperationalSolutionSubtaskTranslation',
+      'PlanDocumentSolutionLinkTranslation',
+      'ExistingModelLinkTranslation',
       'TranslationFieldWithParent',
       'TranslationFieldWithOptionsAndChildren',
       'TranslationFieldWithOptionsAndParent',

--- a/mappings/export/exportTranslation.ts
+++ b/mappings/export/exportTranslation.ts
@@ -11,6 +11,8 @@ import collaborators from '../../src/i18n/en-US/modelPlan/collaborators';
 import crs from '../../src/i18n/en-US/modelPlan/crs';
 import discussions from '../../src/i18n/en-US/modelPlan/discussions';
 import documents from '../../src/i18n/en-US/modelPlan/documents';
+import documentSolutionLink from '../../src/i18n/en-US/modelPlan/documentSolutionLink';
+import existingModelLink from '../../src/i18n/en-US/modelPlan/existingModelLink';
 import generalCharacteristics from '../../src/i18n/en-US/modelPlan/generalCharacteristics';
 import modelPlan from '../../src/i18n/en-US/modelPlan/modelPlan';
 import operationalNeeds from '../../src/i18n/en-US/modelPlan/operationalNeeds';
@@ -41,7 +43,9 @@ export const translationSections = {
   plan_tdl: tdls,
   operational_need: operationalNeeds,
   operational_solution: operationalSolutions,
-  operational_solution_subtask: subtasks
+  operational_solution_subtask: subtasks,
+  existing_model_link: existingModelLink,
+  document_solution_link: documentSolutionLink
 };
 
 export const parseTypscriptToJSON = (translations: any, outputFile: string) => {

--- a/mappings/export/util.ts
+++ b/mappings/export/util.ts
@@ -9,6 +9,8 @@ import collaborator from '../../src/i18n/en-US/modelPlan/collaborators';
 import crs from '../../src/i18n/en-US/modelPlan/crs';
 import discussion from '../../src/i18n/en-US/modelPlan/discussions';
 import document from '../../src/i18n/en-US/modelPlan/documents';
+import documentSolutionLink from '../../src/i18n/en-US/modelPlan/documentSolutionLink';
+import existingModelLink from '../../src/i18n/en-US/modelPlan/existingModelLink';
 import generalCharacteristics from '../../src/i18n/en-US/modelPlan/generalCharacteristics';
 import modelPlan from '../../src/i18n/en-US/modelPlan/modelPlan';
 import operationalNeed from '../../src/i18n/en-US/modelPlan/operationalNeeds';
@@ -41,7 +43,9 @@ export const translationSections = {
   plan_tdl: tdls,
   operational_need: operationalNeed,
   operational_solution: operationalSolution,
-  operational_solution_subtask: subtask
+  operational_solution_subtask: subtask,
+  existing_model_link: existingModelLink,
+  document_solution_link: documentSolutionLink
 };
 
 // Fields that are not needed by BE

--- a/mappings/translation/document_solution_link.json
+++ b/mappings/translation/document_solution_link.json
@@ -1,0 +1,10 @@
+{
+  "solutionID": {
+    "gqlField": "solutionID",
+    "goField": "SolutionID",
+    "dbField": "solution_id",
+    "label": "Solution ID",
+    "dataType": "STRING",
+    "formType": "TEXT"
+  }
+}

--- a/mappings/translation/existing_model_link.json
+++ b/mappings/translation/existing_model_link.json
@@ -1,0 +1,10 @@
+{
+  "exsitingModelID": {
+    "gqlField": "exsitingModelID",
+    "goField": "ExsitingModelID",
+    "dbField": "exsiting_model_id",
+    "label": "Exsiting Model ID",
+    "dataType": "STRING",
+    "formType": "TEXT"
+  }
+}

--- a/mappings/translation/plan_document.json
+++ b/mappings/translation/plan_document.json
@@ -60,11 +60,16 @@
     "dbField": "restricted",
     "label": "Does this document contain cost information?",
     "sublabel": "Cost information would include any content relating to budget, funding, cost, or other monetary considerations.",
+    "exportLabel": "Visibility",
     "dataType": "BOOLEAN",
     "formType": "RADIO",
     "options": {
       "true": "Yes",
       "false": "No"
+    },
+    "exportOptions": {
+      "true": "Restricted",
+      "false": "All"
     }
   },
   "optionalNotes": {

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -34,6 +34,11 @@ type DiscussionReplyTranslation struct {
 	Content             models.TranslationField            `json:"content" db:"content"`
 }
 
+// Represents exsiting model link translation data
+type ExistingModelLinkTranslation struct {
+	ExsitingModelID models.TranslationField `json:"exsitingModelID" db:"existing_model_id"`
+}
+
 // The current user's Launch Darkly key
 type LaunchDarklySettings struct {
 	UserKey    string `json:"userKey"`
@@ -223,6 +228,11 @@ type PlanDocumentLinkInput struct {
 	Restricted           bool                `json:"restricted"`
 	OtherTypeDescription *string             `json:"otherTypeDescription,omitempty"`
 	OptionalNotes        *string             `json:"optionalNotes,omitempty"`
+}
+
+// Represents document solution link translation data
+type PlanDocumentSolutionLinkTranslation struct {
+	SolutionID models.TranslationField `json:"solutionID" db:"solution_id"`
 }
 
 // Represents plan document translation data

--- a/pkg/graph/resolvers/translation.resolvers.go
+++ b/pkg/graph/resolvers/translation.resolvers.go
@@ -6,10 +6,21 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cmsgov/mint-app/pkg/graph/generated"
 	"github.com/cmsgov/mint-app/pkg/models"
 )
+
+// ExportOptions is the resolver for the exportOptions field.
+func (r *translationFieldWithOptionsResolver) ExportOptions(ctx context.Context, obj *models.TranslationFieldWithOptions) (map[string]interface{}, error) {
+	panic(fmt.Errorf("not implemented: ExportOptions - exportOptions"))
+}
+
+// ExportOptions is the resolver for the exportOptions field.
+func (r *translationFieldWithOptionsAndChildrenResolver) ExportOptions(ctx context.Context, obj *models.TranslationFieldWithOptionsAndChildren) (map[string]interface{}, error) {
+	panic(fmt.Errorf("not implemented: ExportOptions - exportOptions"))
+}
 
 // ChildRelation is the resolver for the childRelation field.
 func (r *translationFieldWithOptionsAndChildrenResolver) ChildRelation(ctx context.Context, obj *models.TranslationFieldWithOptionsAndChildren) (map[string]interface{}, error) {
@@ -19,6 +30,16 @@ func (r *translationFieldWithOptionsAndChildrenResolver) ChildRelation(ctx conte
 		resultMap[key] = value
 	}
 	return resultMap, nil
+}
+
+// ExportOptions is the resolver for the exportOptions field.
+func (r *translationFieldWithOptionsAndParentResolver) ExportOptions(ctx context.Context, obj *models.TranslationFieldWithOptionsAndParent) (map[string]interface{}, error) {
+	panic(fmt.Errorf("not implemented: ExportOptions - exportOptions"))
+}
+
+// ExportOptions is the resolver for the exportOptions field.
+func (r *translationFieldWithParentAndChildrenResolver) ExportOptions(ctx context.Context, obj *models.TranslationFieldWithParentAndChildren) (map[string]interface{}, error) {
+	panic(fmt.Errorf("not implemented: ExportOptions - exportOptions"))
 }
 
 // ChildRelation is the resolver for the childRelation field.
@@ -31,9 +52,19 @@ func (r *translationFieldWithParentAndChildrenResolver) ChildRelation(ctx contex
 	return resultMap, nil
 }
 
+// TranslationFieldWithOptions returns generated.TranslationFieldWithOptionsResolver implementation.
+func (r *Resolver) TranslationFieldWithOptions() generated.TranslationFieldWithOptionsResolver {
+	return &translationFieldWithOptionsResolver{r}
+}
+
 // TranslationFieldWithOptionsAndChildren returns generated.TranslationFieldWithOptionsAndChildrenResolver implementation.
 func (r *Resolver) TranslationFieldWithOptionsAndChildren() generated.TranslationFieldWithOptionsAndChildrenResolver {
 	return &translationFieldWithOptionsAndChildrenResolver{r}
+}
+
+// TranslationFieldWithOptionsAndParent returns generated.TranslationFieldWithOptionsAndParentResolver implementation.
+func (r *Resolver) TranslationFieldWithOptionsAndParent() generated.TranslationFieldWithOptionsAndParentResolver {
+	return &translationFieldWithOptionsAndParentResolver{r}
 }
 
 // TranslationFieldWithParentAndChildren returns generated.TranslationFieldWithParentAndChildrenResolver implementation.
@@ -41,5 +72,7 @@ func (r *Resolver) TranslationFieldWithParentAndChildren() generated.Translation
 	return &translationFieldWithParentAndChildrenResolver{r}
 }
 
+type translationFieldWithOptionsResolver struct{ *Resolver }
 type translationFieldWithOptionsAndChildrenResolver struct{ *Resolver }
+type translationFieldWithOptionsAndParentResolver struct{ *Resolver }
 type translationFieldWithParentAndChildrenResolver struct{ *Resolver }

--- a/pkg/graph/schema/types/existing_model_link_translation.graphql
+++ b/pkg/graph/schema/types/existing_model_link_translation.graphql
@@ -1,0 +1,7 @@
+"""
+Represents exsiting model link translation data
+"""
+
+type ExistingModelLinkTranslation {
+    exsitingModelID: TranslationField! @goTag(key: "db", value: "existing_model_id")
+}

--- a/pkg/graph/schema/types/plan_document_solution_link_translation.graphql
+++ b/pkg/graph/schema/types/plan_document_solution_link_translation.graphql
@@ -1,0 +1,7 @@
+"""
+Represents document solution link translation data
+"""
+
+type PlanDocumentSolutionLinkTranslation {
+    solutionID: TranslationField! @goTag(key: "db", value: "solution_id")
+}

--- a/pkg/graph/schema/types/translation.graphql
+++ b/pkg/graph/schema/types/translation.graphql
@@ -104,6 +104,7 @@ type TranslationFieldWithOptions {
   """
   tableReference: String
   options: Map!
+  exportOptions: Map
 }
 
 """
@@ -180,6 +181,7 @@ type TranslationFieldWithOptionsAndChildren {
   """
   tableReference: String
   options: Map!
+  exportOptions: Map
   childRelation: Map!
 }
 
@@ -219,6 +221,7 @@ type TranslationFieldWithOptionsAndParent {
   """
   tableReference: String
   options: Map!
+  exportOptions: Map
   parentRelation: TranslationFieldWithOptionsAndChildren!
 }
 
@@ -258,6 +261,7 @@ type TranslationFieldWithParentAndChildren {
   """
   tableReference: String
   options: Map!
+  exportOptions: Map
   parentRelation: TranslationFieldWithOptionsAndChildren!
   childRelation: Map!
 }

--- a/src/gql/gen/graphql.ts
+++ b/src/gql/gen/graphql.ts
@@ -3517,6 +3517,7 @@ export type TranslationFieldWithOptions = {
   dbField: Scalars['String']['output'];
   /** Labels specifically for export/change history.  Takes priority over all other labels */
   exportLabel?: Maybe<Scalars['String']['output']>;
+  exportOptions?: Maybe<Scalars['Map']['output']>;
   formType: TranslationFormType;
   goField: Scalars['String']['output'];
   gqlField: Scalars['String']['output'];
@@ -3545,6 +3546,7 @@ export type TranslationFieldWithOptionsAndChildren = {
   dbField: Scalars['String']['output'];
   /** Labels specifically for export/change history.  Takes priority over all other labels */
   exportLabel?: Maybe<Scalars['String']['output']>;
+  exportOptions?: Maybe<Scalars['Map']['output']>;
   formType: TranslationFormType;
   goField: Scalars['String']['output'];
   gqlField: Scalars['String']['output'];
@@ -3572,6 +3574,7 @@ export type TranslationFieldWithOptionsAndParent = {
   dbField: Scalars['String']['output'];
   /** Labels specifically for export/change history.  Takes priority over all other labels */
   exportLabel?: Maybe<Scalars['String']['output']>;
+  exportOptions?: Maybe<Scalars['Map']['output']>;
   formType: TranslationFormType;
   goField: Scalars['String']['output'];
   gqlField: Scalars['String']['output'];
@@ -3628,6 +3631,7 @@ export type TranslationFieldWithParentAndChildren = {
   dbField: Scalars['String']['output'];
   /** Labels specifically for export/change history.  Takes priority over all other labels */
   exportLabel?: Maybe<Scalars['String']['output']>;
+  exportOptions?: Maybe<Scalars['Map']['output']>;
   formType: TranslationFormType;
   goField: Scalars['String']['output'];
   gqlField: Scalars['String']['output'];

--- a/src/gql/gen/graphql.ts
+++ b/src/gql/gen/graphql.ts
@@ -470,6 +470,12 @@ export type ExistingModelLink = {
   modifiedDts?: Maybe<Scalars['Time']['output']>;
 };
 
+/** Represents exsiting model link translation data */
+export type ExistingModelLinkTranslation = {
+  __typename: 'ExistingModelLinkTranslation';
+  exsitingModelID: TranslationField;
+};
+
 export type ExistingModelLinks = {
   __typename: 'ExistingModelLinks';
   fieldName: ExisitingModelLinkFieldType;
@@ -1753,6 +1759,12 @@ export type PlanDocumentSolutionLink = {
   modifiedByUserAccount?: Maybe<UserAccount>;
   modifiedDts?: Maybe<Scalars['Time']['output']>;
   solutionID: Scalars['UUID']['output'];
+};
+
+/** Represents document solution link translation data */
+export type PlanDocumentSolutionLinkTranslation = {
+  __typename: 'PlanDocumentSolutionLinkTranslation';
+  solutionID: TranslationField;
 };
 
 /** Represents plan document translation data */

--- a/src/i18n/en-US/modelPlan/documentSolutionLink.ts
+++ b/src/i18n/en-US/modelPlan/documentSolutionLink.ts
@@ -1,0 +1,19 @@
+import { TranslationDocumentSolutionLink } from 'types/translation';
+
+import {
+  TranslationDataType,
+  TranslationFormType
+} from '../../../gql/gen/graphql';
+
+export const documentSolutionLink: TranslationDocumentSolutionLink = {
+  solutionID: {
+    gqlField: 'solutionID',
+    goField: 'SolutionID',
+    dbField: 'solution_id',
+    label: 'Solution ID',
+    dataType: TranslationDataType.STRING,
+    formType: TranslationFormType.TEXT
+  }
+};
+
+export default documentSolutionLink;

--- a/src/i18n/en-US/modelPlan/documents.ts
+++ b/src/i18n/en-US/modelPlan/documents.ts
@@ -70,11 +70,16 @@ export const documents: TranslationDocuments = {
     label: 'Does this document contain cost information?',
     sublabel:
       'Cost information would include any content relating to budget, funding, cost, or other monetary considerations.',
+    exportLabel: 'Visibility',
     dataType: TranslationDataType.BOOLEAN,
     formType: TranslationFormType.RADIO,
     options: {
       true: 'Yes',
       false: 'No'
+    },
+    exportOptions: {
+      true: 'Restricted',
+      false: 'All'
     }
   },
   optionalNotes: {

--- a/src/i18n/en-US/modelPlan/existingModelLink.ts
+++ b/src/i18n/en-US/modelPlan/existingModelLink.ts
@@ -1,0 +1,19 @@
+import { TranslationExistingModelLink } from 'types/translation';
+
+import {
+  TranslationDataType,
+  TranslationFormType
+} from '../../../gql/gen/graphql';
+
+export const existingModelLink: TranslationExistingModelLink = {
+  exsitingModelID: {
+    gqlField: 'exsitingModelID',
+    goField: 'ExsitingModelID',
+    dbField: 'exsiting_model_id',
+    label: 'Exsiting Model ID',
+    dataType: TranslationDataType.STRING,
+    formType: TranslationFormType.TEXT
+  }
+};
+
+export default existingModelLink;

--- a/src/types/translation.ts
+++ b/src/types/translation.ts
@@ -24,6 +24,7 @@ import {
   DiscussionUserRole,
   DocumentType,
   EvaluationApproachType,
+  ExistingModelLinkTranslation,
   FrequencyType,
   FundingSource,
   GainshareArrangementEligibility,
@@ -59,6 +60,7 @@ import {
   PlanCollaboratorTranslation,
   PlanCrTranslation,
   PlanDiscussionTranslation,
+  PlanDocumentSolutionLinkTranslation,
   PlanDocumentTranslation,
   PlanGeneralCharacteristicsTranslation,
   PlanOpsEvalAndLearningTranslation,
@@ -1098,6 +1100,42 @@ type TranslationOperationalSolutionSubtasksGQL = Omit<
 */
 export type TranslationOperationalSolutionSubtasks = {
   [K in keyof TranslationOperationalSolutionSubtasksGQL]: TranslationOperationalSolutionSubtasksForm[K]; // FE form type
+};
+
+// Document Solution Link - Change History purposes only
+export type TranslationDocumentSolutionLinkForm = {
+  solutionID: TranslationFieldProperties;
+};
+
+type TranslationDocumentSolutionLinkGQL = Omit<
+  PlanDocumentSolutionLinkTranslation, // graphql gen type
+  '__typename'
+>;
+
+/* 
+  Merged keys from graphql gen with FE form types
+  Create a tighter connection between BE/FE translation types
+*/
+export type TranslationDocumentSolutionLink = {
+  [K in keyof TranslationDocumentSolutionLinkGQL]: TranslationDocumentSolutionLinkForm[K]; // FE form type
+};
+
+// Existing Model Link - Change History purposes only
+export type TranslationExistingModelLinkForm = {
+  exsitingModelID: TranslationFieldProperties;
+};
+
+type TranslationExistingModelLinkGQL = Omit<
+  ExistingModelLinkTranslation, // graphql gen type
+  '__typename'
+>;
+
+/* 
+  Merged keys from graphql gen with FE form types
+  Create a tighter connection between BE/FE translation types
+*/
+export type TranslationExistingModelLink = {
+  [K in keyof TranslationExistingModelLinkGQL]: TranslationExistingModelLinkForm[K]; // FE form type
 };
 
 export type TranslationPlan = {

--- a/src/types/translation.ts
+++ b/src/types/translation.ts
@@ -149,6 +149,7 @@ export type TranslationOptions<T extends keyof T | string> = Omit<
   optionsLabels?: Partial<Record<T, string>>; // Sub labels to be rendered directly underneath options
   tooltips?: Partial<Record<T, string>>; // Information to be rendered inside a tooltip
   optionsRelatedInfo?: Partial<Record<T, string>>; // T values should/could be a subset of the keys of enum values
+  exportOptions?: Partial<Record<T, string>>; // Export options for ChangeHistory
 };
 
 /*

--- a/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/util.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/ReadOnlySection/util.tsx
@@ -164,7 +164,10 @@ export const getRelatedUneededQuestions = <
     if (childrenToCheck) {
       childRelations = childRelations?.filter(child =>
         childrenToCheck.includes(child().gqlField)
-      );
+      ) as (
+        | Partial<Record<T, (() => TranslationConfigType<T, C>)[]>>
+        | Partial<Record<T, (() => TranslationConfigType<T, void>)[]>>
+      )[T];
     }
 
     // If the evaluation of the parent value triggers a child question, sort into appropriate arrays


### PR DESCRIPTION
# EASI-4361
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

The fields in the new translations are just placeholders!  Feel free to add/edit/remove at will!

- Added optional exportOptions translation type for restricted field
- Added two new translation tables for linking tables
  - plan_document_solution_link
  - existing_model_link
- Export

<!-- Put a description here! -->

## How to test this change

Verify export and types look correct

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
