### PR TITLE
[MINT-3714] Add waiver survey to additional questionnaires

### DIFF
--- a/src/features/ModelPlan/AdditionalQuestionnaires/__snapshots__/index.test.tsx.snap
+++ b/src/features/ModelPlan/AdditionalQuestionnaires/__snapshots__/index.test.tsx.snap
@@ -190,6 +190,74 @@ exports[`AdditionalQuestionnaires > match snapshot 1`] = `
             />
             <li
               class="display-flex padding-bottom-4"
+              data-testid="questionnaire-list-intake-form-waiverAssessmentSurvey"
+            >
+              <div
+                class="width-full"
+              >
+                <div
+                  class="additional-questionnaires-list__task-row display-flex flex-justify flex-align-start"
+                >
+                  <h3
+                    class="margin-top-0 margin-bottom-1"
+                  >
+                    Waiver assessment survey
+                  </h3>
+                  <span
+                    class="display-flex flex-column flex-align-end"
+                  >
+                    <div
+                      class="additional-questionnaires-list__task-tag line-height-body-1 text-bold bg-info-light "
+                      data-testid="questionnaireList-tag"
+                    >
+                      <span>
+                        Ready to start
+                      </span>
+                    </div>
+                  </span>
+                </div>
+                <div
+                  class="additional-questionnaires-list__task-description margin-right-auto line-height-body-5"
+                >
+                  <p
+                    class="margin-top-0"
+                  >
+                    This survey will help determine which specific waivers are most appropriate for your model, ensure proper justification for waiver selections, and identify any instances where standard CMS authorities may be sufficient without additional waiver flexibility.
+                  </p>
+                  <p
+                    class="margin-top-0 margin-bottom-0"
+                  >
+                    Your responses will:
+                  </p>
+                  <ul
+                    class="list-style-disc margin-top-0 margin-bottom-2 padding-left-3"
+                  >
+                    <li>
+                      Inform stakeholder engagement strategies
+                    </li>
+                    <li>
+                      Support operational planning and implementation timelines
+                    </li>
+                    <li>
+                      Ensure compliance with statutory and regulatory requirements
+                    </li>
+                  </ul>
+                </div>
+                <button
+                  aria-label="Start waiver assessment survey"
+                  class="usa-button usa-button margin-bottom-0 width-auto"
+                  data-testid="waiver-assessment-survey-button"
+                  type="button"
+                >
+                  Start
+                </button>
+              </div>
+            </li>
+            <div
+              class="mint-divider margin-bottom-4"
+            />
+            <li
+              class="display-flex padding-bottom-4"
               data-testid="questionnaire-list-intake-form-iddocQuestionnaire"
             >
               <div
@@ -225,56 +293,6 @@ exports[`AdditionalQuestionnaires > match snapshot 1`] = `
                     As you work to complete your Model Plan and model-to-operations matrix (MTO), some of your responses may indicate the need to fill out additional, more-detailed questions about how you plan to implement and operationalize your model. As those questions become required, additional questionnaires will be unlocked in this section of the model collaboration area.
                   </p>
                 </div>
-              </div>
-            </li>
-            <div
-              class="mint-divider margin-bottom-4"
-            />
-            <li
-              class="display-flex padding-bottom-4"
-              data-testid="questionnaire-list-intake-form-waiverAssessmentSurvey"
-            >
-              <div
-                class="width-full"
-              >
-                <div
-                  class="additional-questionnaires-list__task-row display-flex flex-justify flex-align-start"
-                >
-                  <h3
-                    class="margin-top-0 margin-bottom-1"
-                  >
-                    questionnairesList.waiverAssessmentSurvey.heading
-                  </h3>
-                  <span
-                    class="display-flex flex-column flex-align-end"
-                  >
-                    <div
-                      class="additional-questionnaires-list__task-tag line-height-body-1 text-bold bg-info-light "
-                      data-testid="questionnaireList-tag"
-                    >
-                      <span>
-                        Ready to start
-                      </span>
-                    </div>
-                  </span>
-                </div>
-                <div
-                  class="additional-questionnaires-list__task-description margin-right-auto line-height-body-5"
-                >
-                  <p
-                    class="margin-top-0"
-                  >
-                    questionnairesList.waiverAssessmentSurvey.description
-                  </p>
-                </div>
-                <button
-                  aria-label="Start questionnaireslist.waiverassessmentsurvey.heading"
-                  class="usa-button usa-button margin-bottom-0 width-auto"
-                  data-testid="waiver-assessment-survey-button"
-                  type="button"
-                >
-                  Start
-                </button>
               </div>
             </li>
           </ol>

--- a/src/features/ModelPlan/AdditionalQuestionnaires/_components/QuestionnaireListItem/__snapshots__/index.test.tsx.snap
+++ b/src/features/ModelPlan/AdditionalQuestionnaires/_components/QuestionnaireListItem/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`QuestionnaireListItem > match snapshot 1`] = `
 <DocumentFragment>
   <li
     class="display-flex padding-bottom-4"
-    data-testid="questionnaire-list-item"
+    data-testid="questionnaire-list-intake-form-dataExchangeApproach"
   >
     <div
       class="width-full"
@@ -15,7 +15,7 @@ exports[`QuestionnaireListItem > match snapshot 1`] = `
         <h3
           class="margin-top-0 margin-bottom-1"
         >
-          Sample Heading
+          Data exchange approach
         </h3>
         <span
           class="display-flex flex-column flex-align-end"
@@ -36,7 +36,7 @@ exports[`QuestionnaireListItem > match snapshot 1`] = `
         <p
           class="margin-top-0"
         >
-          Sample Description
+          After your 6-page concept paper is approved, work with your IT Lead or Solution Architect (or reach out to the MINT Team if one still needs to be assigned) to determine how you'll exchange data so that we can help with new policy or technology opportunities. You should also include your data exchange approach in your ICIP.
         </p>
       </div>
     </div>

--- a/src/features/ModelPlan/AdditionalQuestionnaires/_components/QuestionnaireListItem/index.test.tsx
+++ b/src/features/ModelPlan/AdditionalQuestionnaires/_components/QuestionnaireListItem/index.test.tsx
@@ -7,6 +7,7 @@ import configureMockStore from 'redux-mock-store';
 import { modelID } from 'tests/mock/general';
 
 import { ASSESSMENT } from 'constants/jobCodes';
+import { QuestionnaireName } from 'types/questionnaires';
 
 import QuestionnaireListItem from './index';
 
@@ -20,10 +21,8 @@ const mockStore = configureMockStore();
 const store = mockStore({ auth: mockAuthAssessment });
 
 const mockProps = {
-  heading: 'Sample Heading',
-  description: 'Sample Description',
-  status: DataExchangeApproachStatus.READY,
-  testId: 'questionnaire-list-item'
+  questionnaireName: 'dataExchangeApproach' as QuestionnaireName,
+  status: DataExchangeApproachStatus.READY
 };
 
 describe('QuestionnaireListItem', () => {

--- a/src/features/ModelPlan/AdditionalQuestionnaires/_components/QuestionnaireListItem/index.tsx
+++ b/src/features/ModelPlan/AdditionalQuestionnaires/_components/QuestionnaireListItem/index.tsx
@@ -5,22 +5,21 @@ import { Button } from '@trussworks/react-uswds';
 import classNames from 'classnames';
 import {
   DataExchangeApproachStatus,
-  IddocQuestionnaireTaskListStatus,
-  WaiverAssessmentSurveyStatus
+  IddocQuestionnaireTaskListStatus
 } from 'gql/generated/graphql';
 
-import '../../index.scss';
+import {
+  QuestionnaireName,
+  QuestionnairesStatusType
+} from 'types/questionnaires';
 
-type QuestionnaireListStatusType =
-  | DataExchangeApproachStatus
-  | IddocQuestionnaireTaskListStatus
-  | WaiverAssessmentSurveyStatus;
+import '../../index.scss';
 
 const QuestionnaireListStatusTag = ({
   status,
   classname
 }: {
-  status: QuestionnaireListStatusType;
+  status: QuestionnairesStatusType;
   classname?: string;
 }) => {
   const { t: additionalQuestionnairesT } = useTranslation(
@@ -83,7 +82,7 @@ export const QuestionnaireListButton = ({
   testId?: string;
   path: string;
   disabled?: boolean;
-  status: QuestionnaireListStatusType;
+  status: QuestionnairesStatusType;
 }) => {
   const { t: additionalQuestionnairesT } = useTranslation(
     'additionalQuestionnaires'
@@ -135,39 +134,71 @@ export const QuestionnaireListButton = ({
 };
 
 type QuestionnaireListItemProps = {
+  questionnaireName: QuestionnaireName;
   children?: React.ReactNode;
-  heading: string;
-  description: string;
-  status: QuestionnaireListStatusType;
-  testId: string;
+  status: QuestionnairesStatusType;
 };
 
 const QuestionnaireListItem = ({
+  questionnaireName,
   children,
-  heading,
-  description,
-  status,
-  testId
+  status
 }: QuestionnaireListItemProps) => {
+  const { t: additionalQuestionnairesT } = useTranslation(
+    'additionalQuestionnaires'
+  );
+
+  const description = additionalQuestionnairesT(
+    `questionnairesList.${questionnaireName}.description`,
+    {
+      returnObjects: true
+    }
+  ) as (string | string[])[];
+
   return (
-    <li className="display-flex padding-bottom-4" data-testid={testId}>
+    <li
+      className="display-flex padding-bottom-4"
+      data-testid={`questionnaire-list-intake-form-${questionnaireName}`}
+    >
       <div className="width-full">
         <div className="additional-questionnaires-list__task-row display-flex flex-justify flex-align-start">
-          <h3 className="margin-top-0 margin-bottom-1">{heading}</h3>
+          <h3 className="margin-top-0 margin-bottom-1">
+            {additionalQuestionnairesT(
+              `questionnairesList.${questionnaireName}.heading`
+            )}
+          </h3>
           <span className="display-flex flex-column flex-align-end">
             <QuestionnaireListStatusTag status={status} />
           </span>
         </div>
 
         <div className="additional-questionnaires-list__task-description margin-right-auto line-height-body-5">
-          <p
-            className={classNames('margin-top-0', {
-              'text-base-dark':
-                status === IddocQuestionnaireTaskListStatus.NOT_NEEDED
-            })}
-          >
-            {description}
-          </p>
+          {description.map((item, index) => {
+            const nextItem =
+              index < description.length - 1 ? description[index + 1] : null;
+
+            if (typeof item === 'string') {
+              return (
+                <p
+                  className={classNames('margin-top-0', {
+                    'text-base-dark':
+                      status === IddocQuestionnaireTaskListStatus.NOT_NEEDED,
+                    'margin-bottom-0': nextItem && typeof nextItem !== 'string'
+                  })}
+                >
+                  {item}
+                </p>
+              );
+            }
+
+            return (
+              <ul className="list-style-disc margin-top-0 margin-bottom-2 padding-left-3">
+                {item.map(bullet => (
+                  <li key={bullet}>{bullet}</li>
+                ))}
+              </ul>
+            );
+          })}
         </div>
 
         {children}

--- a/src/features/ModelPlan/AdditionalQuestionnaires/index.test.tsx
+++ b/src/features/ModelPlan/AdditionalQuestionnaires/index.test.tsx
@@ -52,7 +52,9 @@ describe('AdditionalQuestionnaires', () => {
       ).toBeInTheDocument();
     });
     expect(screen.getByText('Data exchange approach')).toBeInTheDocument();
+    expect(screen.getByText('Waiver assessment survey')).toBeInTheDocument();
     expect(screen.getByText('4i and ACO-OS')).toBeInTheDocument();
+
     expect(
       screen.getByTestId('data-exchange-approach-button')
     ).toBeInTheDocument();

--- a/src/features/ModelPlan/AdditionalQuestionnaires/index.tsx
+++ b/src/features/ModelPlan/AdditionalQuestionnaires/index.tsx
@@ -1,10 +1,10 @@
-import React, { Fragment, useContext, useMemo } from 'react';
+import React, { Fragment, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { Grid, GridContainer, Icon } from '@trussworks/react-uswds';
+import NotFound from 'features/NotFound';
 import {
-  GetAllQuestionnairesQuery,
   GetLockedModelPlanSectionsQuery,
   LockableSection,
   useGetAllQuestionnairesQuery
@@ -21,6 +21,7 @@ import PageLoading from 'components/PageLoading';
 import SectionLock from 'components/SectionLock';
 import { ModelInfoContext } from 'contexts/ModelInfoContext';
 import { SubscriptionContext } from 'contexts/PageLockContext';
+import { QuestionnaireName } from 'types/questionnaires';
 import { formatDateLocal } from 'utils/date';
 import { convertCamelCaseToKebabCase } from 'utils/modelPlan';
 
@@ -37,6 +38,12 @@ const questionnaireSectionMap: Partial<Record<string, LockableSection>> = {
   iddocQuestionnaire: LockableSection.IDDOC_QUESTIONNAIRE
 };
 
+const QUESTIONNAIRE_DISPLAY_ORDER = [
+  'dataExchangeApproach',
+  'waiverAssessmentSurvey',
+  'iddocQuestionnaire'
+] as const satisfies QuestionnaireName[];
+
 const AdditionalQuestionnaires = () => {
   const { t: additionalQuestionnairesT } = useTranslation(
     'additionalQuestionnaires'
@@ -51,23 +58,13 @@ const AdditionalQuestionnaires = () => {
 
   const { modelName } = useContext(ModelInfoContext);
 
-  const { data, loading } = useGetAllQuestionnairesQuery({
+  const { data, loading, error } = useGetAllQuestionnairesQuery({
     variables: {
       id: modelID
     }
   });
 
-  const questionnaireSections = useMemo(() => {
-    if (!data || !data.modelPlan) {
-      return {} as GetAllQuestionnairesQuery['modelPlan']['questionnaires'];
-    }
-    const { __typename, ...questionnaire } = data.modelPlan.questionnaires;
-    return questionnaire;
-  }, [data]);
-
-  const questionnaireNames = Object.keys(
-    questionnaireSections
-  ) as (keyof typeof questionnaireSections)[];
+  const questionnaireSections = data?.modelPlan?.questionnaires;
 
   const getQuestionnaireLockedStatus = (
     section: string
@@ -77,12 +74,16 @@ const AdditionalQuestionnaires = () => {
     );
   };
 
+  if (loading) {
+    return <PageLoading />;
+  }
+
+  if (error || !questionnaireSections) {
+    return <NotFound />;
+  }
+
   // Helper to get the correct status field based on questionnaire type
-  const getQuestionnaireStatus = <
-    Key extends keyof typeof questionnaireSections
-  >(
-    key: Key
-  ) => {
+  const getQuestionnaireStatus = (key: QuestionnaireName) => {
     const questionnaire = questionnaireSections[key];
     // iddocQuestionnaire uses taskListStatus to include needed, others use status
     if ('taskListStatus' in questionnaire) {
@@ -90,10 +91,6 @@ const AdditionalQuestionnaires = () => {
     }
     return questionnaire.status;
   };
-
-  if (loading) {
-    return <PageLoading />;
-  }
 
   return (
     <MainContent
@@ -139,20 +136,13 @@ const AdditionalQuestionnaires = () => {
               data-testid="questionnaire-list"
               className="margin-top-6 margin-bottom-0 padding-left-0"
             >
-              {questionnaireNames.map((key, index) => {
+              {QUESTIONNAIRE_DISPLAY_ORDER.map((key, index) => {
                 const lockedStatus = getQuestionnaireLockedStatus(key);
 
                 return (
                   <Fragment key={key}>
                     <QuestionnaireListItem
-                      key={key}
-                      testId={`questionnaire-list-intake-form-${key}`}
-                      heading={additionalQuestionnairesT(
-                        `questionnairesList.${key}.heading`
-                      )}
-                      description={additionalQuestionnairesT(
-                        `questionnairesList.${key}.description`
-                      )}
+                      questionnaireName={key}
                       status={getQuestionnaireStatus(key)}
                     >
                       {questionnaireSections[key].modifiedDts &&
@@ -199,7 +189,7 @@ const AdditionalQuestionnaires = () => {
                         <SectionLock section={questionnaireSectionMap[key]} />
                       )}
                     </QuestionnaireListItem>
-                    {index < questionnaireNames.length - 1 && (
+                    {index < QUESTIONNAIRE_DISPLAY_ORDER.length - 1 && (
                       <Divider className="margin-bottom-4" />
                     )}
                   </Fragment>

--- a/src/features/ModelPlan/CollaborationArea/Cards/AdditionalQuestionnairesCard/index.test.tsx
+++ b/src/features/ModelPlan/CollaborationArea/Cards/AdditionalQuestionnairesCard/index.test.tsx
@@ -49,7 +49,7 @@ describe('AdditionalQuestionnairesCard', () => {
         i18next.t('collaborationArea:additionalQuestionnairesCard.heading')
       )
     ).toBeInTheDocument();
-    expect(screen.getByText('1 required questionnaire')).toBeInTheDocument();
+    expect(screen.getByText('2 required questionnaires')).toBeInTheDocument();
     expect(
       screen.getByText(
         i18next.t(

--- a/src/features/ModelPlan/CollaborationArea/Cards/AdditionalQuestionnairesCard/index.tsx
+++ b/src/features/ModelPlan/CollaborationArea/Cards/AdditionalQuestionnairesCard/index.tsx
@@ -10,22 +10,16 @@ import {
   Icon
 } from '@trussworks/react-uswds';
 import classNames from 'classnames';
-import {
-  DataExchangeApproachStatus,
-  GetCollaborationAreaQuery,
-  IddocQuestionnaireTaskListStatus,
-  WaiverAssessmentSurveyStatus
-} from 'gql/generated/graphql';
 
 import UswdsReactLink from 'components/LinkWrapper';
+import {
+  Questionnaire,
+  QuestionnaireName,
+  QuestionnairesStatusType,
+  QuestionnairesType
+} from 'types/questionnaires';
 
 import '../cards.scss';
-
-export type QuestionnairesType =
-  GetCollaborationAreaQuery['modelPlan']['questionnaires'];
-
-type QuestionnaireName = keyof Omit<QuestionnairesType, '__typename'>;
-type Questionnaire = Omit<QuestionnairesType, '__typename'>[QuestionnaireName];
 
 type QuestionnaireRow = {
   name: QuestionnaireName;
@@ -36,11 +30,6 @@ export type AdditionalQuestionnairesCardType = {
   modelID: string;
   questionnairesData: QuestionnairesType;
 };
-
-export type QuestionnairesStatusType =
-  | DataExchangeApproachStatus
-  | IddocQuestionnaireTaskListStatus
-  | WaiverAssessmentSurveyStatus;
 
 const REQUIRED_QUESTIONNAIRES: QuestionnaireName[] = [
   'dataExchangeApproach',

--- a/src/features/ModelPlan/CollaborationArea/Cards/AdditionalQuestionnairesCard/index.tsx
+++ b/src/features/ModelPlan/CollaborationArea/Cards/AdditionalQuestionnairesCard/index.tsx
@@ -24,6 +24,14 @@ import '../cards.scss';
 export type QuestionnairesType =
   GetCollaborationAreaQuery['modelPlan']['questionnaires'];
 
+type QuestionnaireName = keyof Omit<QuestionnairesType, '__typename'>;
+type Questionnaire = Omit<QuestionnairesType, '__typename'>[QuestionnaireName];
+
+type QuestionnaireRow = {
+  name: QuestionnaireName;
+  questionnaire: Questionnaire;
+};
+
 export type AdditionalQuestionnairesCardType = {
   modelID: string;
   questionnairesData: QuestionnairesType;
@@ -34,7 +42,10 @@ export type QuestionnairesStatusType =
   | IddocQuestionnaireTaskListStatus
   | WaiverAssessmentSurveyStatus;
 
-const REQUIRED_QUESTIONNAIRES = ['dataExchangeApproach'];
+const REQUIRED_QUESTIONNAIRES: QuestionnaireName[] = [
+  'dataExchangeApproach',
+  'waiverAssessmentSurvey'
+];
 
 const QuestionnaireStatusPill = ({
   status
@@ -89,7 +100,7 @@ const QuestionnaireStatusPill = ({
 
 const AdditionalQuestionnairesCard = ({
   modelID,
-  questionnairesData
+  questionnairesData: { __typename, ...questionnaires }
 }: AdditionalQuestionnairesCardType) => {
   const { t: collaborationAreaT } = useTranslation('collaborationArea');
   const { t: additionalQuestionnairesT } = useTranslation(
@@ -98,39 +109,37 @@ const AdditionalQuestionnairesCard = ({
 
   const navigate = useNavigate();
 
-  const { __typename, ...questionnaires } = questionnairesData;
-
-  const questionnaireNames = Object.keys(
-    questionnaires
-  ) as (keyof typeof questionnaires)[];
+  const questionnaireNames = Object.keys(questionnaires) as QuestionnaireName[];
 
   const allQuestionnaires = questionnaireNames.reduce<{
-    requiredQuestionnaires: (typeof questionnaires)[keyof typeof questionnaires][];
-    otherQuestionnaires: (typeof questionnaires)[keyof typeof questionnaires][];
+    requiredQuestionnaires: QuestionnaireRow[];
+    otherQuestionnaires: QuestionnaireRow[];
   }>(
     (groupedQuestionnaires, name) => {
       const questionnaire = questionnaires[name];
 
-      if (
+      const isRequired =
         REQUIRED_QUESTIONNAIRES.includes(name) ||
-        ('needed' in questionnaire && questionnaire.needed)
-      ) {
-        groupedQuestionnaires.requiredQuestionnaires.push(questionnaire);
+        ('needed' in questionnaire && questionnaire.needed);
+
+      if (isRequired) {
+        groupedQuestionnaires.requiredQuestionnaires.push({
+          name,
+          questionnaire
+        });
       } else {
-        groupedQuestionnaires.otherQuestionnaires.push(questionnaire);
+        groupedQuestionnaires.otherQuestionnaires.push({ name, questionnaire });
       }
+
       return groupedQuestionnaires;
     },
-    {
-      requiredQuestionnaires: [],
-      otherQuestionnaires: []
-    }
+    { requiredQuestionnaires: [], otherQuestionnaires: [] }
   );
 
-  const requiredQuestionnairesCount =
-    allQuestionnaires.requiredQuestionnaires.length;
+  const { requiredQuestionnaires, otherQuestionnaires } = allQuestionnaires;
 
-  const otherQuestionnairesCount = allQuestionnaires.otherQuestionnaires.length;
+  const requiredQuestionnairesCount = requiredQuestionnaires.length;
+  const otherQuestionnairesCount = otherQuestionnaires.length;
 
   return (
     <>
@@ -154,32 +163,26 @@ const AdditionalQuestionnairesCard = ({
 
           {/* questionnaires status */}
           <div className="margin-bottom-2">
-            {allQuestionnaires.requiredQuestionnaires.map(
-              requiredQuestionnaire => (
+            {requiredQuestionnaires.map(({ name, questionnaire }) => {
+              const status =
+                'taskListStatus' in questionnaire
+                  ? questionnaire.taskListStatus
+                  : questionnaire.status;
+
+              return (
                 <div
                   className="display-flex flex-align-center margin-bottom-1"
-                  key={requiredQuestionnaire.id}
+                  key={questionnaire.id}
                 >
-                  <QuestionnaireStatusPill
-                    status={
-                      'taskListStatus' in requiredQuestionnaire
-                        ? requiredQuestionnaire.taskListStatus
-                        : (requiredQuestionnaire as any).status
-                    }
-                  />
+                  <QuestionnaireStatusPill status={status} />
                   <p className="margin-y-0">
                     {additionalQuestionnairesT(
-                      `questionnairesList.${
-                        requiredQuestionnaire.__typename ===
-                        'PlanDataExchangeApproach'
-                          ? 'dataExchangeApproach'
-                          : 'iddocQuestionnaire'
-                      }.heading`
+                      `questionnairesList.${name}.heading`
                     )}
                   </p>
                 </div>
-              )
-            )}
+              );
+            })}
           </div>
 
           <UswdsReactLink
@@ -229,7 +232,6 @@ const AdditionalQuestionnairesCard = ({
                 `/models/${modelID}/collaboration-area/additional-questionnaires`
               )
             }
-            data-testid="to-data-exchange-approach"
           >
             {collaborationAreaT(
               'additionalQuestionnairesCard.goToQuestionnaires'

--- a/src/i18n/en-US/modelPlan/additionalQuestionnaires.ts
+++ b/src/i18n/en-US/modelPlan/additionalQuestionnaires.ts
@@ -1,3 +1,5 @@
+import { QuestionnaireName } from 'types/questionnaires';
+
 import {
   DataExchangeApproachStatus,
   IddocQuestionnaireTaskListStatus
@@ -17,6 +19,45 @@ const iddocQuestionnaireStatus: Record<
   [IddocQuestionnaireTaskListStatus.READY]: 'Ready to start',
   [IddocQuestionnaireTaskListStatus.IN_PROGRESS]: 'In progress',
   [IddocQuestionnaireTaskListStatus.COMPLETE]: 'Complete'
+};
+
+const questionnairesList: Record<
+  QuestionnaireName,
+  {
+    heading: string;
+    // Enter description text as an array of strings for bulleted lists
+    description: (string | string[])[];
+    path: string;
+  }
+> = {
+  dataExchangeApproach: {
+    heading: 'Data exchange approach',
+    description: [
+      "After your 6-page concept paper is approved, work with your IT Lead or Solution Architect (or reach out to the MINT Team if one still needs to be assigned) to determine how you'll exchange data so that we can help with new policy or technology opportunities. You should also include your data exchange approach in your ICIP."
+    ],
+    path: 'data-exchange-approach/about-completing-data-exchange'
+  },
+  waiverAssessmentSurvey: {
+    heading: 'Waiver assessment survey',
+    description: [
+      'This survey will help determine which specific waivers are most appropriate for your model, ensure proper justification for waiver selections, and identify any instances where standard CMS authorities may be sufficient without additional waiver flexibility.',
+      'Your responses will:',
+      [
+        'Inform stakeholder engagement strategies',
+        'Support operational planning and implementation timelines',
+        'Ensure compliance with statutory and regulatory requirements'
+      ]
+    ],
+    // TODO: Update path
+    path: ''
+  },
+  iddocQuestionnaire: {
+    heading: '4i and ACO-OS',
+    description: [
+      'As you work to complete your Model Plan and model-to-operations matrix (MTO), some of your responses may indicate the need to fill out additional, more-detailed questions about how you plan to implement and operationalize your model. As those questions become required, additional questionnaires will be unlocked in this section of the model collaboration area.'
+    ],
+    path: 'iddoc-questionnaire/operations'
+  }
 };
 
 const additionalQuestionnaires = {
@@ -39,27 +80,7 @@ const additionalQuestionnaires = {
     dataExchangeApproach: dataExchangeApproachStatus,
     iddocQuestionnaire: iddocQuestionnaireStatus
   },
-  questionnairesList: {
-    dataExchangeApproach: {
-      heading: 'Data exchange approach',
-      description:
-        "After your 6-page concept paper is approved, work with your IT Lead or Solution Architect (or reach out to the MINT Team if one still needs to be assigned) to determine how you'll exchange data so that we can help with new policy or technology opportunities. You should also include your data exchange approach in your ICIP.",
-      path: 'data-exchange-approach/about-completing-data-exchange'
-    },
-    iddocQuestionnaire: {
-      heading: '4i and ACO-OS',
-      description:
-        'As you work to complete your Model Plan and model-to-operations matrix (MTO), some of your responses may indicate the need to fill out additional, more-detailed questions about how you plan to implement and operationalize your model. As those questions become required, additional questionnaires will be unlocked in this section of the model collaboration area.',
-      path: 'iddoc-questionnaire/operations'
-    },
-    waiverAssessmentSurvey: {
-      heading: 'Waiver assessment survey',
-      description:
-        'This survey will help determine which specific waivers are most appropriate for your model, ensure proper justification for waiver selections, and identify any instances where standard CMS authorities may be sufficient without additional waiver flexibility.',
-      // TODO: Update path
-      path: ''
-    }
-  },
+  questionnairesList,
   questionnaireButton: {
     start: 'Start',
     continue: 'Continue',

--- a/src/i18n/en-US/modelPlan/additionalQuestionnaires.ts
+++ b/src/i18n/en-US/modelPlan/additionalQuestionnaires.ts
@@ -51,6 +51,13 @@ const additionalQuestionnaires = {
       description:
         'As you work to complete your Model Plan and model-to-operations matrix (MTO), some of your responses may indicate the need to fill out additional, more-detailed questions about how you plan to implement and operationalize your model. As those questions become required, additional questionnaires will be unlocked in this section of the model collaboration area.',
       path: 'iddoc-questionnaire/operations'
+    },
+    waiverAssessmentSurvey: {
+      heading: 'Waiver assessment survey',
+      description:
+        'This survey will help determine which specific waivers are most appropriate for your model, ensure proper justification for waiver selections, and identify any instances where standard CMS authorities may be sufficient without additional waiver flexibility.',
+      // TODO: Update path
+      path: ''
     }
   },
   questionnaireButton: {

--- a/src/stylesheets/custom.scss
+++ b/src/stylesheets/custom.scss
@@ -156,6 +156,10 @@ th {
   list-style-type: none !important;
 }
 
+.list-style-disc {
+  list-style-type: disc !important;
+}
+
 .line-height-sans-lg {
   line-height: 2.1875rem !important;
 }

--- a/src/tests/mock/general.ts
+++ b/src/tests/mock/general.ts
@@ -1,6 +1,5 @@
 import { MockedResponse } from '@apollo/client/testing';
 import { KeyContactCategoryType } from 'features/HelpAndKnowledge/KeyContactDirectory/_components/CategoryModal';
-import { QuestionnairesType } from 'features/ModelPlan/CollaborationArea/Cards/AdditionalQuestionnairesCard';
 import {
   DataExchangeApproachStatus,
   GetAllKeyContactCategoriesDocument,
@@ -48,6 +47,7 @@ import {
 } from 'gql/generated/graphql';
 
 import { GetModelPlanBaseModelPlan } from 'contexts/ModelInfoContext';
+import { QuestionnairesType } from 'types/questionnaires';
 
 type GetFavoritesType = GetFavoritesQuery['modelPlanCollection'];
 type GetModelPlansType = GetModelPlansQuery['modelPlanCollection'];

--- a/src/types/questionnaires.ts
+++ b/src/types/questionnaires.ts
@@ -1,0 +1,21 @@
+import {
+  DataExchangeApproachStatus,
+  GetCollaborationAreaQuery,
+  IddocQuestionnaireTaskListStatus,
+  WaiverAssessmentSurveyStatus
+} from 'gql/generated/graphql';
+
+export type QuestionnairesType =
+  GetCollaborationAreaQuery['modelPlan']['questionnaires'];
+
+export type Questionnaire = Omit<
+  QuestionnairesType,
+  '__typename'
+>[QuestionnaireName];
+
+export type QuestionnaireName = keyof Omit<QuestionnairesType, '__typename'>;
+
+export type QuestionnairesStatusType =
+  | DataExchangeApproachStatus
+  | IddocQuestionnaireTaskListStatus
+  | WaiverAssessmentSurveyStatus;


### PR DESCRIPTION
# MINT-3714

[Figma](https://www.figma.com/design/qXhO12xSSkDF4LaToGKJoV/MINT-Blue-Sky-Ideas?node-id=4540-3190&t=VHONK0QJgdFE49KB-1)

## Description
- Added waiver assessment survey to additional questionnaires card and page
- Note: "Responsible team member" section on additional questionnaires page is ticketed separately

## How to test this change
1.  Go to collaboration area for any model
2. Confirm waiver assessment survey is displayed in additional questionnaires card
3. Click "View all required questionnaires"
4. Confirm waiver assessment survey section on page matches Figma

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.
- [x] Updated the [BRUNO Collection](../query_examples/MINT) if necessary.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
