### PR TITLE
[Easi 4407]solution not needed meta

### DIFF
--- a/pkg/graph/schema/types/translated_audit.graphql
+++ b/pkg/graph/schema/types/translated_audit.graphql
@@ -48,6 +48,9 @@ type TranslatedAuditMetaOperationalSolution {
     numberOfSubtasks: Int!
     needName: String!
     needIsOther: Boolean!
+    solutionStatus: String!
+    solutionMustStart: Time
+    solutionMustFinish: Time
 }
 """
 TranslatedAuditMetaOperationalSolutionSubtask is the meta data type that is provided when a translated audit is for an operational solution subtask

--- a/pkg/models/operational_solution_subtask.go
+++ b/pkg/models/operational_solution_subtask.go
@@ -33,7 +33,7 @@ type OperationalSolutionSubtask struct {
 // NewOperationalSolutionSubtask is a constructor to create an instance of OperationalSolutionSubtask
 func NewOperationalSolutionSubtask(
 	createdBy uuid.UUID,
-	ID uuid.UUID,
+	ID uuid.UUID, //TODO: This ID is not being used. Refactor.
 	solutionID uuid.UUID,
 	name string,
 	status OperationalSolutionSubtaskStatus,

--- a/pkg/models/translated_audit_meta_base.go
+++ b/pkg/models/translated_audit_meta_base.go
@@ -23,7 +23,7 @@ type TranslatedAuditMetaData interface {
 type TranslatedAuditMetaBaseStruct struct {
 	// Changes: (Meta) do we actually need table name here? What about version? Are these doing anything?
 	TableName string `json:"tableName"`
-	Version   int    `json:"id"`
+	Version   int    `json:"version"`
 }
 
 // NewTranslatedAuditMetaBaseStruct creates a New TranslatedAuditMetaBaseStruct

--- a/pkg/models/translated_audit_meta_operational_solution.go
+++ b/pkg/models/translated_audit_meta_operational_solution.go
@@ -4,22 +4,28 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"time"
 )
 
 // TranslatedAuditMetaOperationalSolution represents the data about an operational need to render an operational need human readable.
 type TranslatedAuditMetaOperationalSolution struct {
 	TranslatedAuditMetaBaseStruct
-	NeedName            string  `json:"needName"`
-	NeedIsOther         bool    `json:"needIsOther"`
-	SolutionName        string  `json:"solutionName"`
-	SolutionOtherHeader *string `json:"solutionOtherHeader"`
-	NumberOfSubtasks    int     `json:"numberOfSubtasks"`
-	SolutionIsOther     bool    `json:"isOther"`
-	// Changes: (Meta) do we need the otherHeader in the meta data as well?
+	NeedName            string     `json:"needName"`
+	NeedIsOther         bool       `json:"needIsOther"`
+	SolutionName        string     `json:"solutionName"`
+	SolutionOtherHeader *string    `json:"solutionOtherHeader"`
+	NumberOfSubtasks    int        `json:"numberOfSubtasks"`
+	SolutionIsOther     bool       `json:"isOther"`
+	SolutionStatus      string     `json:"solutionStatus"`
+	SolutionMustStart   *time.Time `json:"solutionMustStart"`
+	SolutionMustFinish  *time.Time `json:"solutionMustFinish"`
 }
 
 // NewTranslatedAuditMetaOperationalSolution creates a New TranslatedAuditMetaOperationalSolution
-func NewTranslatedAuditMetaOperationalSolution(tableName string, version int, solutionName string, solutionOtherHeader *string, solIsOther bool, numSubtasks int, needName string, needIsOther bool) TranslatedAuditMetaOperationalSolution {
+func NewTranslatedAuditMetaOperationalSolution(tableName string, version int, solutionName string, solutionOtherHeader *string, solIsOther bool, numSubtasks int, needName string, needIsOther bool, solStatus OpSolutionStatus,
+	solMustStart *time.Time,
+	solMustFinish *time.Time,
+) TranslatedAuditMetaOperationalSolution {
 
 	return TranslatedAuditMetaOperationalSolution{
 		TranslatedAuditMetaBaseStruct: NewTranslatedAuditMetaBaseStruct(tableName, version),
@@ -29,6 +35,9 @@ func NewTranslatedAuditMetaOperationalSolution(tableName string, version int, so
 		NumberOfSubtasks:              numSubtasks,
 		NeedName:                      needName,
 		NeedIsOther:                   needIsOther,
+		SolutionStatus:                string(solStatus),
+		SolutionMustStart:             solMustStart,
+		SolutionMustFinish:            solMustFinish,
 	}
 }
 

--- a/pkg/translatedaudit/translated_audit.go
+++ b/pkg/translatedaudit/translated_audit.go
@@ -120,7 +120,7 @@ func genericAuditTranslation(ctx context.Context, store *storage.Store, plan *mo
 	}
 
 	// Changes: (Translations) refactor this, perhaps this should be a receiver method on the translated audit? That way we set if not nil, instead of the default implementation?
-	metaData, metaDataType, err := TranslatedAuditMetaData(ctx, store, audit)
+	metaData, metaDataType, err := TranslatedAuditMetaData(ctx, store, audit, operation)
 	if err != nil {
 		return nil, fmt.Errorf("unable to translate meta data. err %w", err)
 	}
@@ -130,7 +130,7 @@ func genericAuditTranslation(ctx context.Context, store *storage.Store, plan *mo
 	return &translatedAudit, nil
 }
 
-// translateField translates a given audit field. It returns the translated audit, as well as a bool to signify if it was translated or not
+// translateField translates a given audit field. It returns the translated audit field, as well as a bool to signify if it was translated or not
 func translateField(
 	ctx context.Context,
 	store *storage.Store,

--- a/pkg/translatedaudit/translated_audit_meta_data.go
+++ b/pkg/translatedaudit/translated_audit_meta_data.go
@@ -76,6 +76,9 @@ func OperationalSolutionMetaDataGet(ctx context.Context, store *storage.Store, o
 		opSolutionWithSubtasks.NumberOfSubtasks,
 		opNeed.GetName(),
 		opNeed.GetIsOther(),
+		opSolutionWithSubtasks.Status,
+		opSolutionWithSubtasks.MustStartDts,
+		opSolutionWithSubtasks.MustFinishDts,
 	)
 	metaType := models.TAMetaOperationalSolution
 

--- a/pkg/translatedaudit/translated_audit_meta_data_test.go
+++ b/pkg/translatedaudit/translated_audit_meta_data_test.go
@@ -1,0 +1,46 @@
+package translatedaudit
+
+import (
+	"time"
+)
+
+func (suite *TAuditSuite) TestDiscussionReplyMetaDataGet() {
+	plan := suite.createModelPlan("testPlan")
+	discussionContent := "Blah blah blah discussion"
+	discussion := suite.createPlanDiscussion(plan.ID, discussionContent)
+	replyContent := "that's very interesting"
+
+	reply := suite.createDiscussionReply(discussion.ID, replyContent)
+	now := time.Now()
+	numReplies := 1
+
+	metaData, err := DiscussionReplyMetaDataGet(suite.testConfigs.Context, suite.testConfigs.Store, reply.ID.String(), discussion.ID.String(), now)
+	suite.NoError(err)
+	suite.NotNil(metaData)
+
+	suite.EqualValues(discussionContent, metaData.DiscussionContent)
+	suite.EqualValues(discussion.ID, metaData.DiscussionID)
+	suite.EqualValues(numReplies, metaData.NumberOfReplies)
+
+	suite.EqualValues("discussion_reply", metaData.TableName)
+	suite.EqualValues(0, metaData.Version)
+
+}
+
+// OperationalNeedMetaDataGet uses the provided information to generate metadata needed for any operational need audits
+func (suite *TAuditSuite) OperationalNeedMetaDataGet() {
+
+}
+
+// OperationalSolutionMetaDataGet uses the provided information to generate metadata needed for any operational solution audits
+func (suite *TAuditSuite) OperationalSolutionMetaDataGet() {
+
+}
+
+// OperationalSolutionSubtaskMetaDataGet uses the provided information to generate metadata needed for any operational solution subtask audits.
+// it checks if there is a name in the changes, and if so it sets that in the meta data, otherwise it will fetch it from the table record
+func (suite *TAuditSuite) OperationalSolutionSubtaskMetaDataGet() {
+}
+
+func (suite *TAuditSuite) TranslatedAuditMetaData() {
+}

--- a/pkg/translatedaudit/translated_audit_meta_data_test.go
+++ b/pkg/translatedaudit/translated_audit_meta_data_test.go
@@ -31,6 +31,24 @@ func (suite *TAuditSuite) TestDiscussionReplyMetaDataGet() {
 }
 
 func (suite *TAuditSuite) TestOperationalNeedMetaDataGet() {
+	plan := suite.createModelPlan("test plan")
+	needName := "To test operational solution meta data"
+	need := suite.createOperationalNeed(plan.ID, needName)
+
+	// the test function makes a custom solution
+	needIsOther := true
+	metaData, err := OperationalNeedMetaDataGet(suite.testConfigs.Context, suite.testConfigs.Store, need.ID.String())
+
+	suite.NoError(err)
+	suite.NotNil(metaData)
+
+	//Changes: (Testing) expand this
+	suite.EqualValues(needName, metaData.NeedName)
+	suite.EqualValues(needIsOther, metaData.IsOther)
+
+	tableName := "operational_need"
+	suite.EqualValues(tableName, metaData.TableName)
+	suite.EqualValues(0, metaData.Version)
 
 }
 

--- a/pkg/translatedaudit/translated_audit_meta_data_test.go
+++ b/pkg/translatedaudit/translated_audit_meta_data_test.go
@@ -42,7 +42,6 @@ func (suite *TAuditSuite) TestOperationalNeedMetaDataGet() {
 	suite.NoError(err)
 	suite.NotNil(metaData)
 
-	//Changes: (Testing) expand this
 	suite.EqualValues(needName, metaData.NeedName)
 	suite.EqualValues(needIsOther, metaData.IsOther)
 
@@ -80,7 +79,6 @@ func (suite *TAuditSuite) TestOperationalSolutionMetaDataGet() {
 		suite.EqualValues(models.TAMetaOperationalSolution, *metaDataType)
 	}
 
-	//Changes: (Testing) expand this
 	suite.EqualValues(needName, metaData.NeedName)
 	suite.EqualValues(needIsOther, metaData.NeedIsOther)
 	suite.EqualValues(0, metaData.NumberOfSubtasks)
@@ -143,7 +141,6 @@ func (suite *TAuditSuite) TestOperationalSolutionSubtaskMetaDataGet() {
 	suite.NoError(err)
 	suite.NotNil(metaData)
 
-	//Changes: (Testing) expand this
 	suite.EqualValues(needName, metaData.NeedName)
 	suite.EqualValues(needIsOther, metaData.NeedIsOther)
 	suite.EqualValues(1, metaData.NumberOfSubtasks)
@@ -161,14 +158,13 @@ func (suite *TAuditSuite) TestOperationalSolutionSubtaskMetaDataGet() {
 	suite.EqualValues(subtaskNameNewForChanges, metaData.SubtaskName)
 
 	suite.Run("A delete or truncate without a name in the changes object will error", func() {
-		// operation =
 		metaData, err := OperationalSolutionSubtaskMetaDataGet(suite.testConfigs.Context, suite.testConfigs.Store, subTask.ID.String(), sol.ID.String(), emptyChanges, models.DBOpDelete)
 
 		suite.Error(err)
 		suite.Nil(metaData)
 	})
 	suite.Run("An update without a name in the changes object will fetch from DB", func() {
-		// operation =
+
 		metaData, err := OperationalSolutionSubtaskMetaDataGet(suite.testConfigs.Context, suite.testConfigs.Store, subTask.ID.String(), sol.ID.String(), emptyChanges, models.DBOpUpdate)
 
 		suite.NoError(err)
@@ -176,7 +172,4 @@ func (suite *TAuditSuite) TestOperationalSolutionSubtaskMetaDataGet() {
 		suite.EqualValues(subtaskNameNew, metaData.SubtaskName)
 	})
 
-}
-
-func (suite *TAuditSuite) TestTranslatedAuditMetaData() {
 }

--- a/pkg/translatedaudit/translated_audit_meta_data_test.go
+++ b/pkg/translatedaudit/translated_audit_meta_data_test.go
@@ -56,7 +56,8 @@ func (suite *TAuditSuite) TestOperationalSolutionMetaDataGet() {
 	needName := "To test operational solution meta data"
 	need := suite.createOperationalNeed(plan.ID, needName)
 	solName := "make a unit test"
-	mustFinish := time.Now().UTC()
+	// we round to the micro second, because when the data is serialized to the db in meta data, it rounds to micro seconds
+	mustFinish := time.Now().UTC().Round(time.Microsecond)
 	mustStart := mustFinish.Add(-24 * time.Hour)
 	solStatus := models.OpSAtRisk
 	solOtherHeader := models.StringPointer("hooray! It's the other header!")

--- a/pkg/translatedaudit/translated_audit_suite_utils_test.go
+++ b/pkg/translatedaudit/translated_audit_suite_utils_test.go
@@ -33,10 +33,14 @@ func (suite *TAuditSuite) createOperationalNeed(modelPlanID uuid.UUID, customNee
 }
 
 // createOperationalSolution creates an operational solution using the store. It is just for testing
-func (suite *TAuditSuite) createOperationalSolution(operationalNeedID uuid.UUID, customSolution string) *models.OperationalSolution {
+func (suite *TAuditSuite) createOperationalSolution(operationalNeedID uuid.UUID, customSolution string, preHooks ...func(*models.OperationalSolution)) *models.OperationalSolution {
 
 	solToCreate := models.NewOperationalSolution(suite.testConfigs.Principal.UserAccount.ID, operationalNeedID)
 	solToCreate.NameOther = &customSolution
+	for _, preHook := range preHooks {
+		preHook(solToCreate)
+
+	}
 
 	retSol, err := suite.testConfigs.Store.OperationalSolutionInsert(suite.testConfigs.Logger, solToCreate, nil)
 	suite.NoError(err)

--- a/pkg/translatedaudit/translated_audit_suite_utils_test.go
+++ b/pkg/translatedaudit/translated_audit_suite_utils_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/guregu/null/zero"
 
 	"github.com/cmsgov/mint-app/pkg/models"
+	"github.com/cmsgov/mint-app/pkg/storage"
 )
 
 // CreateModelPlan creates a model plan using the store. It doesn't do this in a transaction, and doesn't make
@@ -62,5 +63,46 @@ func (suite *TAuditSuite) createPlanDocument(modelPlanID uuid.UUID, fileName str
 	retDocument, err := suite.testConfigs.Store.PlanDocumentCreate(suite.testConfigs.Logger, suite.testConfigs.Principal.UserAccount.ID.String(), document)
 	suite.NoError(err)
 	return retDocument
+
+}
+
+// createPlanDiscussion creates a test plan discussion for testing. It doesn't go through normal resolver procedures (eg there are no tags)
+func (suite *TAuditSuite) createPlanDiscussion(modelPlanID uuid.UUID, content string) *models.PlanDiscussion {
+
+	discussionUserRole := models.DiscussionRoleMintTeam
+	taggedContent, err := models.NewTaggedContentFromString(content)
+	suite.NoError(err)
+
+	discussion := models.NewPlanDiscussion(suite.testConfigs.Principal.UserAccount.ID,
+		false, modelPlanID,
+		models.TaggedHTML(taggedContent),
+		&discussionUserRole,
+		nil,
+	)
+
+	retDisc, err := suite.testConfigs.Store.PlanDiscussionCreate(suite.testConfigs.Logger, discussion, suite.testConfigs.Store)
+
+	suite.NoError(err)
+	return retDisc
+}
+
+// createDiscussionReply creates a test  discussion reply for testing
+func (suite *TAuditSuite) createDiscussionReply(discussionID uuid.UUID, content string) *models.DiscussionReply {
+
+	discussionUserRole := models.DiscussionRoleMintTeam
+	taggedContent, err := models.NewTaggedContentFromString(content)
+	suite.NoError(err)
+
+	discussionReply := models.NewDiscussionReply(suite.testConfigs.Principal.UserAccount.ID,
+		false, discussionID,
+		models.TaggedHTML(taggedContent),
+		&discussionUserRole,
+		nil,
+	)
+
+	retReply, err := storage.DiscussionReplyCreate(suite.testConfigs.Logger, discussionReply, suite.testConfigs.Store)
+
+	suite.NoError(err)
+	return retReply
 
 }

--- a/pkg/translatedaudit/translated_audit_suite_utils_test.go
+++ b/pkg/translatedaudit/translated_audit_suite_utils_test.go
@@ -47,6 +47,25 @@ func (suite *TAuditSuite) createOperationalSolution(operationalNeedID uuid.UUID,
 	return retSol
 }
 
+// createOperationalSolutionSubtask creates an operational solution subtask using the store. It is just for testing
+func (suite *TAuditSuite) createOperationalSolutionSubtask(solutionID uuid.UUID, subtaskName string, subtaskStatus *models.OperationalSolutionSubtaskStatus) *models.OperationalSolutionSubtask {
+
+	if subtaskStatus == nil {
+		status := models.OperationalSolutionSubtaskStatusTodo
+		subtaskStatus = &status
+	}
+
+	subtaskToCreate := models.NewOperationalSolutionSubtask(suite.testConfigs.Principal.UserAccount.ID, uuid.New(), solutionID, subtaskName, *subtaskStatus)
+
+	retSubTaskList, err := suite.testConfigs.Store.OperationalSolutionSubtasksCreate(suite.testConfigs.Logger, []*models.OperationalSolutionSubtask{subtaskToCreate})
+	suite.NoError(err)
+	if suite.Len(retSubTaskList, 1) {
+		return retSubTaskList[0]
+	}
+
+	return nil
+}
+
 // createPlanDocument creates a test plan document for testing
 func (suite *TAuditSuite) createPlanDocument(modelPlanID uuid.UUID, fileName string) *models.PlanDocument {
 

--- a/pkg/translatedaudit/translated_audit_test.go
+++ b/pkg/translatedaudit/translated_audit_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cmsgov/mint-app/pkg/storage"
 )
 
-func TestHumanizeAuditsForModelPlan(t *testing.T) {
+func TestTranslateAuditsForModelPlan(t *testing.T) {
 	//Changes: (ChChCh Changes!) This should really happen in this package, testing in the resolver package for now just for simplicity for a POC
 
 }

--- a/src/gql/gen/graphql.ts
+++ b/src/gql/gen/graphql.ts
@@ -3529,8 +3529,11 @@ export type TranslatedAuditMetaOperationalSolution = {
   needName: Scalars['String']['output'];
   numberOfSubtasks: Scalars['Int']['output'];
   solutionIsOther: Scalars['Boolean']['output'];
+  solutionMustFinish?: Maybe<Scalars['Time']['output']>;
+  solutionMustStart?: Maybe<Scalars['Time']['output']>;
   solutionName: Scalars['String']['output'];
   solutionOtherHeader?: Maybe<Scalars['String']['output']>;
+  solutionStatus: Scalars['String']['output'];
   tableName: Scalars['String']['output'];
   version: Scalars['Int']['output'];
 };


### PR DESCRIPTION
# EASI-4407
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

- Solution subtask can get name from changes fields on delete
- Operational Solution now stores must start, must finish, and status in meta data
- Unit tests added for all current meta data functions
<!-- Put a description here! -->

## How to test this change
1.Make the new types
2. Make sure they provide the needed info
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
