### PR TITLE
[EASi-4511] Convert empty strings to nil for translations

### DIFF
--- a/.github/workflows/change_history_dev_deploy.yml
+++ b/.github/workflows/change_history_dev_deploy.yml
@@ -12,9 +12,7 @@ jobs:
   run_tests:
     uses: ./.github/workflows/run_tests.yml
     secrets: inherit
-    with:
-      continue_on_error: true
-      
+
   build_frontend_assets:
     strategy:
       matrix:

--- a/pkg/translatedaudit/translated_audit.go
+++ b/pkg/translatedaudit/translated_audit.go
@@ -117,6 +117,14 @@ func genericAuditTranslation(ctx context.Context, store *storage.Store, audit *m
 	return &translatedAudit, nil
 }
 
+// setEmptyStringsToNil checks if a value is an empty string, and if so, t
+func setEmptyStringsToNil(value interface{}) interface{} {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
 // translateField translates a given audit field. It returns the translated audit field, as well as a bool to signify if it was translated or not
 func translateField(
 	ctx context.Context,
@@ -127,14 +135,15 @@ func translateField(
 	operation models.DatabaseOperation,
 	translationMap map[string]models.ITranslationField) (*models.TranslatedAuditField, bool, error) {
 
-	old := field.Old
-	new := field.New
+	//Check if any value is "", if so, update to nil instead.
+	old := setEmptyStringsToNil(field.Old)
+	new := setEmptyStringsToNil(field.New)
 	translatedOld := old
 	translatedNew := new
 	changeType := getChangeType(old, new)
 	if changeType == models.AFCUnchanged {
 		// If a field is actually unchanged (null to empty array or v versa), don't write an entry.
-		// This should not happen, except in rare cases when an empty array is passed to update from a null value.
+		// This should not happen, except in rare cases when an empty array is passed to update from a null value. Or a value was changed from null to empty string or vice versa
 		return nil, false, nil
 	}
 

--- a/pkg/translatedaudit/translated_audit_test.go
+++ b/pkg/translatedaudit/translated_audit_test.go
@@ -117,6 +117,18 @@ func TestTranslateField(t *testing.T) {
 		assert.NoError(t, err)
 
 	})
+	t.Run("When a field is changed to empty string, there is no translation field ", func(t *testing.T) {
+		unchangedAuditField := models.AuditField{
+			Old: nil,
+			New: "",
+		}
+		var store *storage.Store //nil store
+		translatedField, wasTranslated, err := translateField(ctx, store, "there is no translation for this", unchangedAuditField, &testAuditChange, models.DBOpUpdate, testTranslationMap)
+		assert.False(t, wasTranslated)
+		assert.Nil(t, (translatedField))
+		assert.NoError(t, err)
+
+	})
 
 }
 

--- a/pkg/translatedaudit/translated_audit_test.go
+++ b/pkg/translatedaudit/translated_audit_test.go
@@ -129,6 +129,18 @@ func TestTranslateField(t *testing.T) {
 		assert.NoError(t, err)
 
 	})
+	t.Run("When a field is changed from empty string to nil, there is no translation field ", func(t *testing.T) {
+		unchangedAuditField := models.AuditField{
+			Old: "",
+			New: nil,
+		}
+		var store *storage.Store //nil store
+		translatedField, wasTranslated, err := translateField(ctx, store, "there is no translation for this", unchangedAuditField, &testAuditChange, models.DBOpUpdate, testTranslationMap)
+		assert.False(t, wasTranslated)
+		assert.Nil(t, (translatedField))
+		assert.NoError(t, err)
+
+	})
 
 }
 

--- a/src/views/HomeNew/__snapshots__/index.test.tsx.snap
+++ b/src/views/HomeNew/__snapshots__/index.test.tsx.snap
@@ -63,12 +63,12 @@ exports[`The home page > matches setting snapshot 1`] = `
                         aria-controls="pre-decisional-collapse"
                         aria-expanded="false"
                         class="usa-button usa-button--unstyled mint-no-print"
-                        data-testid="collapsable-link"
+                        data-testid="pre-decisional-collapse"
                         type="button"
                       >
                         Read more
                         <svg
-                          class="usa-icon top-05"
+                          class="usa-icon top-05 margin-right-05"
                           focusable="false"
                           height="1em"
                           role="img"


### PR DESCRIPTION
<!--
REQUIRED
    Ensure that your PR title has the relevant Jira ticket number(s) in the title.
    Follow this pattern: [EASI-1234] [EASI-4567] Title of the PR.
    Use [NOREF] in place of a ticket number when there's no associated Jira ticket.
    The heading below should just have the ticket numbers (for easy linking in Jira)
-->
# EASI-4511

## Description

It was noted that certain conditions can create a translation error when a field tries to write an empty string to the old, new or translated fields. This is not allowed as the fields are `ZERO_STRINGS` (requiring non empty strings or nil).

To address situations where an answer changes from nil to "", we now convert "" to nil. If the answer is effectively unchanged, the field is not saved as a translated field.

This happened effectively when a new CR was made with an empty note field.
<!--
REQUIRED
    Provide details as to what the PR aims to accomplish
    Be as descriptive as you can, and include any relevant information that will help the reviewer understand the scope of the changes
    Include screenshots or screen recordings to assist in reviewing if possible.
-->


## How to test this change
<!--
REQUIRED
    Add instructions on how to test the changes in this PR
    This can be a list of steps to reproduce a bug, or a list of steps to verify a feature in the application
    Include any example shell commands, SQL queries/commands, or Postman requests that reviewers can run to test the changes
-->
- Create a model plan
- Create a plan CR, enter text in the note field, but then delete all the text
- translate the audit changes.
- verify that there is an entry for the new CR, and also verify that the note field does not render on the front end.

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.
- [x] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
