### PR TITLE
[Easi 4360]/change history translation export options

### DIFF
--- a/mappings/translation_test_utilities.go
+++ b/mappings/translation_test_utilities.go
@@ -205,6 +205,8 @@ func assertTFieldBase(t *testing.T, field reflect.StructField, base models.Trans
 
 // assertTFieldOptions asserts that a translation has options when it is supposed to
 func assertTFieldOptions(t *testing.T, field reflect.StructField, translation models.ITranslationField) {
+
+	// This asserts that it has some options it doesn't assert ExportOptions over standard options
 	options, hasOptions := translation.GetOptions()
 	assert.True(t, hasOptions)
 

--- a/pkg/graph/resolvers/translation.resolvers.go
+++ b/pkg/graph/resolvers/translation.resolvers.go
@@ -6,21 +6,10 @@ package resolvers
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cmsgov/mint-app/pkg/graph/generated"
 	"github.com/cmsgov/mint-app/pkg/models"
 )
-
-// ExportOptions is the resolver for the exportOptions field.
-func (r *translationFieldWithOptionsResolver) ExportOptions(ctx context.Context, obj *models.TranslationFieldWithOptions) (map[string]interface{}, error) {
-	panic(fmt.Errorf("not implemented: ExportOptions - exportOptions"))
-}
-
-// ExportOptions is the resolver for the exportOptions field.
-func (r *translationFieldWithOptionsAndChildrenResolver) ExportOptions(ctx context.Context, obj *models.TranslationFieldWithOptionsAndChildren) (map[string]interface{}, error) {
-	panic(fmt.Errorf("not implemented: ExportOptions - exportOptions"))
-}
 
 // ChildRelation is the resolver for the childRelation field.
 func (r *translationFieldWithOptionsAndChildrenResolver) ChildRelation(ctx context.Context, obj *models.TranslationFieldWithOptionsAndChildren) (map[string]interface{}, error) {
@@ -30,16 +19,6 @@ func (r *translationFieldWithOptionsAndChildrenResolver) ChildRelation(ctx conte
 		resultMap[key] = value
 	}
 	return resultMap, nil
-}
-
-// ExportOptions is the resolver for the exportOptions field.
-func (r *translationFieldWithOptionsAndParentResolver) ExportOptions(ctx context.Context, obj *models.TranslationFieldWithOptionsAndParent) (map[string]interface{}, error) {
-	panic(fmt.Errorf("not implemented: ExportOptions - exportOptions"))
-}
-
-// ExportOptions is the resolver for the exportOptions field.
-func (r *translationFieldWithParentAndChildrenResolver) ExportOptions(ctx context.Context, obj *models.TranslationFieldWithParentAndChildren) (map[string]interface{}, error) {
-	panic(fmt.Errorf("not implemented: ExportOptions - exportOptions"))
 }
 
 // ChildRelation is the resolver for the childRelation field.
@@ -52,19 +31,9 @@ func (r *translationFieldWithParentAndChildrenResolver) ChildRelation(ctx contex
 	return resultMap, nil
 }
 
-// TranslationFieldWithOptions returns generated.TranslationFieldWithOptionsResolver implementation.
-func (r *Resolver) TranslationFieldWithOptions() generated.TranslationFieldWithOptionsResolver {
-	return &translationFieldWithOptionsResolver{r}
-}
-
 // TranslationFieldWithOptionsAndChildren returns generated.TranslationFieldWithOptionsAndChildrenResolver implementation.
 func (r *Resolver) TranslationFieldWithOptionsAndChildren() generated.TranslationFieldWithOptionsAndChildrenResolver {
 	return &translationFieldWithOptionsAndChildrenResolver{r}
-}
-
-// TranslationFieldWithOptionsAndParent returns generated.TranslationFieldWithOptionsAndParentResolver implementation.
-func (r *Resolver) TranslationFieldWithOptionsAndParent() generated.TranslationFieldWithOptionsAndParentResolver {
-	return &translationFieldWithOptionsAndParentResolver{r}
 }
 
 // TranslationFieldWithParentAndChildren returns generated.TranslationFieldWithParentAndChildrenResolver implementation.
@@ -72,7 +41,5 @@ func (r *Resolver) TranslationFieldWithParentAndChildren() generated.Translation
 	return &translationFieldWithParentAndChildrenResolver{r}
 }
 
-type translationFieldWithOptionsResolver struct{ *Resolver }
 type translationFieldWithOptionsAndChildrenResolver struct{ *Resolver }
-type translationFieldWithOptionsAndParentResolver struct{ *Resolver }
 type translationFieldWithParentAndChildrenResolver struct{ *Resolver }

--- a/pkg/models/translation_field.go
+++ b/pkg/models/translation_field.go
@@ -201,6 +201,9 @@ type TranslationFieldWithParent struct {
 // translationOptionRelation is struct that is mean to be embedded in other Translation types to expose options, and functionality of options
 type translationOptionRelation struct {
 	Options map[string]interface{} `json:"options"`
+
+	// ExportOptions is the optional values of options when it should differ from regular viewable options
+	ExportOptions map[string]interface{} `json:"exportOptions"` // This is optional, but GQL doesn't allow a map pointer
 }
 
 // HasOptions specifies if a translation field has options or not
@@ -210,6 +213,9 @@ func (tor translationOptionRelation) HasOptions() bool {
 
 // GetOptions returns options for a translation
 func (tor translationOptionRelation) GetOptions() (map[string]interface{}, bool) {
+	if len(tor.ExportOptions) > 0 {
+		return tor.ExportOptions, tor.HasOptions()
+	}
 	return tor.Options, tor.HasOptions()
 }
 

--- a/pkg/models/translation_field_test.go
+++ b/pkg/models/translation_field_test.go
@@ -179,3 +179,56 @@ func TestTranslationFieldLabel(t *testing.T) {
 	})
 
 }
+
+func TestGetOptions(t *testing.T) {
+	label := "Hooray, you got the label from the parent"
+	dbField := "db_field_name"
+	field1Key := "hooray"
+	field1Value := "value1"
+
+	field2Key := "boo"
+	field2Value := "value2"
+
+	TranslationField := TranslationFieldWithOptions{
+		TranslationFieldBase: TranslationFieldBase{
+			DbField: dbField,
+
+			Label:                 label,
+			ReadOnlyLabel:         nil,
+			SubLabel:              nil,
+			MultiSelectLabel:      nil,
+			IsArray:               false,
+			DataType:              TDTString,
+			FormType:              TFTText,
+			IsNote:                false,
+			IsOtherType:           false,
+			OtherParentField:      nil,
+			ParentReferencesLabel: nil,
+		},
+		translationOptionRelation: translationOptionRelation{
+			Options: map[string]interface{}{
+				field1Key: field1Value,
+				field2Key: field2Value,
+			},
+		},
+	}
+	assert := assert.New(t)
+
+	// Get options, assert that there are two (the regular options)
+	options, hasOptions := TranslationField.GetOptions()
+	assert.True(hasOptions)
+	assert.Len(options, 2)
+	assert.EqualValues(field1Value, options[field1Key])
+	assert.EqualValues(field2Value, options[field2Key])
+
+	field1ValueExport := "ExportOption"
+	// Add export options and assert they are retrieved
+	TranslationField.ExportOptions = map[string]interface{}{
+		field1Key: field1ValueExport,
+	}
+	options2, hasOptions2 := TranslationField.GetOptions()
+	assert.True(hasOptions2)
+	assert.Len(options2, 1)
+	assert.EqualValues(field1ValueExport, options2[field1Key])
+
+}


### PR DESCRIPTION
# EASI-4360
## Changes and Description

- Add export options as the first priority option to return for a translation with Options

<!-- Put a description here! -->

## How to test this change
1. Make a change that uses export options ( I suggest plan document restricted status)
2.  Translate the change.
3. Assert that the data was translated with export options and not the regular options.
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
