### PR TITLE
[EASI-4416, EASI-4445] - Read-only -> Read-view changes

### DIFF
--- a/cypress/e2e/collaborator.spec.js
+++ b/cypress/e2e/collaborator.spec.js
@@ -138,15 +138,15 @@ describe('The Collaborator/Team Member Form', () => {
     cy.get('[data-testid="table"] a').contains('Empty Plan').click();
 
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/\/models\/.{36}\/read-only\/model-basics/);
+      expect(loc.pathname).to.match(/\/models\/.{36}\/read-view\/model-basics/);
     });
 
     cy.get('@modelPlanURL').then(modelPlanURL => {
-      const taskList = modelPlanURL.replace('read-only', 'task-list');
+      const taskList = modelPlanURL.replace('read-view', 'task-list');
       cy.visit(taskList);
       cy.location().should(loc => {
         expect(loc.pathname).to.match(
-          /\/models\/.{36}\/read-only\/model-basics/
+          /\/models\/.{36}\/read-view\/model-basics/
         );
       });
     });

--- a/cypress/e2e/notification.spec.js
+++ b/cypress/e2e/notification.spec.js
@@ -99,7 +99,7 @@ describe('Notification Center', () => {
     cy.contains('h3', 'Empty Plan').siblings('a').click();
 
     cy.location().should(loc => {
-      expect(loc.pathname).to.match(/models\/.{36}\/read-only\/model-basics/);
+      expect(loc.pathname).to.match(/models\/.{36}\/read-view\/model-basics/);
     });
   });
 

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -109,8 +109,26 @@ const AppRoutes = () => {
       {/* Model Routes */}
       <SecureRoute path="/models" exact component={ModelPlan} />
 
+      <Redirect
+        exact
+        from="/models/:modelID/read-only"
+        to="/models/:modelID/read-view"
+      />
+
+      <Redirect
+        exact
+        from="/models/:modelID/read-view"
+        to="/models/:modelID/read-view/model-basics"
+      />
+
+      <Redirect
+        exact
+        from="/models/:modelID/read-only/:subinfo?"
+        to="/models/:modelID/read-view/:subinfo?"
+      />
+
       <SecureRoute
-        path="/models/:modelID/read-only/:subinfo?"
+        path="/models/:modelID/read-view/:subinfo?"
         exact
         component={ReadOnly}
       />

--- a/src/views/App/index.tsx
+++ b/src/views/App/index.tsx
@@ -121,10 +121,18 @@ const AppRoutes = () => {
         to="/models/:modelID/read-view/model-basics"
       />
 
-      <Redirect
-        exact
-        from="/models/:modelID/read-only/:subinfo?"
-        to="/models/:modelID/read-view/:subinfo?"
+      {/* Wrap redirect as child of route to pass on query parameters */}
+      <Route
+        path="/models/:modelID/read-only/:subinfo?"
+        render={match => (
+          <Redirect
+            to={{
+              // /models/:modelID/read-view/:subinfo? syntax does not work with pathname prop, so we replace 'only' with 'view'
+              pathname: match.location.pathname.replace('only', 'view'),
+              search: match.location.search
+            }}
+          />
+        )}
       />
 
       <SecureRoute

--- a/src/views/ModelPlan/ReadOnly/index.tsx
+++ b/src/views/ModelPlan/ReadOnly/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RootStateOrAny, useSelector } from 'react-redux';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { Grid, GridContainer, Icon, SummaryBox } from '@trussworks/react-uswds';
 import classnames from 'classnames';
 import {
@@ -223,11 +223,6 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
 
   const isViewingFilteredGroup = filteredView !== null;
 
-  const history = useHistory();
-
-  // If no subinfo param exists, default to first subpage key
-  const defaultSection: typeof listOfSubpageKey[number] = listOfSubpageKey[0];
-
   // Used to check if user is assessment for rendering subnav to task list
   const { groups } = useSelector((state: RootStateOrAny) => state.auth);
 
@@ -302,10 +297,6 @@ const ReadOnly = ({ isHelpArticle }: { isHelpArticle?: boolean }) => {
 
   if ((!loading && error) || (!loading && !data?.modelPlan)) {
     return <NotFound />;
-  }
-
-  if (!subinfo && !isViewingFilteredGroup) {
-    history.replace(`${location.pathname}/${defaultSection}`);
   }
 
   if (!isSubpage(subinfo, flags, isHelpArticle) && !isViewingFilteredGroup) {


### PR DESCRIPTION
# EASI-4416, EASI-4445
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

- Added redirect for all `read-only` routes to `read-view`
- Added redirect instead of string parse to default to `model-basics`

<!-- Put a description here! -->

## How to test this change

Verify all attempts to access `read-only` redirect to `read-view`
Verify read view always defaults to `model-basics` if no subroute present
  - Include a slash, don't include a trailing slash, both should work
Verify links from emails work

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
