### PR TITLE
[EASi-4520]/Change history job logging

### DIFF
--- a/pkg/sqlqueries/SQL/translated_audit_queue/update.sql
+++ b/pkg/sqlqueries/SQL/translated_audit_queue/update.sql
@@ -8,7 +8,7 @@ SET
     created_by= :created_by,
     created_dts= :created_dts,
     modified_by= :modified_by,
-    modified_dts= :modified_dts
+    modified_dts= CURRENT_TIMESTAMP
 WHERE id =  :id
 RETURNING
 id,

--- a/pkg/sqlutils/errors.go
+++ b/pkg/sqlutils/errors.go
@@ -1,0 +1,75 @@
+package sqlutils
+
+import (
+	"fmt"
+
+	"github.com/lib/pq"
+)
+
+/********************
+* //Future Enhancement:
+* Add more errors here when needed to handle specific errors later in the app code.
+********************/
+
+// ErrDuplicateConstraint is a pointer to the errDupConstraint error, which can be used to verify if an error is of this specific type.
+var ErrDuplicateConstraint *errDupConstraint
+
+// errDupConstraint is a custom error type for unique constraint violations that wraps the original pq error.
+type errDupConstraint struct {
+	baseDBError
+}
+
+// newErrDupConstraintErr is a constructor to be used when a pq error occurs because of a duplicate value error.
+func newErrDupConstraintErr(message string, pqErr *pq.Error) *errDupConstraint {
+	return &errDupConstraint{
+		baseDBError: newBaseDBError(message, pqErr),
+	}
+
+}
+
+// newBaseDBError is a constructor for the base db error.
+func newBaseDBError(message string, pqErr *pq.Error) baseDBError {
+	return baseDBError{
+		Message:       message,
+		OriginalError: pqErr,
+	}
+
+}
+
+// baseDBError is the base type shared by all errors in the sqlutils package.
+type baseDBError struct {
+	Message       string
+	OriginalError *pq.Error
+}
+
+// Error implements the error interface for ErrDuplicateConstraint.
+func (e errDupConstraint) Error() string {
+	return fmt.Sprintf("dbErr: duplicate key value violates unique constraint: %s, table: %s, detail: %s",
+		e.OriginalError.Constraint, e.OriginalError.Table, e.OriginalError.Detail)
+}
+
+// Error implements the error interface for baseDBError. In most cases, this should be handled for each specific type that embeds it
+func (e baseDBError) Error() string {
+	return fmt.Sprintf("dbErr: message: %s, error %v", e.Message, e.OriginalError)
+}
+
+// Unwrap returns the original pq error.
+func (e *baseDBError) Unwrap() error {
+	return e.OriginalError
+}
+
+func ProcessDataBaseErrors(message string, err error) error {
+	if pqErr, ok := err.(*pq.Error); ok {
+
+		switch pqErr.Code.Name() {
+		case "unique_violation":
+			return newErrDupConstraintErr(message, pqErr)
+
+		default:
+			return newBaseDBError(message, pqErr)
+		}
+
+	}
+	return fmt.Errorf(message+" err: %w", err)
+
+}

--- a/pkg/sqlutils/exec_procedure.go
+++ b/pkg/sqlutils/exec_procedure.go
@@ -1,20 +1,18 @@
 package sqlutils
 
-import "fmt"
-
 // GetProcedure is a wrapper function that handles the boiler plate of creating and executing a returned object from the database
 // Under the hood, it calls stmt.Get to return an object from the database
 func GetProcedure[T any](np NamedPreparer, sqlQuery string, arg interface{}) (*T, error) {
 	stmt, err := np.PrepareNamed(sqlQuery)
 	if err != nil {
-		return nil, fmt.Errorf(" issue preparing named statement: %w", err)
+		return nil, ProcessDataBaseErrors("issue preparing named statement", err)
 	}
 	defer stmt.Close()
 	var dest T
 
 	err = stmt.Get(&dest, arg)
 	if err != nil {
-		return nil, fmt.Errorf(" issue executing named statement: %w", err)
+		return nil, ProcessDataBaseErrors("issue executing named statement", err)
 	}
 	return &dest, nil
 }
@@ -24,14 +22,14 @@ func GetProcedure[T any](np NamedPreparer, sqlQuery string, arg interface{}) (*T
 func SelectProcedure[T any](np NamedPreparer, sqlQuery string, arg interface{}) ([]*T, error) {
 	stmt, err := np.PrepareNamed(sqlQuery)
 	if err != nil {
-		return nil, fmt.Errorf(" issue preparing named statement: %w", err)
+		return nil, ProcessDataBaseErrors("issue preparing named statement", err)
 	}
 	defer stmt.Close()
 	var dest []*T
 
 	err = stmt.Select(&dest, arg)
 	if err != nil {
-		return nil, fmt.Errorf(" issue executing named statement: %w", err)
+		return nil, ProcessDataBaseErrors("issue executing named statement", err)
 	}
 	return dest, nil
 }

--- a/pkg/storage/translated_audit_queueStore.go
+++ b/pkg/storage/translated_audit_queueStore.go
@@ -49,7 +49,6 @@ func TranslatedAuditQueueUpdate(
 	np sqlutils.NamedPreparer,
 	logger *zap.Logger,
 	translatedAuditQueue *models.TranslatedAuditQueue) (*models.TranslatedAuditQueue, error) {
-
 	retTranslatedAuditQueue, procErr := sqlutils.GetProcedure[models.TranslatedAuditQueue](np, sqlqueries.TranslatedAuditQueue.Update, translatedAuditQueue)
 
 	if procErr != nil {

--- a/pkg/translatedaudit/translated_audit_job_utitilities.go
+++ b/pkg/translatedaudit/translated_audit_job_utitilities.go
@@ -2,12 +2,14 @@ package translatedaudit
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
 	"github.com/cmsgov/mint-app/pkg/models"
+	"github.com/cmsgov/mint-app/pkg/sqlutils"
 	"github.com/cmsgov/mint-app/pkg/storage"
 )
 
@@ -15,8 +17,9 @@ func TranslateAuditJobByID(ctx context.Context, store *storage.Store, logger *za
 
 	queueEntry, err := storage.TranslatedAuditQueueGetByID(store, queueID)
 	if err != nil {
-		return nil, fmt.Errorf("unable to return translatedAuditQueue entry  for translated_audit_queue_id (%s) for the translate audit job. Err %w", queueID, err)
-
+		decErr := fmt.Errorf("unable to return translatedAuditQueue entry  for translated_audit_queue_id (%s) for the translate audit job. Err %w", queueID, err)
+		logger.Warn(decErr.Error())
+		return nil, decErr
 	}
 	queueEntry.Attempts++
 	queueEntry.Status = models.TPSProcessing
@@ -28,14 +31,20 @@ func TranslateAuditJobByID(ctx context.Context, store *storage.Store, logger *za
 
 	translatedAuditAndFields, translateErr := TranslateAudit(ctx, store, logger, auditID)
 	if translateErr != nil {
-		// fail the translation
-		queueEntry.Status = models.TPSFailed
-		_, err = storage.TranslatedAuditQueueUpdate(store, logger, queueEntry)
-		if err != nil {
-			return nil, fmt.Errorf("unable to return translatedAuditQueue entry, err: %w", err)
-		}
+		// Errors as checks the type of the error. In this case, we check if it is a duplicate constraint error from pq. If so, we don't fail the job.
+		duplicateTranslatedAuditExist := errors.As(translateErr, &sqlutils.ErrDuplicateConstraint)
 
-		return nil, fmt.Errorf("error translating audit for audit id %v. Err %w", auditID, translateErr)
+		if !duplicateTranslatedAuditExist {
+			// fail the translation
+			queueEntry.Status = models.TPSFailed
+			_, err = storage.TranslatedAuditQueueUpdate(store, logger, queueEntry)
+			if err != nil {
+				return nil, fmt.Errorf("unable to return translatedAuditQueue entry, err: %w", err)
+			}
+
+			return nil, fmt.Errorf("error translating audit for audit id %v. Err %w", auditID, translateErr)
+		}
+		queueEntry.Note = models.StringPointer("A translation already exists for this change.")
 	}
 	queueEntry.Status = models.TPSProcessed
 	_, err = storage.TranslatedAuditQueueUpdate(store, logger, queueEntry)

--- a/pkg/translatedaudit/translated_audit_job_utitilities.go
+++ b/pkg/translatedaudit/translated_audit_job_utitilities.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/cmsgov/mint-app/pkg/constants"
 	"github.com/cmsgov/mint-app/pkg/models"
 	"github.com/cmsgov/mint-app/pkg/sqlutils"
 	"github.com/cmsgov/mint-app/pkg/storage"
@@ -23,7 +24,7 @@ func TranslateAuditJobByID(ctx context.Context, store *storage.Store, logger *za
 	queueEntry.Attempts++
 	queueEntry.Status = models.TPSProcessing
 
-	queueEntry, err = storage.TranslatedAuditQueueUpdate(store, logger, queueEntry)
+	queueEntry, err = TranslatedAuditQueueUpdate(store, logger, queueEntry, constants.GetSystemAccountUUID())
 	if err != nil {
 		logger.Warn(err.Error(), zap.Error(err))
 		return nil, err
@@ -37,7 +38,7 @@ func TranslateAuditJobByID(ctx context.Context, store *storage.Store, logger *za
 		if !duplicateTranslatedAuditExist {
 			// fail the translation
 			queueEntry.Status = models.TPSFailed
-			_, err = storage.TranslatedAuditQueueUpdate(store, logger, queueEntry)
+			_, err = TranslatedAuditQueueUpdate(store, logger, queueEntry, constants.GetSystemAccountUUID())
 			if err != nil {
 				logger.Warn(err.Error(), zap.Error(err))
 				return nil, err
@@ -49,12 +50,27 @@ func TranslateAuditJobByID(ctx context.Context, store *storage.Store, logger *za
 		queueEntry.Note = models.StringPointer("A translation already exists for this change.")
 	}
 	queueEntry.Status = models.TPSProcessed
-	_, err = storage.TranslatedAuditQueueUpdate(store, logger, queueEntry)
+	_, err = TranslatedAuditQueueUpdate(store, logger, queueEntry, constants.GetSystemAccountUUID())
 	if err != nil {
 		finalErr := fmt.Errorf("unable to return final translatedAuditQueue entry, err: %w", err)
 		logger.Warn(finalErr.Error(), zap.Error(finalErr))
 		return nil, finalErr
 	}
 	return translatedAuditAndFields, nil
+
+}
+
+// TranslatedAuditQueueUpdate handles the business logic of setting who modified a translated audit queue entry, and calling the appropriate store methods.
+func TranslatedAuditQueueUpdate(
+	np sqlutils.NamedPreparer,
+	logger *zap.Logger,
+	translatedAuditQueue *models.TranslatedAuditQueue,
+	modifiedByAccountID uuid.UUID,
+) (*models.TranslatedAuditQueue, error) {
+
+	// Note, we don't call set modified by here for simplicity.
+	translatedAuditQueue.ModifiedBy = &modifiedByAccountID
+
+	return storage.TranslatedAuditQueueUpdate(np, logger, translatedAuditQueue)
 
 }

--- a/pkg/worker/translate_audit_batch_job.go
+++ b/pkg/worker/translate_audit_batch_job.go
@@ -9,9 +9,11 @@ import (
 	"github.com/jmoiron/sqlx"
 	"go.uber.org/zap"
 
+	"github.com/cmsgov/mint-app/pkg/constants"
 	"github.com/cmsgov/mint-app/pkg/models"
 	"github.com/cmsgov/mint-app/pkg/sqlutils"
 	"github.com/cmsgov/mint-app/pkg/storage"
+	"github.com/cmsgov/mint-app/pkg/translatedaudit"
 )
 
 // TranslateAuditCronJob is the job the cron schedule calls
@@ -40,7 +42,7 @@ func QueueTranslatedAuditJob(w *Worker, batch *faktory.Batch, queueObj *models.T
 		queueObj.Status = models.TPSQueued
 		w.Logger.Debug("queuing job for translated audit.", zap.Any("queue entry", queueObj))
 
-		retQueueEntry, err := storage.TranslatedAuditQueueUpdate(w.Store, w.Logger, queueObj)
+		retQueueEntry, err := translatedaudit.TranslatedAuditQueueUpdate(w.Store, w.Logger, queueObj, constants.GetSystemAccountUUID())
 		if err != nil {
 			return nil, fmt.Errorf("issue saving translatedAuditQueueEntry for audit %v, queueID %s", queueObj.ChangeID, queueObj.ID)
 		}

--- a/pkg/worker/translate_audit_batch_job.go
+++ b/pkg/worker/translate_audit_batch_job.go
@@ -16,6 +16,8 @@ import (
 	"github.com/cmsgov/mint-app/pkg/translatedaudit"
 )
 
+var translatedAuditJobMaxRetry = 2
+
 // TranslateAuditCronJob is the job the cron schedule calls
 // TranslateAuditBatchJob batches all the TranslateAuditJobs. When all are complete it will fire a callback
 // args are not currently being used.
@@ -50,6 +52,8 @@ func QueueTranslatedAuditJob(w *Worker, batch *faktory.Batch, queueObj *models.T
 		// Change ID not strictly needed here, the job can get it from queue id, but this is for convenience.
 		job := faktory.NewJob(translateAuditJobName, retQueueEntry.ChangeID, retQueueEntry.ID)
 		job.Queue = auditTranslateQueue
+
+		job.Retry = &translatedAuditJobMaxRetry
 		err = batch.Push(job)
 		if err != nil {
 			return nil, err

--- a/pkg/worker/translate_audit_job_test.go
+++ b/pkg/worker/translate_audit_job_test.go
@@ -46,5 +46,15 @@ func (suite *WorkerSuite) TestTranslateAuditJob() {
 	jobErr := perf.Execute(job, worker.TranslateAuditJob)
 	suite.NoError(jobErr)
 
-	suite.NoError(jobErr)
+	suite.Run("A queue entry for a duplicate translated audit will not fail the translation queue job", func() {
+		//Update the queue to set it as NEW again.
+		entryToTest.Status = models.TPSNew
+		_, err = storage.TranslatedAuditQueueUpdate(suite.testConfigs.Store, suite.testConfigs.Logger, entryToTest)
+		suite.NoError(err)
+
+		// We expect no error when there is a duplicate entry.
+		jobErr2 := perf.Execute(job, worker.TranslateAuditJob)
+		suite.NoError(jobErr2)
+	})
+
 }

--- a/pkg/worker/translate_audit_job_test.go
+++ b/pkg/worker/translate_audit_job_test.go
@@ -3,6 +3,9 @@ package worker
 import (
 	"time"
 
+	faktory "github.com/contribsys/faktory/client"
+	faktory_worker "github.com/contribsys/faktory_worker_go"
+
 	"github.com/samber/lo"
 
 	"github.com/cmsgov/mint-app/pkg/models"
@@ -36,7 +39,12 @@ func (suite *WorkerSuite) TestTranslateAuditJob() {
 	}
 	entryToTest := testableEntries[0]
 
-	jobErr := worker.TranslateAuditJob(suite.testConfigs.Context, entryToTest.ChangeID, entryToTest.ID)
+	pool, err := faktory.NewPool(5)
+	suite.NoError(err)
+	job := faktory.NewJob(translateAuditJobName, entryToTest.ChangeID, entryToTest.ID)
+	perf := faktory_worker.NewTestExecutor(pool)
+	jobErr := perf.Execute(job, worker.TranslateAuditJob)
+	suite.NoError(jobErr)
 
 	suite.NoError(jobErr)
 }

--- a/pkg/worker/translate_audit_job_test.go
+++ b/pkg/worker/translate_audit_job_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cmsgov/mint-app/pkg/models"
 	"github.com/cmsgov/mint-app/pkg/storage"
+	"github.com/cmsgov/mint-app/pkg/translatedaudit"
 )
 
 func (suite *WorkerSuite) TestTranslateAuditJob() {
@@ -49,7 +50,7 @@ func (suite *WorkerSuite) TestTranslateAuditJob() {
 	suite.Run("A queue entry for a duplicate translated audit will not fail the translation queue job", func() {
 		//Update the queue to set it as NEW again.
 		entryToTest.Status = models.TPSNew
-		_, err = storage.TranslatedAuditQueueUpdate(suite.testConfigs.Store, suite.testConfigs.Logger, entryToTest)
+		_, err = translatedaudit.TranslatedAuditQueueUpdate(suite.testConfigs.Store, suite.testConfigs.Logger, entryToTest, suite.testConfigs.Principal.UserAccount.ID)
 		suite.NoError(err)
 
 		// We expect no error when there is a duplicate entry.


### PR DESCRIPTION
<!--
REQUIRED
    Ensure that your PR title has the relevant Jira ticket number(s) in the title.
    Follow this pattern: [EASI-1234] [EASI-4567] Title of the PR.
    Use [NOREF] in place of a ticket number when there's no associated Jira ticket.
    The heading below should just have the ticket numbers (for easy linking in Jira)
-->
# EASI-4520

## Description

The jobs for change history currently will fail if there is a duplicate entry attempting to translate an audit. This might happen in lower environments based on the timing of the `postgres` database being cleaned, and a mismatch with the faktory reddis instance. This isn't actually an issue though, so we should ideally not fail the job. 

This PR accomplishes that by typing that error, and not failing if so. This also begins to expand error handling for postgres data, so that `errors.As` can be used to determine specific error types. You will note that sqlutils get and select now process all errors. This can be expanded to handle new error types as desired in the future.

Also, the translated audit job is now a sugared logger with the worker JID, internal translated_audit_queue_id, and the audit.change id. 
<!--
REQUIRED
    Provide details as to what the PR aims to accomplish
    Be as descriptive as you can, and include any relevant information that will help the reviewer understand the scope of the changes
    Include screenshots or screen recordings to assist in reviewing if possible.
-->


## How to test this change
1. Run the app with Faktory running locally (
    a. set envrc.local variable values
          i.  APP_ENV=local
          ii. FAKTORY_PROCESS_JOBS=TRUE
         
 2. Seed the database.
 3. Once the audits have been translated, manually update the data in the database to try to reprocess all these already processed jobs
 ```sql
UPDATE translated_audit_queue
SET
 status = 'NEW',
 modified_by = '00000001-0001-0001-0001-000000000001',
 modified_dts = CURRENT_TIMESTAMP

RETURNING *
 ```
  
<!--
REQUIRED
    Add instructions on how to test the changes in this PR
    This can be a list of steps to reproduce a bug, or a list of steps to verify a feature in the application
    Include any example shell commands, SQL queries/commands, or Postman requests that reviewers can run to test the changes
-->
4. Ensure that the duplicate processing doesn't cause the job to fail.
5. You can also inspect the Docker Container to look at the logging messages.


Unit tests have been updated to also replicate this condition for the translated audit job.

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.
- [x] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
