### PR TITLE
[Easi 4420]/audit meta data translation

### DIFF
--- a/pkg/graph/schema/types/translated_audit.graphql
+++ b/pkg/graph/schema/types/translated_audit.graphql
@@ -106,6 +106,9 @@ type TranslatedAuditMetaDocumentSolutionLink {
     Document URL will only be visible if the user is a collaborator, or has assessment permission
     """
     documentURL: String
+    """
+    Document Visibility is the translated value of the restricted bool for a document
+    """
     documentVisibility: String
     documentRestricted: Boolean
 

--- a/pkg/graph/schema/types/translated_audit.graphql
+++ b/pkg/graph/schema/types/translated_audit.graphql
@@ -52,6 +52,9 @@ type TranslatedAuditMetaOperationalSolution {
     numberOfSubtasks: Int!
     needName: String!
     needIsOther: Boolean!
+    """
+    SolutionStatus is the translated value for the type of solution
+    """
     solutionStatus: String!
     solutionMustStart: Time
     solutionMustFinish: Time
@@ -93,6 +96,9 @@ type TranslatedAuditMetaDocumentSolutionLink {
     Document Name will be present if the document is still present and not deleted
     """
     documentName: String
+    """
+    Document type is the translated value of the document type enum
+    """
     documentType: String
     documentOtherType: String
     documentNote: String

--- a/pkg/models/translated_audit_meta_operational_solution.go
+++ b/pkg/models/translated_audit_meta_operational_solution.go
@@ -22,7 +22,7 @@ type TranslatedAuditMetaOperationalSolution struct {
 }
 
 // NewTranslatedAuditMetaOperationalSolution creates a New TranslatedAuditMetaOperationalSolution
-func NewTranslatedAuditMetaOperationalSolution(tableName string, version int, solutionName string, solutionOtherHeader *string, solIsOther bool, numSubtasks int, needName string, needIsOther bool, solStatus OpSolutionStatus,
+func NewTranslatedAuditMetaOperationalSolution(tableName string, version int, solutionName string, solutionOtherHeader *string, solIsOther bool, numSubtasks int, needName string, needIsOther bool, solStatusTranslated string,
 	solMustStart *time.Time,
 	solMustFinish *time.Time,
 ) TranslatedAuditMetaOperationalSolution {
@@ -35,7 +35,7 @@ func NewTranslatedAuditMetaOperationalSolution(tableName string, version int, so
 		NumberOfSubtasks:              numSubtasks,
 		NeedName:                      needName,
 		NeedIsOther:                   needIsOther,
-		SolutionStatus:                string(solStatus),
+		SolutionStatus:                solStatusTranslated,
 		SolutionMustStart:             solMustStart,
 		SolutionMustFinish:            solMustFinish,
 	}

--- a/pkg/translatedaudit/translated_audit.go
+++ b/pkg/translatedaudit/translated_audit.go
@@ -292,7 +292,6 @@ func translateValue(value interface{}, options map[string]interface{}) interface
 	if value == nil {
 		return nil
 	}
-	// Changes: (Translations) Check if value is nil, don't need to translate that.
 	// Changes: (Translations) work on bool representation, they should come through here as a string, but show up as t, f. We will want to set they values
 	// strSlice, isSlice := value.([]string)
 	str, isString := value.(string)
@@ -311,6 +310,7 @@ func translateValue(value interface{}, options map[string]interface{}) interface
 		return translateValueSingle(str, options)
 	}
 	// Changes: (Translations)  Should we handle the case where we can't translate it more?
+	// Should we also try to use fmt to make the value a string, for example an enum is not able to be translated this way, as it isn't castable to string.
 	return value
 
 }

--- a/pkg/translatedaudit/translated_audit_meta_data.go
+++ b/pkg/translatedaudit/translated_audit_meta_data.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/cmsgov/mint-app/mappings"
 	"github.com/cmsgov/mint-app/pkg/appcontext"
 	"github.com/cmsgov/mint-app/pkg/models"
 	"github.com/cmsgov/mint-app/pkg/storage"
@@ -72,25 +71,8 @@ func OperationalSolutionMetaDataGet(ctx context.Context, store *storage.Store, o
 		return nil, nil, fmt.Errorf("unable to get operational need for operational solution audit metadata. err %w", err)
 	}
 
-	//Changes: (Translations) abstract this logic in a helper function?
-	translatedStatus := fmt.Sprint(opSolutionWithSubtasks.Status)
-	// Translate the status if possible. If there are any errors, continue without translating.
-	translation, err := mappings.OperationalSolutionTranslation()
 	const statusKey = "status"
-	if err == nil {
-		translationMap, err := translation.ToMap()
-		if err == nil {
-
-			translationInterface, hasTranslation := translationMap[statusKey]
-			if hasTranslation {
-				options, hasOptions := translationInterface.GetOptions()
-				if hasOptions {
-					translation := translateValueSingle(translatedStatus, options)
-					translatedStatus = fmt.Sprint(translation)
-				}
-			}
-		}
-	}
+	translatedStatus := getTranslationMapAndTranslateSingleValue("operational_solution", statusKey, fmt.Sprint(opSolutionWithSubtasks.Status))
 
 	metaNeed := models.NewTranslatedAuditMetaOperationalSolution(
 		"operational_solution",

--- a/pkg/translatedaudit/translated_audit_meta_data.go
+++ b/pkg/translatedaudit/translated_audit_meta_data.go
@@ -222,8 +222,15 @@ func DocumentSolutionLinkMetaDataGet(ctx context.Context, store *storage.Store, 
 		documentUUID,
 	)
 	if document != nil {
-		// Changes: (Meta) all these document fields will also need to be translated
-		meta.SetOptionalDocumentFields(document.FileName, string(document.DocumentType), document.OtherTypeDescription, document.OptionalNotes, document.URL, fmt.Sprint(document.Restricted), document.Restricted)
+
+		// Changes: (Meta) This could be a little more efficient, because this gets the translation each call
+		const restrictedKey = "restricted"
+		translatedDocRestricted := getTranslationMapAndTranslateSingleValue("plan_document", restrictedKey, fmt.Sprint(document.Restricted))
+
+		const typeKey = "document_type"
+		translatedDocType := getTranslationMapAndTranslateSingleValue("plan_document", typeKey, fmt.Sprint(document.DocumentType))
+
+		meta.SetOptionalDocumentFields(document.FileName, translatedDocType, document.OtherTypeDescription, document.OptionalNotes, document.URL, translatedDocRestricted, document.Restricted)
 	}
 
 	//Changes: (Meta) We need to get other document information, and it needs to be translated.

--- a/pkg/translatedaudit/translated_audit_meta_data.go
+++ b/pkg/translatedaudit/translated_audit_meta_data.go
@@ -365,9 +365,11 @@ func PlanDocumentMetaDataGet(ctx context.Context, store *storage.Store, document
 
 		}
 	} else {
-		if operation == models.DBOpDelete || operation == models.DBOpTruncate {
-			return nil, nil, fmt.Errorf("the %s field, wasn't present on the audit change, and the data is deleted, and not queryable", fileNameField)
-		}
+
+		// If the data isn't present, don't error, just have document name be nil
+		// if operation == models.DBOpDelete || operation == models.DBOpTruncate {
+		// 	return nil, nil, fmt.Errorf("the %s field, wasn't present on the audit change, and the data is deleted, and not queryable", fileNameField)
+		// }
 		logger := appcontext.ZLogger(ctx)
 		document, docErr := storage.PlanDocumentGetByIDNoS3Check(store, logger, documentID)
 		if docErr != nil {
@@ -378,10 +380,10 @@ func PlanDocumentMetaDataGet(ctx context.Context, store *storage.Store, document
 			}
 		}
 
-		if document == nil {
-			return nil, nil, fmt.Errorf("document is not present in the database, but expected for this meta data")
+		if document != nil {
+			fileName = document.FileName
+			// return nil, nil, fmt.Errorf("document is not present in the database, but expected for this meta data")
 		}
-		fileName = document.FileName
 
 	}
 

--- a/pkg/translatedaudit/translated_audit_meta_data.go
+++ b/pkg/translatedaudit/translated_audit_meta_data.go
@@ -190,11 +190,11 @@ func DocumentSolutionLinkMetaDataGet(ctx context.Context, store *storage.Store, 
 	}
 
 	// get the document
-	document, err := storage.PlanDocumentGetByIDNoS3Check(store, logger, documentUUID)
-	if err != nil {
+	document, docErr := storage.PlanDocumentGetByIDNoS3Check(store, logger, documentUUID)
+	if docErr != nil {
 		//EXPECT THERE TO BE NULL results, don't treat this as an error
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil, fmt.Errorf("there was an issue getting the plan document for the . err %w", err)
+		if !errors.Is(docErr, sql.ErrNoRows) {
+			return nil, nil, fmt.Errorf("there was an issue getting the plan document for the . err %w", docErr)
 		}
 	}
 
@@ -317,10 +317,10 @@ func PlanCollaboratorMetaDataGet(ctx context.Context, store *storage.Store, prim
 			return nil, nil, fmt.Errorf("the %s field, wasn't present on the audit change, and the data is deleted, and not queryable", userIDField)
 		}
 
-		collab, err := store.PlanCollaboratorGetByID(primaryKey)
-		if err != nil {
-			if !errors.Is(err, sql.ErrNoRows) {
-				return nil, nil, err
+		collab, collabErr := store.PlanCollaboratorGetByID(primaryKey)
+		if collabErr != nil {
+			if !errors.Is(collabErr, sql.ErrNoRows) {
+				return nil, nil, collabErr
 			}
 		}
 		if collab != nil {
@@ -369,11 +369,12 @@ func PlanDocumentMetaDataGet(ctx context.Context, store *storage.Store, document
 			return nil, nil, fmt.Errorf("the %s field, wasn't present on the audit change, and the data is deleted, and not queryable", fileNameField)
 		}
 		logger := appcontext.ZLogger(ctx)
-		document, err := storage.PlanDocumentGetByIDNoS3Check(store, logger, documentID)
-		if err != nil {
-			if err.Error() != "sql: no rows in result set" { //EXPECT THERE TO BE NULL results, don't treat this as an error
+		document, docErr := storage.PlanDocumentGetByIDNoS3Check(store, logger, documentID)
+		if docErr != nil {
+			if !errors.Is(docErr, sql.ErrNoRows) {
+				//EXPECT THERE TO BE NULL results, don't treat this as an error
 
-				return nil, nil, fmt.Errorf("there was an issue getting the plan document for the . err %w", err)
+				return nil, nil, fmt.Errorf("there was an issue getting the plan document for the . err %w", docErr)
 			}
 		}
 

--- a/pkg/translatedaudit/translated_audit_meta_data_test.go
+++ b/pkg/translatedaudit/translated_audit_meta_data_test.go
@@ -656,12 +656,14 @@ func (suite *TAuditSuite) TestPlanDocumentMetaDataGet() {
 		}
 	})
 
-	suite.Run("Document meta data fails when field isn't present in change set for DELETE", func() {
+	suite.Run("Document meta data doesn't fail when field isn't present in change set for DELETE, fetch filename from db", func() {
 		docMeta, metaDataType, err := PlanDocumentMetaDataGet(suite.testConfigs.Context, suite.testConfigs.Store, document.ID, tableName, emptyChanges, models.DBOpDelete)
-		suite.Error(err)
-		suite.Nil(metaDataType)
+		suite.NoError(err)
+		suite.NotNil(metaDataType)
 
-		suite.Nil(docMeta)
+		if suite.NotNil(docMeta) {
+			suite.EqualValues(docNameDB, *docMeta.RelationContent)
+		}
 	})
 	suite.Run("Document meta data fails when field isn't present on the correct / NEW / OLD value", func() {
 		collabMeta, metaDataType, err := PlanDocumentMetaDataGet(suite.testConfigs.Context, suite.testConfigs.Store, document.ID, tableName, oldChanges, models.DBOpInsert)
@@ -669,6 +671,19 @@ func (suite *TAuditSuite) TestPlanDocumentMetaDataGet() {
 		suite.Nil(metaDataType)
 
 		suite.Nil(collabMeta)
+	})
+
+	suite.Run("Document meta data doesn't fail when field isn't present in change set for DELETE, but filename is nil", func() {
+		// Delete the document and run tests on empty state
+		suite.deleteDocument(document.ID)
+
+		docMeta, metaDataType, err := PlanDocumentMetaDataGet(suite.testConfigs.Context, suite.testConfigs.Store, document.ID, tableName, emptyChanges, models.DBOpDelete)
+		suite.NoError(err)
+		suite.NotNil(metaDataType)
+
+		if suite.NotNil(docMeta) {
+			suite.Nil(docMeta.RelationContent)
+		}
 	})
 
 }

--- a/pkg/translatedaudit/translated_audit_meta_data_test.go
+++ b/pkg/translatedaudit/translated_audit_meta_data_test.go
@@ -1,7 +1,6 @@
 package translatedaudit
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/cmsgov/mint-app/pkg/models"
@@ -61,6 +60,8 @@ func (suite *TAuditSuite) TestOperationalSolutionMetaDataGet() {
 	mustFinish := time.Now().UTC().Round(time.Microsecond)
 	mustStart := mustFinish.Add(-24 * time.Hour)
 	solStatus := models.OpSAtRisk
+	// just provide the translated value here instead of trying to translate it for this test
+	solStatusTranslated := "At risk"
 	solOtherHeader := models.StringPointer("hooray! It's the other header!")
 	sol := suite.createOperationalSolution(need.ID, solName, func(os *models.OperationalSolution) {
 		os.MustStartDts = &mustStart
@@ -93,7 +94,7 @@ func (suite *TAuditSuite) TestOperationalSolutionMetaDataGet() {
 	if suite.NotNil(metaData.SolutionMustStart) {
 		suite.EqualValues(mustStart, metaData.SolutionMustStart.UTC())
 	}
-	suite.EqualValues(solStatus, metaData.SolutionStatus)
+	suite.EqualValues(solStatusTranslated, metaData.SolutionStatus)
 	suite.EqualValues(solIsOther, metaData.SolutionIsOther)
 	suite.EqualValues(solOtherHeader, metaData.SolutionOtherHeader)
 
@@ -211,6 +212,9 @@ func (suite *TAuditSuite) TestDocumentSolutionLinkMetaDataGet() {
 	docName := "hooray! a document"
 
 	document := suite.createPlanDocument(plan.ID, docName)
+	// for simplicity, just write the translation here instead of trying to translate it
+	visibilityTranslated := "All"
+	documentTypeTranslated := "Other"
 
 	link := suite.createDocumentSolutionLink(document.ID, sol.ID)
 
@@ -255,10 +259,10 @@ func (suite *TAuditSuite) TestDocumentSolutionLinkMetaDataGet() {
 		suite.EqualValues(document.FileName, *metaData.DocumentName)
 	}
 	if suite.NotNil(metaData.DocumentType) {
-		suite.EqualValues(document.DocumentType, *metaData.DocumentType)
+		suite.EqualValues(documentTypeTranslated, *metaData.DocumentType)
 	}
 	if suite.NotNil(metaData.DocumentVisibility) {
-		suite.EqualValues(fmt.Sprint(document.Restricted), *metaData.DocumentVisibility)
+		suite.EqualValues(visibilityTranslated, *metaData.DocumentVisibility)
 	}
 
 	tableName := "document_solution_link"

--- a/pkg/translatedaudit/translated_audit_meta_data_test.go
+++ b/pkg/translatedaudit/translated_audit_meta_data_test.go
@@ -642,26 +642,26 @@ func (suite *TAuditSuite) TestPlanDocumentMetaDataGet() {
 		}
 	})
 	suite.Run("Document meta data gets data from db if not in change set", func() {
-		collabMeta, metaDataType, err := PlanDocumentMetaDataGet(suite.testConfigs.Context, suite.testConfigs.Store, document.ID, tableName, emptyChanges, models.DBOpInsert)
+		docMeta, metaDataType, err := PlanDocumentMetaDataGet(suite.testConfigs.Context, suite.testConfigs.Store, document.ID, tableName, emptyChanges, models.DBOpInsert)
 		suite.NoError(err)
 		if suite.NotNil(metaDataType) {
 			suite.EqualValues(models.TAMetaGeneric, *metaDataType)
 		}
 
-		if suite.NotNil(collabMeta) {
-			suite.EqualValues("fileName", collabMeta.Relation)
-			if suite.NotNil(collabMeta.RelationContent) {
-				suite.EqualValues(docNameDB, *collabMeta.RelationContent)
+		if suite.NotNil(docMeta) {
+			suite.EqualValues("fileName", docMeta.Relation)
+			if suite.NotNil(docMeta.RelationContent) {
+				suite.EqualValues(docNameDB, *docMeta.RelationContent)
 			}
 		}
 	})
 
 	suite.Run("Document meta data fails when field isn't present in change set for DELETE", func() {
-		collabMeta, metaDataType, err := PlanDocumentMetaDataGet(suite.testConfigs.Context, suite.testConfigs.Store, document.ID, tableName, emptyChanges, models.DBOpDelete)
+		docMeta, metaDataType, err := PlanDocumentMetaDataGet(suite.testConfigs.Context, suite.testConfigs.Store, document.ID, tableName, emptyChanges, models.DBOpDelete)
 		suite.Error(err)
 		suite.Nil(metaDataType)
 
-		suite.Nil(collabMeta)
+		suite.Nil(docMeta)
 	})
 	suite.Run("Document meta data fails when field isn't present on the correct / NEW / OLD value", func() {
 		collabMeta, metaDataType, err := PlanDocumentMetaDataGet(suite.testConfigs.Context, suite.testConfigs.Store, document.ID, tableName, oldChanges, models.DBOpInsert)

--- a/pkg/translatedaudit/translated_audit_utils.go
+++ b/pkg/translatedaudit/translated_audit_utils.go
@@ -1,6 +1,11 @@
 package translatedaudit
 
-import "github.com/cmsgov/mint-app/pkg/models"
+import (
+	"fmt"
+
+	"github.com/cmsgov/mint-app/mappings"
+	"github.com/cmsgov/mint-app/pkg/models"
+)
 
 // GetDatabaseOperation casts the string representation of a database action to the appropriate enum
 // the boolean return value will be true for a successful matching, and false if unmatched
@@ -17,5 +22,31 @@ func GetDatabaseOperation(action string) (models.DatabaseOperation, bool) {
 		return models.DBOpTruncate, true
 	}
 	return models.DatabaseOperation(""), false
+
+}
+
+// getTranslationMapAndTranslateSingleValue is a utility function to translate a single field value to a translated value, assuming that the key for the translation, and the function to get the function is passed
+// it should be used in places where you need to get a single outlier translation (such as meta data) instead of normal operations where you can batch some of these data calls.
+func getTranslationMapAndTranslateSingleValue(tableName string, translationKey string, rawValue string) string {
+
+	translation, err := mappings.GetTranslation(tableName)
+	if err == nil {
+		translationMap, err := translation.ToMap()
+		if err == nil {
+
+			translationInterface, hasTranslation := translationMap[translationKey]
+			// translate if a translation is available
+			if hasTranslation {
+				options, hasOptions := translationInterface.GetOptions()
+				// if the translation has options, use the options to translate the value
+				if hasOptions {
+					translation := translateValueSingle(rawValue, options)
+					return fmt.Sprint(translation)
+				}
+			}
+		}
+	}
+	// if this could not be translated return the raw initial value instead
+	return rawValue
 
 }

--- a/src/gql/gen/graphql.ts
+++ b/src/gql/gen/graphql.ts
@@ -3544,6 +3544,7 @@ export type TranslatedAuditMetaDocumentSolutionLink = {
   documentType?: Maybe<Scalars['String']['output']>;
   /** Document URL will only be visible if the user is a collaborator, or has assessment permission */
   documentURL?: Maybe<Scalars['String']['output']>;
+  /** Document Visibility is the translated value of the restricted bool for a document */
   documentVisibility?: Maybe<Scalars['String']['output']>;
   needIsOther: Scalars['Boolean']['output'];
   needName: Scalars['String']['output'];

--- a/src/gql/gen/graphql.ts
+++ b/src/gql/gen/graphql.ts
@@ -3540,6 +3540,7 @@ export type TranslatedAuditMetaDocumentSolutionLink = {
   documentNote?: Maybe<Scalars['String']['output']>;
   documentOtherType?: Maybe<Scalars['String']['output']>;
   documentRestricted?: Maybe<Scalars['Boolean']['output']>;
+  /** Document type is the translated value of the document type enum */
   documentType?: Maybe<Scalars['String']['output']>;
   /** Document URL will only be visible if the user is a collaborator, or has assessment permission */
   documentURL?: Maybe<Scalars['String']['output']>;
@@ -3582,6 +3583,7 @@ export type TranslatedAuditMetaOperationalSolution = {
   solutionMustStart?: Maybe<Scalars['Time']['output']>;
   solutionName: Scalars['String']['output'];
   solutionOtherHeader?: Maybe<Scalars['String']['output']>;
+  /** SolutionStatus is the translated value for the type of solution */
   solutionStatus: Scalars['String']['output'];
   tableName: Scalars['String']['output'];
   version: Scalars['Int']['output'];


### PR DESCRIPTION
# EASI-4420
<!-- Follow the pattern of Parent issue, Child issue, if appropriate -->

## Changes and Description

- Translate Audit Meta Data
    - Operational Solution Status
    - Document Type
    - Document Visibility
 - Utility function to translate a single field by providing.

- Updates to Plan Document meta Data paradigm
   - don't fail if can't fetch the name even for delete or truncate  
<!-- Put a description here! -->

## How to test this change
1. Seed the data
2. Verify the translated data meta data is now translated.

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

## PR Author Review Checklist

- [ ] Met the ticket's acceptance criteria, or will meet them in a subsequent PR.
- [ ] Added or updated tests for backend resolvers or other functions as needed.
- [ ] Added or updated client tests for new components, parent components, functions, or e2e tests as necessary.
- [ ] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
- Always make comments, even if it's minor, or if you don't understand why something was done.
