### PR TITLE
[EASI-4368] Fix missing element scroll, incorrect PoC link

### DIFF
--- a/src/views/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Modal/index.tsx
+++ b/src/views/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Modal/index.tsx
@@ -124,7 +124,7 @@ const SolutionDetailsModal = ({
         contentLabel={t('ariaLabel')}
         appElement={document.getElementById('root')! as HTMLElement}
       >
-        <div data-testid="operational-solution-modal">
+        <div data-testid="operational-solution-modal" id="scroll-element">
           <div className="mint-discussions__x-button-container display-flex text-base flex-align-center">
             <button
               type="button"
@@ -164,7 +164,7 @@ const SolutionDetailsModal = ({
                     paramActive
                   />
 
-                  <Contact contact={primaryContact} />
+                  <Contact contact={primaryContact} closeRoute={closeRoute} />
 
                   <Alert
                     type="info"

--- a/src/views/HelpAndKnowledge/SolutionsHelp/SolutionDetails/_components/Contact/index.tsx
+++ b/src/views/HelpAndKnowledge/SolutionsHelp/SolutionDetails/_components/Contact/index.tsx
@@ -13,7 +13,13 @@ import { formatQueryParam } from '../../Modal';
 
 import './index.scss';
 
-export const Contact = ({ contact }: { contact?: SolutionContactType }) => {
+export const Contact = ({
+  contact,
+  closeRoute
+}: {
+  contact?: SolutionContactType;
+  closeRoute?: string;
+}) => {
   const { t } = useTranslation('helpAndKnowledge');
   const { t: h } = useTranslation('generalReadOnly');
 
@@ -71,7 +77,7 @@ export const Contact = ({ contact }: { contact?: SolutionContactType }) => {
           to={formatQueryParam(
             paramValues,
             'points-of-contact',
-            solutionHelpRoute
+            closeRoute || solutionHelpRoute
           )}
           className="display-flex flex-align-center"
         >

--- a/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
@@ -33,6 +33,10 @@ const SideNav = ({
     // `element` is the SectionWrapper component, everything below the ModelWarning
     const element = document.querySelector('#scroll-element')!;
 
+    if (!element) {
+      return;
+    }
+
     // Find the margin-top value of the element
     const marginTopValue = parseFloat(
       window.getComputedStyle(element).marginTop

--- a/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/_components/Sidenav/index.tsx
@@ -43,7 +43,7 @@ const SideNav = ({
     );
 
     // Find the top of the element
-    const { top } = element?.getBoundingClientRect()!;
+    const { top } = element?.getBoundingClientRect() || 0;
 
     // Calculate all the things
     const distanceFromTopOfPage =


### PR DESCRIPTION
# EASI-4368
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

The SideNav component used in readonly and help modal was targeting an element that didnt exist in help modal `scroll-element` and was attemping to call `window.getComputedStyle` on that element, triggering an error.  This fix returns early on element absence.  Additionally I added a scoll element to the modal to snap to the top when navigation changes  

- Early return on scroll function if element is not found
- Fixed incorrect PoC link when viewing from Op solutions
- Added 'scroll-element' id to help modal

<!-- Put a description here! -->

## How to test this change

Verify navigation works for help solutions, as well as the PoC link

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
