### PR TITLE
[NOREF] Addressing annoying alerts in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@apollo/client": "^3.13.9",
+    "@apollo/client": "^3.14.1",
     "@babel/plugin-syntax-class-properties": "^7.12.13",
     "@hookform/resolvers": "^3.9.1",
     "@json2csv/formatters": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "graphql": "^16.13.1",
     "html-react-parser": "^5.2.17",
     "html2canvas": "^1.4.1",
-    "i18next": "^25.10.4",
+    "i18next": "^26.3.3",
     "i18next-browser-languagedetector": "^8.2.1",
     "istanbul-lib-coverage": "^3.2.2",
     "jspdf": "^4.2.1",

--- a/src/components/AskAQuestion/index.test.tsx
+++ b/src/components/AskAQuestion/index.test.tsx
@@ -131,7 +131,7 @@ describe('Ask a Question Component', () => {
         {
           path: '/models/:modelID/collaboration-area/task-list/basics',
           element: (
-            <MockedProvider mocks={mocks} addTypename={false}>
+            <MockedProvider mocks={mocks}>
               <Provider store={store}>
                 <AskAQuestion modelID={modelID} />
               </Provider>

--- a/src/components/EChimpCards/EChimpCardsTable.test.tsx
+++ b/src/components/EChimpCards/EChimpCardsTable.test.tsx
@@ -45,7 +45,7 @@ describe('EChimpCardsTable', () => {
     );
 
     render(
-      <MockedProvider mocks={echimpCRsAndTDLsMock} addTypename={false}>
+      <MockedProvider mocks={echimpCRsAndTDLsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -80,7 +80,7 @@ describe('EChimpCardsTable', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={echimpCRsAndTDLsMock} addTypename={false}>
+      <MockedProvider mocks={echimpCRsAndTDLsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/components/EChimpCards/__snapshots__/EChimpCardsTable.test.tsx.snap
+++ b/src/components/EChimpCards/__snapshots__/EChimpCardsTable.test.tsx.snap
@@ -190,7 +190,7 @@ exports[`EChimpCardsTable > matches snapshot 1`] = `
               <p
                 class="text-bold"
               >
-                TDL Status
+                CR Status
               </p>
               <p>
                 Open
@@ -202,7 +202,7 @@ exports[`EChimpCardsTable > matches snapshot 1`] = `
               <p
                 class="text-bold"
               >
-                Issued date
+                Implementation Date
               </p>
               <p>
                 2022-07-30T05:00:00Z

--- a/src/components/Header/index.test.tsx
+++ b/src/components/Header/index.test.tsx
@@ -54,7 +54,7 @@ describe('The Header component when logged in', () => {
     );
 
     render(
-      <MockedProvider mocks={notificationsMock} addTypename={false}>
+      <MockedProvider mocks={notificationsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -96,7 +96,7 @@ describe('When logged in', () => {
     );
 
     render(
-      <MockedProvider mocks={notificationsMock} addTypename={false}>
+      <MockedProvider mocks={notificationsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/components/NavigationBar/index.test.tsx
+++ b/src/components/NavigationBar/index.test.tsx
@@ -68,7 +68,7 @@ describe('The NavigationBar component', () => {
     );
 
     const { getByTestId } = render(
-      <MockedProvider mocks={notificationsMock} addTypename={false}>
+      <MockedProvider mocks={notificationsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -97,7 +97,7 @@ describe('The NavigationBar component', () => {
     );
 
     const { getByText, getByTestId } = render(
-      <MockedProvider mocks={notificationsMock} addTypename={false}>
+      <MockedProvider mocks={notificationsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/components/OktaUserSelect/index.test.tsx
+++ b/src/components/OktaUserSelect/index.test.tsx
@@ -29,7 +29,7 @@ describe('OktaUserSelect', () => {
 
   it('selects contact from dropdown', async () => {
     const { user, asFragment, getByRole, findByText } = setup(
-      <MockedProvider mocks={[oktaUsersQuery]} addTypename={false}>
+      <MockedProvider mocks={[oktaUsersQuery]}>
         <OktaUserSelect
           id="cedarContactSelect"
           name="cedarContactSelect"

--- a/src/components/ShareExport/index.test.tsx
+++ b/src/components/ShareExport/index.test.tsx
@@ -61,7 +61,6 @@ describe('ShareExportModal', () => {
             ...solutionAndMilestoneMock,
             ...echimpCRsAndTDLsMock
           ]}
-          addTypename={false}
         >
           <RouterProvider router={router} />
         </VerboseMockedProvider>
@@ -130,7 +129,6 @@ describe('ShareExportModal', () => {
             ...solutionAndMilestoneMock,
             ...echimpCRsAndTDLsMock
           ]}
-          addTypename={false}
         >
           <RouterProvider router={router} />
         </VerboseMockedProvider>

--- a/src/components/UpdateStatusModal/index.test.tsx
+++ b/src/components/UpdateStatusModal/index.test.tsx
@@ -78,7 +78,7 @@ describe('UpdateStatusModal', () => {
       }
     );
     render(
-      <MockedProvider mocks={statusMock} addTypename={false}>
+      <MockedProvider mocks={statusMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/Feedback/ReportAProblem/index.test.tsx
+++ b/src/features/Feedback/ReportAProblem/index.test.tsx
@@ -47,7 +47,7 @@ describe('Report a problem form', () => {
         {
           path: '/report-a-problem',
           element: (
-            <VerboseMockedProvider mocks={mocks} addTypename={false}>
+            <VerboseMockedProvider mocks={mocks}>
               <ReportAProblem />
             </VerboseMockedProvider>
           )
@@ -106,7 +106,7 @@ describe('Report a problem form', () => {
         {
           path: '/report-a-problem',
           element: (
-            <VerboseMockedProvider mocks={mocks} addTypename={false}>
+            <VerboseMockedProvider mocks={mocks}>
               <ReportAProblem />
             </VerboseMockedProvider>
           )

--- a/src/features/Feedback/SendFeedback/index.test.tsx
+++ b/src/features/Feedback/SendFeedback/index.test.tsx
@@ -44,7 +44,7 @@ describe('Send feedback form', () => {
         {
           path: '/send-feedback',
           element: (
-            <MockedProvider mocks={mocks} addTypename={false}>
+            <MockedProvider mocks={mocks}>
               <SendFeedback />
             </MockedProvider>
           )
@@ -98,7 +98,7 @@ describe('Send feedback form', () => {
         {
           path: '/send-feedback',
           element: (
-            <MockedProvider mocks={mocks} addTypename={false}>
+            <MockedProvider mocks={mocks}>
               <SendFeedback />
             </MockedProvider>
           )

--- a/src/features/HelpAndKnowledge/Articles/AllArticles/index.test.tsx
+++ b/src/features/HelpAndKnowledge/Articles/AllArticles/index.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
-import { MockedProvider } from '@apollo/client/testing';
 import { render } from '@testing-library/react';
 
 import AllArticles from '.';
@@ -11,11 +10,7 @@ describe('The AllArticles component', () => {
       [
         {
           path: '/help-and-knowledge/articles',
-          element: (
-            <MockedProvider mocks={[]} addTypename={false}>
-              <AllArticles />
-            </MockedProvider>
-          )
+          element: <AllArticles />
         }
       ],
       {
@@ -35,11 +30,7 @@ describe('The AllArticles component', () => {
       [
         {
           path: '/help-and-knowledge/articles',
-          element: (
-            <MockedProvider mocks={[]} addTypename={false}>
-              <AllArticles />
-            </MockedProvider>
-          )
+          element: <AllArticles />
         }
       ],
       {
@@ -59,11 +50,7 @@ describe('The AllArticles component', () => {
       [
         {
           path: '/',
-          element: (
-            <MockedProvider mocks={[]} addTypename={false}>
-              <AllArticles />
-            </MockedProvider>
-          )
+          element: <AllArticles />
         }
       ],
       {

--- a/src/features/HelpAndKnowledge/Articles/HighLevelProjectPlan/index.test.tsx
+++ b/src/features/HelpAndKnowledge/Articles/HighLevelProjectPlan/index.test.tsx
@@ -15,7 +15,7 @@ describe('High Level Project Plan Article', () => {
         {
           path: '/help-and-knowledge/high-level-project-plan',
           element: (
-            <VerboseMockedProvider mocks={mocks} addTypename={false}>
+            <VerboseMockedProvider mocks={mocks}>
               <HighLevelProjectPlan />
             </VerboseMockedProvider>
           )

--- a/src/features/HelpAndKnowledge/Articles/ModelSolutionDesign/index.test.tsx
+++ b/src/features/HelpAndKnowledge/Articles/ModelSolutionDesign/index.test.tsx
@@ -27,7 +27,7 @@ describe('ModelSolutionDesign', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/Articles/SixPagerMeeting/index.test.tsx
+++ b/src/features/HelpAndKnowledge/Articles/SixPagerMeeting/index.test.tsx
@@ -15,7 +15,7 @@ describe('SixPagerMeeting', () => {
         {
           path: '/',
           element: (
-            <VerboseMockedProvider mocks={mocks} addTypename={false}>
+            <VerboseMockedProvider mocks={mocks}>
               <SixPagerMeeting />
             </VerboseMockedProvider>
           )

--- a/src/features/HelpAndKnowledge/Articles/TwoPagerMeeting/index.test.tsx
+++ b/src/features/HelpAndKnowledge/Articles/TwoPagerMeeting/index.test.tsx
@@ -16,7 +16,7 @@ describe('TwoPagerMeeting', () => {
         {
           path: '/help-and-knowledge/about-2-page-concept-papers-and-review-meetings',
           element: (
-            <VerboseMockedProvider mocks={mocks} addTypename={false}>
+            <VerboseMockedProvider mocks={mocks}>
               <TwoPagerMeeting />
             </VerboseMockedProvider>
           )
@@ -30,7 +30,7 @@ describe('TwoPagerMeeting', () => {
     );
 
     const { asFragment, getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/Articles/UtilizingSolutions/index.test.tsx
+++ b/src/features/HelpAndKnowledge/Articles/UtilizingSolutions/index.test.tsx
@@ -27,7 +27,7 @@ describe('UtilizingSolutions', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/Articles/_components/ExternalResourceCard/index.test.tsx
+++ b/src/features/HelpAndKnowledge/Articles/_components/ExternalResourceCard/index.test.tsx
@@ -29,7 +29,7 @@ describe('ExternalResourceCard', () => {
     );
 
     render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -70,7 +70,7 @@ describe('ExternalResourceCard', () => {
     );
 
     render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -99,7 +99,7 @@ describe('ExternalResourceCard', () => {
     );
 
     render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -130,7 +130,7 @@ describe('ExternalResourceCard', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/HKCMilestoneLibrary/_components/CommonMilestoneActions/index.test.tsx
+++ b/src/features/HelpAndKnowledge/HKCMilestoneLibrary/_components/CommonMilestoneActions/index.test.tsx
@@ -41,7 +41,7 @@ describe('CommonMilestoneActions', () => {
     );
 
     const { getByText } = render(
-      <MockedProvider addTypename={false}>
+      <MockedProvider>
         <Provider store={storeAssessment}>
           <RouterProvider router={router} />
         </Provider>
@@ -72,7 +72,7 @@ describe('CommonMilestoneActions', () => {
     );
 
     const { getByText } = render(
-      <MockedProvider addTypename={false}>
+      <MockedProvider>
         <Provider store={storeAssessment}>
           <RouterProvider router={router} />
         </Provider>
@@ -101,7 +101,7 @@ describe('CommonMilestoneActions', () => {
     );
 
     render(
-      <MockedProvider addTypename={false}>
+      <MockedProvider>
         <Provider store={storeNotAssessment}>
           <RouterProvider router={router} />
         </Provider>
@@ -127,7 +127,7 @@ describe('CommonMilestoneActions', () => {
     );
 
     const { asFragment, getByText } = render(
-      <MockedProvider addTypename={false}>
+      <MockedProvider>
         <Provider store={storeAssessment}>
           <RouterProvider router={router} />
         </Provider>

--- a/src/features/HelpAndKnowledge/HKCMilestoneLibrary/_components/CommonMilestoneConfirmationModal/index.test.tsx
+++ b/src/features/HelpAndKnowledge/HKCMilestoneLibrary/_components/CommonMilestoneConfirmationModal/index.test.tsx
@@ -28,7 +28,7 @@ describe('CommonMilestoneConfirmationModal Component', () => {
 
   it('renders the edit context correctly', () => {
     const { getByText, getByRole } = render(
-      <MockedProvider addTypename={false}>
+      <MockedProvider>
         <RouterProvider router={renderComponent('edit')} />
       </MockedProvider>
     );
@@ -46,7 +46,7 @@ describe('CommonMilestoneConfirmationModal Component', () => {
 
   it('renders the remove context with error styling', () => {
     const { getByText, getByRole } = render(
-      <MockedProvider addTypename={false}>
+      <MockedProvider>
         <RouterProvider router={renderComponent('remove')} />
       </MockedProvider>
     );
@@ -63,7 +63,7 @@ describe('CommonMilestoneConfirmationModal Component', () => {
 
   it('matches snapshot', () => {
     const { asFragment } = render(
-      <MockedProvider addTypename={false}>
+      <MockedProvider>
         <RouterProvider router={renderComponent('edit')} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/HKCMilestoneLibrary/_components/CommonMilestoneForm/index.test.tsx
+++ b/src/features/HelpAndKnowledge/HKCMilestoneLibrary/_components/CommonMilestoneForm/index.test.tsx
@@ -35,7 +35,7 @@ describe('Manage Common Milestone form', () => {
     );
 
     const { getByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -78,7 +78,7 @@ describe('Manage Common Milestone form', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -119,7 +119,7 @@ describe('Manage Common Milestone form', () => {
     );
 
     const { queryByText, asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/HKCMilestoneLibrary/_components/CommonMilestoneSidePanel/index.test.tsx
+++ b/src/features/HelpAndKnowledge/HKCMilestoneLibrary/_components/CommonMilestoneSidePanel/index.test.tsx
@@ -71,7 +71,7 @@ describe('CommonMilestoneSidePanel', () => {
 
   it('should render side panel in add mode accordingly', async () => {
     const { getByText, getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={addRouterConfig(true)} />
         </Provider>
@@ -87,7 +87,7 @@ describe('CommonMilestoneSidePanel', () => {
 
   it('should render side panel in edit mode accordingly', async () => {
     const { getByText, getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={editRouterConfig(true)} />
         </Provider>
@@ -103,7 +103,7 @@ describe('CommonMilestoneSidePanel', () => {
 
   it('matches snapshot', async () => {
     const { getByTestId, getByRole, baseElement } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={addRouterConfig(true)} />
         </Provider>

--- a/src/features/HelpAndKnowledge/HKCMilestoneLibrary/index.test.tsx
+++ b/src/features/HelpAndKnowledge/HKCMilestoneLibrary/index.test.tsx
@@ -46,10 +46,7 @@ describe('HKC Milestone library Component', () => {
     );
 
     const { getByTestId, findByRole, asFragment } = render(
-      <MockedProvider
-        mocks={[...commonMilestonesLibraryMock]}
-        addTypename={false}
-      >
+      <MockedProvider mocks={[...commonMilestonesLibraryMock]}>
         <Provider store={store2}>
           <RouterProvider router={router} />
         </Provider>
@@ -80,10 +77,7 @@ describe('HKC Milestone library Component', () => {
     );
 
     const { getByRole, getByTestId } = render(
-      <MockedProvider
-        mocks={[...commonMilestonesLibraryMock]}
-        addTypename={false}
-      >
+      <MockedProvider mocks={[...commonMilestonesLibraryMock]}>
         <Provider store={store2}>
           <RouterProvider router={router} />
         </Provider>
@@ -113,10 +107,7 @@ describe('HKC Milestone library Component', () => {
     );
 
     const { getByText } = render(
-      <MockedProvider
-        mocks={[...commonMilestonesLibraryMock]}
-        addTypename={false}
-      >
+      <MockedProvider mocks={[...commonMilestonesLibraryMock]}>
         <Provider store={store1}>
           <RouterProvider router={router} />
         </Provider>

--- a/src/features/HelpAndKnowledge/KeyContactDirectory/_components/CategoryModal/index.test.tsx
+++ b/src/features/HelpAndKnowledge/KeyContactDirectory/_components/CategoryModal/index.test.tsx
@@ -13,7 +13,7 @@ describe('CategoryModal Component', () => {
     <CategoryModal isOpen closeModal={() => {}} mode="add" />;
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={keyContactCategoriesMock} addTypename={false}>
+      <MockedProvider mocks={keyContactCategoriesMock}>
         <CategoryModal isOpen closeModal={() => {}} mode="add" />
       </MockedProvider>
     );
@@ -30,7 +30,7 @@ describe('CategoryModal Component', () => {
 
   it('should render edit key contact category when in edit mode', () => {
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={keyContactCategoriesMock} addTypename={false}>
+      <MockedProvider mocks={keyContactCategoriesMock}>
         <CategoryModal
           isOpen
           closeModal={() => {}}
@@ -47,7 +47,7 @@ describe('CategoryModal Component', () => {
 
   it('matches snapshot', () => {
     render(
-      <MockedProvider mocks={keyContactCategoriesMock} addTypename={false}>
+      <MockedProvider mocks={keyContactCategoriesMock}>
         <CategoryModal isOpen closeModal={() => {}} mode="add" />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/KeyContactDirectory/_components/KeyContactTable/__snapshots__/index.test.tsx.snap
+++ b/src/features/HelpAndKnowledge/KeyContactDirectory/_components/KeyContactTable/__snapshots__/index.test.tsx.snap
@@ -102,6 +102,7 @@ exports[`KeyContactTable > matches snapshot 1`] = `
           >
             Aliza Kim (aliza.kim@cms.hhs.gov
             <svg
+              aria-hidden="true"
               class="usa-icon margin-left-05 text-tbottom"
               focusable="false"
               height="1em"
@@ -139,6 +140,7 @@ exports[`KeyContactTable > matches snapshot 1`] = `
           >
             pstm team mailbox (pstm@example.com
             <svg
+              aria-hidden="true"
               class="usa-icon margin-left-05 text-tbottom"
               focusable="false"
               height="1em"

--- a/src/features/HelpAndKnowledge/KeyContactDirectory/_components/KeyContactTable/index.tsx
+++ b/src/features/HelpAndKnowledge/KeyContactDirectory/_components/KeyContactTable/index.tsx
@@ -108,7 +108,11 @@ const KeyContactTable = ({
               target="_blank"
             >
               {name} ({email}
-              <Icon.MailOutline className="margin-left-05 text-tbottom" />)
+              <Icon.MailOutline
+                className="margin-left-05 text-tbottom"
+                aria-hidden
+              />
+              )
             </Link>
           );
         }

--- a/src/features/HelpAndKnowledge/KeyContactDirectory/_components/RemoveModal/index.test.tsx
+++ b/src/features/HelpAndKnowledge/KeyContactDirectory/_components/RemoveModal/index.test.tsx
@@ -14,7 +14,7 @@ const mocks = [...keyContactsMock];
 describe('RemoveModal Component', () => {
   it('should render sme context when given key contact', () => {
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RemoveModal
           isModalOpen
           closeModal={() => {}}
@@ -35,7 +35,7 @@ describe('RemoveModal Component', () => {
 
   it('should render category context when given key contact category', () => {
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RemoveModal
           isModalOpen
           closeModal={() => {}}
@@ -57,7 +57,7 @@ describe('RemoveModal Component', () => {
 
   it('matches snapshot', () => {
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RemoveModal
           isModalOpen
           closeModal={() => {}}

--- a/src/features/HelpAndKnowledge/KeyContactDirectory/_components/SmeForm/index.test.tsx
+++ b/src/features/HelpAndKnowledge/KeyContactDirectory/_components/SmeForm/index.test.tsx
@@ -28,7 +28,7 @@ describe('Sme form', () => {
       }
     );
     const { getByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -64,7 +64,7 @@ describe('Sme form', () => {
       }
     );
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/KeyContactDirectory/_components/SmeModal/index.test.tsx
+++ b/src/features/HelpAndKnowledge/KeyContactDirectory/_components/SmeModal/index.test.tsx
@@ -43,7 +43,7 @@ describe('SmeModal Component', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -75,7 +75,7 @@ describe('SmeModal Component', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -88,7 +88,7 @@ describe('SmeModal Component', () => {
 
   it('matches snapshot', () => {
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <SmeModal isOpen closeModal={() => {}} mode="addWithoutCategory" />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/ModelUsage/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/ModelUsage/index.test.tsx
@@ -63,7 +63,7 @@ describe('Operational Solutions Model Usage Components', () => {
         {
           path: '/help-and-knowledge/operational-solutions',
           element: (
-            <MockedProvider mocks={modelUsageMock} addTypename={false}>
+            <MockedProvider mocks={modelUsageMock}>
               <ModelUsage solution={helpSolutions.AMS} />
             </MockedProvider>
           )

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/PointsOfContact/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/PointsOfContact/index.test.tsx
@@ -19,7 +19,7 @@ describe('Operational Solutions Points of Contact Components', () => {
           {
             path: '/help-and-knowledge/operational-solutions',
             element: (
-              <VerboseMockedProvider mocks={mocks} addTypename={false}>
+              <VerboseMockedProvider mocks={mocks}>
                 <PointsOfContact solution={solutionPoCComponent} />
               </VerboseMockedProvider>
             )

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/BCDA/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/BCDA/index.test.tsx
@@ -26,7 +26,7 @@ describe('The MTOWarning component', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/ModelUsage/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/ModelUsage/index.test.tsx
@@ -62,7 +62,7 @@ describe('Operational Solutions Model Usage Components', () => {
         {
           path: '/help-and-knowledge/operational-solutions',
           element: (
-            <MockedProvider mocks={modelUsageMock} addTypename={false}>
+            <MockedProvider mocks={modelUsageMock}>
               <GenericModelUsage solution={helpSolutions.AMS} />
             </MockedProvider>
           )

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/ContractorCard/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/ContractorCard/index.test.tsx
@@ -39,7 +39,7 @@ describe('ContractorCard Component', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/ContractorForm/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/ContractorForm/index.test.tsx
@@ -43,7 +43,7 @@ describe('Contractor form', () => {
       }
     );
     const { getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -78,7 +78,7 @@ describe('Contractor form', () => {
       }
     );
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/ContractorModal/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/ContractorModal/index.test.tsx
@@ -55,7 +55,7 @@ describe('ContractorModal Component', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -88,7 +88,7 @@ describe('ContractorModal Component', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -121,7 +121,7 @@ describe('ContractorModal Component', () => {
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/Contractors/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/Contractors/index.test.tsx
@@ -47,7 +47,7 @@ describe('Contractors Component', () => {
     );
 
     const { queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -77,7 +77,7 @@ describe('Contractors Component', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxAndTeamMemberCard/__snapshots__/index.test.tsx.snap
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxAndTeamMemberCard/__snapshots__/index.test.tsx.snap
@@ -78,6 +78,7 @@ exports[`MailboxAndTeamMemberCard Component > should matches snapshot 1`] = `
           >
             aliza.kim@cms.hhs.gov
             <svg
+              aria-hidden="true"
               class="usa-icon margin-left-05 margin-bottom-1px text-tbottom"
               focusable="false"
               height="1em"

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxAndTeamMemberCard/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxAndTeamMemberCard/index.test.tsx
@@ -45,7 +45,7 @@ describe('MailboxAndTeamMemberCard Component', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxAndTeamMemberCard/index.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxAndTeamMemberCard/index.tsx
@@ -99,7 +99,10 @@ const MailboxAndTeamMemberCard = ({
           >
             {pointOfContact.email}
 
-            <Icon.MailOutline className="margin-left-05 margin-bottom-1px text-tbottom" />
+            <Icon.MailOutline
+              className="margin-left-05 margin-bottom-1px text-tbottom"
+              aria-hidden
+            />
           </Link>
         </CardBody>
         {pointOfContact.isPrimary && (

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxAndTeamMemberModal/__snapshots__/index.test.tsx.snap
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxAndTeamMemberModal/__snapshots__/index.test.tsx.snap
@@ -287,6 +287,7 @@ exports[`MailboxAndTeamMemberModal Component > matches snapshot 1`] = `
                 type="button"
               >
                 <svg
+                  aria-label="info"
                   class="usa-icon minw-4 text-base-light margin-left-neg-05 margin-bottom-neg-2px"
                   focusable="false"
                   height="1em"

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxAndTeamMemberModal/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxAndTeamMemberModal/index.test.tsx
@@ -55,7 +55,7 @@ describe('MailboxAndTeamMemberModal Component', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -90,7 +90,7 @@ describe('MailboxAndTeamMemberModal Component', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -125,7 +125,7 @@ describe('MailboxAndTeamMemberModal Component', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -160,7 +160,7 @@ describe('MailboxAndTeamMemberModal Component', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -195,7 +195,7 @@ describe('MailboxAndTeamMemberModal Component', () => {
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxesAndTeamMembers/__snapshots__/index.test.tsx.snap
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxesAndTeamMembers/__snapshots__/index.test.tsx.snap
@@ -134,6 +134,7 @@ exports[`MailboxAndTeamMembers Component > matches snapshot 1`] = `
             >
               aliza.kim@cms.hhs.gov
               <svg
+                aria-hidden="true"
                 class="usa-icon margin-left-05 margin-bottom-1px text-tbottom"
                 focusable="false"
                 height="1em"
@@ -256,6 +257,7 @@ exports[`MailboxAndTeamMembers Component > matches snapshot 1`] = `
             >
               zinnia.purple@cms.hhs.gov
               <svg
+                aria-hidden="true"
                 class="usa-icon margin-left-05 margin-bottom-1px text-tbottom"
                 focusable="false"
                 height="1em"

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxesAndTeamMembers/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/MailboxesAndTeamMembers/index.test.tsx
@@ -59,7 +59,7 @@ describe('MailboxAndTeamMembers Component', () => {
     );
 
     const { getAllByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -89,7 +89,7 @@ describe('MailboxAndTeamMembers Component', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/OwnerCard/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/OwnerCard/index.test.tsx
@@ -42,7 +42,7 @@ describe('Owners Component', () => {
       }
     );
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/OwnerForm/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/OwnerForm/index.test.tsx
@@ -47,7 +47,7 @@ describe('Owner Form Component', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -79,7 +79,7 @@ describe('Owner Form Component', () => {
       }
     );
     const { getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/OwnerModal/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/OwnerModal/index.test.tsx
@@ -51,7 +51,7 @@ describe('Owner Modal Component', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -93,7 +93,7 @@ describe('Owner Modal Component', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/Owners/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/Owners/index.test.tsx
@@ -50,7 +50,7 @@ describe('Owners Component', () => {
       }
     );
     const { queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -81,7 +81,7 @@ describe('Owners Component', () => {
       }
     );
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/RemoveContactModal/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/RemoveContactModal/index.test.tsx
@@ -76,7 +76,7 @@ describe('RemoveContactModal Component', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -109,7 +109,7 @@ describe('RemoveContactModal Component', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -144,7 +144,7 @@ describe('RemoveContactModal Component', () => {
     );
 
     const { getByText, queryByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -181,7 +181,7 @@ describe('RemoveContactModal Component', () => {
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/TeamMailboxForm/__snapshots__/index.test.tsx.snap
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/TeamMailboxForm/__snapshots__/index.test.tsx.snap
@@ -104,6 +104,7 @@ exports[`Team mailbox point of contact form > should matches snapshot 1`] = `
               type="button"
             >
               <svg
+                aria-label="info"
                 class="usa-icon minw-4 text-base-light margin-left-neg-05 margin-bottom-neg-2px"
                 focusable="false"
                 height="1em"

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/TeamMailboxForm/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/TeamMailboxForm/index.test.tsx
@@ -55,7 +55,7 @@ describe('Team mailbox point of contact form', () => {
     );
 
     const { getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -95,7 +95,7 @@ describe('Team mailbox point of contact form', () => {
     );
 
     const { getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -131,7 +131,7 @@ describe('Team mailbox point of contact form', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/TeamMailboxForm/index.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/TeamMailboxForm/index.tsx
@@ -253,7 +253,10 @@ const TeamMailboxForm = ({
                       className="bg-white padding-0 text-base-dark"
                       style={{ gap: '0.25rem' }}
                     >
-                      <Icon.Info className="minw-4 text-base-light margin-left-neg-05 margin-bottom-neg-2px" />
+                      <Icon.Info
+                        className="minw-4 text-base-light margin-left-neg-05 margin-bottom-neg-2px"
+                        aria-label="info"
+                      />
                     </Tooltip>
                   }
                 />

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/TeamMemberForm/__snapshots__/index.test.tsx.snap
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/TeamMemberForm/__snapshots__/index.test.tsx.snap
@@ -228,6 +228,7 @@ exports[`Team member point of contact form > should matches snapshot 1`] = `
               type="button"
             >
               <svg
+                aria-label="info"
                 class="usa-icon minw-4 text-base-light margin-left-neg-05 margin-bottom-neg-2px"
                 focusable="false"
                 height="1em"

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/TeamMemberForm/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/TeamMemberForm/index.test.tsx
@@ -49,7 +49,7 @@ describe('Team member point of contact form', () => {
       }
     );
     const { getByTestId, getByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -88,7 +88,7 @@ describe('Team member point of contact form', () => {
       }
     );
     const { getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -123,7 +123,7 @@ describe('Team member point of contact form', () => {
       }
     );
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/TeamMemberForm/index.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/Solutions/Generic/_components/TeamMemberForm/index.tsx
@@ -273,7 +273,10 @@ const TeamMemberForm = ({
                       className="bg-white padding-0 text-base-dark"
                       style={{ gap: '0.25rem' }}
                     >
-                      <Icon.Info className="minw-4 text-base-light margin-left-neg-05 margin-bottom-neg-2px" />
+                      <Icon.Info
+                        className="minw-4 text-base-light margin-left-neg-05 margin-bottom-neg-2px"
+                        aria-label="info"
+                      />
                     </Tooltip>
                   }
                 />

--- a/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/_components/Contact/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/SolutionDetails/_components/Contact/index.test.tsx
@@ -42,7 +42,7 @@ describe('Operation Solution Contact', () => {
     );
 
     const { getByText } = render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -69,7 +69,7 @@ describe('Operation Solution Contact', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/HelpAndKnowledge/SolutionsHelp/_components/SolutionHelpCard/index.test.tsx
+++ b/src/features/HelpAndKnowledge/SolutionsHelp/_components/SolutionHelpCard/index.test.tsx
@@ -23,7 +23,7 @@ describe('Operation Solution Help Card', () => {
         {
           path: '/help-and-knowledge/operational-solutions',
           element: (
-            <VerboseMockedProvider mocks={mocks} addTypename={false}>
+            <VerboseMockedProvider mocks={mocks}>
               <SolutionHelpCard solution={solutionToTest} />
             </VerboseMockedProvider>
           )
@@ -47,7 +47,7 @@ describe('Operation Solution Help Card', () => {
         {
           path: '/help-and-knowledge/operational-solutions',
           element: (
-            <VerboseMockedProvider mocks={mocks} addTypename={false}>
+            <VerboseMockedProvider mocks={mocks}>
               <SolutionHelpCard solution={solutionToTest} />
             </VerboseMockedProvider>
           )

--- a/src/features/Home/Settings/index.test.tsx
+++ b/src/features/Home/Settings/index.test.tsx
@@ -142,7 +142,7 @@ describe('settings snapshots', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -167,7 +167,7 @@ describe('settings snapshots', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -192,7 +192,7 @@ describe('settings snapshots', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={[...mocks, solutionsMock]} addTypename={false}>
+      <MockedProvider mocks={[...mocks, solutionsMock]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/Home/components/ModelCardTable/__snapshots__/index.test.tsx.snap
+++ b/src/features/Home/components/ModelCardTable/__snapshots__/index.test.tsx.snap
@@ -692,34 +692,34 @@ exports[`ModelsCardTable > matches snapshot with no models 1`] = `
       <div
         class="usa-alert__body"
       >
-        <p
-          class="usa-alert__text"
-        >
-          <span />
-        </p>
         <h3
-          class="margin-0"
+          class="usa-alert__heading"
         >
           There is no record of any  models using this solution.
         </h3>
-        If you believe this is an error, please 
-        <a
-          class="usa-link"
-          data-discover="true"
-          href="/report-a-problem"
-          target="_blank"
+        <p
+          class="usa-alert__text"
         >
-          report a problem
-        </a>
-         or email the MINT Team at 
-        <a
-          class="usa-link"
-          href="mailto:MINTTeam@cms.hhs.gov"
-        >
-          MINTTeam@cms.hhs.gov
-        </a>
-        .
-        <p />
+          <span>
+            If you believe this is an error, please 
+            <a
+              class="usa-link"
+              data-discover="true"
+              href="/report-a-problem"
+              target="_blank"
+            >
+              report a problem
+            </a>
+             or email the MINT Team at 
+            <a
+              class="usa-link"
+              href="mailto:MINTTeam@cms.hhs.gov"
+            >
+              MINTTeam@cms.hhs.gov
+            </a>
+            .
+          </span>
+        </p>
       </div>
     </div>
     <div

--- a/src/features/Home/components/ModelCardTable/index.tsx
+++ b/src/features/Home/components/ModelCardTable/index.tsx
@@ -122,13 +122,12 @@ const ModelsCardTable = ({ models, filterKey, type }: ModelsCardTableProps) => {
 
       {(modelsWithStatus(models, selectedStatus).length === 0 ||
         models.length === 0) && (
-        <Alert type="info">
-          <>
+        <Alert
+          type="info"
+          headingLevel="h3"
+          heading={
             <Trans
               i18nKey="customHome:noModelsHeading"
-              components={{
-                h3: <h3 className="margin-0"> </h3>
-              }}
               values={{
                 status:
                   selectedStatus === 'total'
@@ -140,18 +139,19 @@ const ModelsCardTable = ({ models, filterKey, type }: ModelsCardTableProps) => {
                 article: type === 'solution' ? 'using' : 'in'
               }}
             />
-            <Trans
-              i18nKey="customHome:noModelsDescription"
-              components={{
-                report: (
-                  <UswdsReactLink to="/report-a-problem" target="_blank">
-                    {' '}
-                  </UswdsReactLink>
-                ),
-                email: <Link href="mailto:MINTTeam@cms.hhs.gov"> </Link>
-              }}
-            />
-          </>
+          }
+        >
+          <Trans
+            i18nKey="customHome:noModelsDescription"
+            components={{
+              report: (
+                <UswdsReactLink to="/report-a-problem" target="_blank">
+                  {' '}
+                </UswdsReactLink>
+              ),
+              email: <Link href="mailto:MINTTeam@cms.hhs.gov"> </Link>
+            }}
+          />
         </Alert>
       )}
 

--- a/src/features/Home/components/ModelsByGroup/__snapshots__/index.test.tsx.snap
+++ b/src/features/Home/components/ModelsByGroup/__snapshots__/index.test.tsx.snap
@@ -169,34 +169,34 @@ exports[`ModelsByGroup > matches snapshot 1`] = `
         <div
           class="usa-alert__body"
         >
-          <p
-            class="usa-alert__text"
-          >
-            <span />
-          </p>
           <h3
-            class="margin-0"
+            class="usa-alert__heading"
           >
             There is no record of any  models in this group.
           </h3>
-          If you believe this is an error, please 
-          <a
-            class="usa-link"
-            data-discover="true"
-            href="/report-a-problem"
-            target="_blank"
+          <p
+            class="usa-alert__text"
           >
-            report a problem
-          </a>
-           or email the MINT Team at 
-          <a
-            class="usa-link"
-            href="mailto:MINTTeam@cms.hhs.gov"
-          >
-            MINTTeam@cms.hhs.gov
-          </a>
-          .
-          <p />
+            <span>
+              If you believe this is an error, please 
+              <a
+                class="usa-link"
+                data-discover="true"
+                href="/report-a-problem"
+                target="_blank"
+              >
+                report a problem
+              </a>
+               or email the MINT Team at 
+              <a
+                class="usa-link"
+                href="mailto:MINTTeam@cms.hhs.gov"
+              >
+                MINTTeam@cms.hhs.gov
+              </a>
+              .
+            </span>
+          </p>
         </div>
       </div>
       <div

--- a/src/features/Home/index.test.tsx
+++ b/src/features/Home/index.test.tsx
@@ -174,7 +174,6 @@ describe('The home page', () => {
           ...modelPlanCollectionMock(ModelPlanFilter.INCLUDE_ALL),
           ...modelPlanCollectionMock(ModelPlanFilter.COLLAB_ONLY)
         ]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </VerboseMockedProvider>
@@ -223,7 +222,6 @@ describe('The home page', () => {
           ...modelPlanCollectionMock(ModelPlanFilter.INCLUDE_ALL),
           ...modelPlanCollectionMock(ModelPlanFilter.COLLAB_ONLY)
         ]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </MockedProvider>
@@ -264,7 +262,6 @@ describe('The home page', () => {
           ...modelPlanCollectionMock(ModelPlanFilter.INCLUDE_ALL),
           ...modelPlanCollectionMock(ModelPlanFilter.COLLAB_ONLY)
         ]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </VerboseMockedProvider>
@@ -318,7 +315,6 @@ describe('The home page', () => {
           ...modelPlanCollectionMock(ModelPlanFilter.INCLUDE_ALL),
           ...modelPlanCollectionMock(ModelPlanFilter.COLLAB_ONLY)
         ]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </VerboseMockedProvider>
@@ -367,7 +363,6 @@ describe('The home page', () => {
           ...modelPlanCollectionMock(ModelPlanFilter.INCLUDE_ALL),
           ...modelPlanCollectionMock(ModelPlanFilter.COLLAB_ONLY)
         ]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </MockedProvider>

--- a/src/features/MilestoneLibrary/MilestoneCard/index.test.tsx
+++ b/src/features/MilestoneLibrary/MilestoneCard/index.test.tsx
@@ -60,7 +60,7 @@ describe('MilestoneCard Component', () => {
     );
 
     const { asFragment, getByText } = render(
-      <MockedProvider mocks={suggestedMilestonesMock} addTypename={false}>
+      <MockedProvider mocks={suggestedMilestonesMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/MilestoneLibrary/MilestonePanel/index.test.tsx
+++ b/src/features/MilestoneLibrary/MilestonePanel/index.test.tsx
@@ -75,7 +75,7 @@ describe('MilestonePanel Component', () => {
     );
 
     const { asFragment, getByText } = render(
-      <MockedProvider mocks={[...possibleSolutionsMock]} addTypename={false}>
+      <MockedProvider mocks={[...possibleSolutionsMock]}>
         <Provider store={store2}>
           <RouterProvider router={router} />
         </Provider>
@@ -117,7 +117,7 @@ describe('MilestonePanel Component', () => {
     );
 
     const { getByText, getByRole } = render(
-      <MockedProvider mocks={[...possibleSolutionsMock]} addTypename={false}>
+      <MockedProvider mocks={[...possibleSolutionsMock]}>
         <Provider store={store1}>
           <RouterProvider router={router} />
         </Provider>

--- a/src/features/ModelPlan/AdditionalQuestionnaires/DataExchangeApproach/AboutCompletingDataExchange/index.test.tsx
+++ b/src/features/ModelPlan/AdditionalQuestionnaires/DataExchangeApproach/AboutCompletingDataExchange/index.test.tsx
@@ -27,7 +27,7 @@ describe('AboutCompletingDataExchange', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={collaboratorsMocks} addTypename={false}>
+      <MockedProvider mocks={collaboratorsMocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/AdditionalQuestionnaires/DataExchangeApproach/CollectingAndSendingData/index.test.tsx
+++ b/src/features/ModelPlan/AdditionalQuestionnaires/DataExchangeApproach/CollectingAndSendingData/index.test.tsx
@@ -67,7 +67,7 @@ describe('CollectingAndSendingData', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mock} addTypename={false}>
+      <MockedProvider mocks={mock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -95,7 +95,7 @@ describe('CollectingAndSendingData', () => {
     );
 
     render(
-      <MockedProvider mocks={mock} addTypename={false}>
+      <MockedProvider mocks={mock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/AdditionalQuestionnaires/DataExchangeApproach/CollectionAndAggregation/index.test.tsx
+++ b/src/features/ModelPlan/AdditionalQuestionnaires/DataExchangeApproach/CollectionAndAggregation/index.test.tsx
@@ -66,7 +66,7 @@ describe('CollectionAndAggregation', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mock} addTypename={false}>
+      <MockedProvider mocks={mock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -94,7 +94,7 @@ describe('CollectionAndAggregation', () => {
     );
 
     render(
-      <MockedProvider mocks={mock} addTypename={false}>
+      <MockedProvider mocks={mock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/AdditionalQuestionnaires/DataExchangeApproach/NewMethologiesAndConsiderations/index.test.tsx
+++ b/src/features/ModelPlan/AdditionalQuestionnaires/DataExchangeApproach/NewMethologiesAndConsiderations/index.test.tsx
@@ -65,7 +65,7 @@ describe('TestComponent', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mock} addTypename={false}>
+      <MockedProvider mocks={mock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/AdditionalQuestionnaires/IddocQuestionnaire/IDDOCMonitoring/index.test.tsx
+++ b/src/features/ModelPlan/AdditionalQuestionnaires/IddocQuestionnaire/IDDOCMonitoring/index.test.tsx
@@ -106,7 +106,7 @@ describe('Model Plan Ops Eval and Learning IDDOC', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={iddocMonitoringMock} addTypename={false}>
+      <MockedProvider mocks={iddocMonitoringMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/AdditionalQuestionnaires/IddocQuestionnaire/IDDOCOperations/index.test.tsx
+++ b/src/features/ModelPlan/AdditionalQuestionnaires/IddocQuestionnaire/IDDOCOperations/index.test.tsx
@@ -66,7 +66,7 @@ describe('Model Plan Ops Eval and Learning IDDOC', () => {
     );
 
     render(
-      <MockedProvider mocks={iddocMock} addTypename={false}>
+      <MockedProvider mocks={iddocMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -102,7 +102,7 @@ describe('Model Plan Ops Eval and Learning IDDOC', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={iddocMock} addTypename={false}>
+      <MockedProvider mocks={iddocMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/AdditionalQuestionnaires/IddocQuestionnaire/IDDOCTesting/index.test.tsx
+++ b/src/features/ModelPlan/AdditionalQuestionnaires/IddocQuestionnaire/IDDOCTesting/index.test.tsx
@@ -64,7 +64,7 @@ describe('Model Plan Ops Eval and Learning IDDOC', () => {
     );
 
     render(
-      <MockedProvider mocks={iddocTestingMock} addTypename={false}>
+      <MockedProvider mocks={iddocTestingMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -100,7 +100,7 @@ describe('Model Plan Ops Eval and Learning IDDOC', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={iddocTestingMock} addTypename={false}>
+      <MockedProvider mocks={iddocTestingMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/CRTDL/CRTDLs/__snapshots__/index.test.tsx.snap
+++ b/src/features/ModelPlan/CRTDL/CRTDLs/__snapshots__/index.test.tsx.snap
@@ -328,7 +328,7 @@ exports[`CR and TDLs page > matches snapshot 1`] = `
                     <p
                       class="text-bold"
                     >
-                      TDL Status
+                      CR Status
                     </p>
                     <p>
                       Open
@@ -340,7 +340,7 @@ exports[`CR and TDLs page > matches snapshot 1`] = `
                     <p
                       class="text-bold"
                     >
-                      Issued date
+                      Implementation Date
                     </p>
                     <p>
                       2022-07-30T05:00:00Z

--- a/src/features/ModelPlan/CRTDL/CRTDLs/index.test.tsx
+++ b/src/features/ModelPlan/CRTDL/CRTDLs/index.test.tsx
@@ -41,7 +41,7 @@ describe('CR and TDLs page', () => {
     );
 
     render(
-      <MockedProvider mocks={echimpCRsAndTDLsMock} addTypename={false}>
+      <MockedProvider mocks={echimpCRsAndTDLsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -76,7 +76,7 @@ describe('CR and TDLs page', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={echimpCRsAndTDLsMock} addTypename={false}>
+      <MockedProvider mocks={echimpCRsAndTDLsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ChangeHistory/components/RecentChanges/index.test.tsx
+++ b/src/features/ModelPlan/ChangeHistory/components/RecentChanges/index.test.tsx
@@ -84,7 +84,7 @@ describe('RecentChanges', () => {
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -108,7 +108,7 @@ describe('RecentChanges', () => {
     );
 
     const { getByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -137,7 +137,7 @@ describe('RecentChanges', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/CollaborationArea/Cards/TeamCard/index.test.tsx
+++ b/src/features/ModelPlan/CollaborationArea/Cards/TeamCard/index.test.tsx
@@ -29,7 +29,7 @@ describe('TeamCard component', () => {
     );
 
     const { asFragment, getByTestId, getByText, queryByTestId } = render(
-      <MockedProvider mocks={collaboratorsMocks} addTypename={false}>
+      <MockedProvider mocks={collaboratorsMocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -65,7 +65,7 @@ describe('TeamCard component', () => {
     );
 
     const { asFragment, getByTestId } = render(
-      <MockedProvider mocks={collaboratorsMocks} addTypename={false}>
+      <MockedProvider mocks={collaboratorsMocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/Collaborators/AddCollaborator/index.test.tsx
+++ b/src/features/ModelPlan/Collaborators/AddCollaborator/index.test.tsx
@@ -29,7 +29,7 @@ describe('Adding a collaborator page', () => {
     );
 
     const { asFragment, getByTestId } = render(
-      <MockedProvider mocks={collaboratorsMocks} addTypename={false}>
+      <MockedProvider mocks={collaboratorsMocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/Collaborators/index.test.tsx
+++ b/src/features/ModelPlan/Collaborators/index.test.tsx
@@ -89,7 +89,7 @@ describe('Collaborator/Team Member page w/table', () => {
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>
@@ -127,7 +127,7 @@ describe('Collaborator/Team Member page w/table', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>

--- a/src/features/ModelPlan/Discussions/index.test.tsx
+++ b/src/features/ModelPlan/Discussions/index.test.tsx
@@ -143,7 +143,7 @@ describe('Discussion Component', () => {
     );
 
     const { getByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>
@@ -177,7 +177,7 @@ describe('Discussion Component', () => {
     );
 
     const { getByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>
@@ -223,7 +223,7 @@ describe('Discussion Component', () => {
     );
 
     const { getByText } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>

--- a/src/features/ModelPlan/Documents/AddDocument/index.test.tsx
+++ b/src/features/ModelPlan/Documents/AddDocument/index.test.tsx
@@ -28,7 +28,7 @@ describe('Model Plan Add Documents page', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/Documents/index.test.tsx
+++ b/src/features/ModelPlan/Documents/index.test.tsx
@@ -104,7 +104,7 @@ describe('Model Plan Documents page', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={documentMocks} addTypename={false}>
+      <MockedProvider mocks={documentMocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>

--- a/src/features/ModelPlan/ModelToOperations/MilestoneLibrary/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/MilestoneLibrary/index.test.tsx
@@ -50,7 +50,6 @@ describe('Milestone library Component', () => {
     const { asFragment } = render(
       <MockedProvider
         mocks={[...suggestedMilestonesMock, ...commonMilestonesMock]}
-        addTypename={false}
       >
         <Provider store={store2}>
           <RouterProvider router={router} />
@@ -84,7 +83,6 @@ describe('Milestone library Component', () => {
     render(
       <MockedProvider
         mocks={[...suggestedMilestonesMock, ...commonMilestonesMock]}
-        addTypename={false}
       >
         <Provider store={store2}>
           <RouterProvider router={router} />
@@ -119,7 +117,6 @@ describe('Milestone library Component', () => {
     render(
       <MockedProvider
         mocks={[...suggestedMilestonesMock, ...commonMilestonesMock]}
-        addTypename={false}
       >
         <Provider store={store1}>
           <RouterProvider router={router} />

--- a/src/features/ModelPlan/ModelToOperations/SolutionLibrary/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/SolutionLibrary/index.test.tsx
@@ -35,7 +35,6 @@ describe('SolutionLibrary Component', () => {
     const { asFragment, getByText } = render(
       <MockedProvider
         mocks={[...commonSolutionsMock, ...possibleSolutionsMock]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </MockedProvider>

--- a/src/features/ModelPlan/ModelToOperations/_components/ActionsMenu/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/ActionsMenu/index.test.tsx
@@ -83,7 +83,6 @@ describe('Component', () => {
           ...categoryMock,
           ...allMTOSolutionsMock
         ]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </MockedProvider>

--- a/src/features/ModelPlan/ModelToOperations/_components/ActionsTable/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/ActionsTable/index.test.tsx
@@ -41,7 +41,6 @@ describe('MTO Table Actions Component', () => {
           ...commonMilestonesMock,
           ...commonMilestonesMock
         ]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </MockedProvider>

--- a/src/features/ModelPlan/ModelToOperations/_components/AddCommonMilestoneForm/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/AddCommonMilestoneForm/index.test.tsx
@@ -49,7 +49,7 @@ describe('Add common milestone form', () => {
     );
 
     const { asFragment } = render(
-      <VerboseMockedProvider mocks={[]} addTypename={false}>
+      <VerboseMockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </VerboseMockedProvider>
     );

--- a/src/features/ModelPlan/ModelToOperations/_components/AddCustomCategoryForm/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/AddCustomCategoryForm/index.test.tsx
@@ -29,7 +29,7 @@ describe('Custom Catergory form', () => {
     );
 
     const { asFragment } = render(
-      <VerboseMockedProvider mocks={[...[...categoryMock]]} addTypename={false}>
+      <VerboseMockedProvider mocks={[...[...categoryMock]]}>
         <RouterProvider router={router} />
       </VerboseMockedProvider>
     );

--- a/src/features/ModelPlan/ModelToOperations/_components/AddCustomMilestoneForm/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/AddCustomMilestoneForm/index.test.tsx
@@ -76,7 +76,7 @@ describe('Custom Milestone form', () => {
     );
 
     const { getAllByTestId, getByTestId, asFragment } = render(
-      <VerboseMockedProvider mocks={mocks} addTypename={false}>
+      <VerboseMockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </VerboseMockedProvider>
     );

--- a/src/features/ModelPlan/ModelToOperations/_components/AddCustomSolutionForm/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/AddCustomSolutionForm/index.test.tsx
@@ -30,7 +30,7 @@ describe('Custom Solution form', () => {
     );
 
     const { getAllByTestId, getByTestId, asFragment } = render(
-      <VerboseMockedProvider mocks={[...categoryMock]} addTypename={false}>
+      <VerboseMockedProvider mocks={[...categoryMock]}>
         <RouterProvider router={router} />
       </VerboseMockedProvider>
     );

--- a/src/features/ModelPlan/ModelToOperations/_components/AddTemplateModal/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/AddTemplateModal/index.test.tsx
@@ -125,7 +125,7 @@ const renderWithTemplate = (
   };
 
   return render(
-    <MockedProvider mocks={mocks} addTypename={false}>
+    <MockedProvider mocks={mocks}>
       <TestWrapperWithRouter />
     </MockedProvider>
   );
@@ -140,7 +140,7 @@ describe('AddTemplateModal', () => {
     const router = createMockRouter();
 
     const { asFragment } = render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ModelToOperations/_components/AddToExistingMilestoneForm/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/AddToExistingMilestoneForm/index.test.tsx
@@ -36,7 +36,7 @@ describe('Custom Catergory form', () => {
     );
 
     render(
-      <VerboseMockedProvider mocks={[allMilestonesMock]} addTypename={false}>
+      <VerboseMockedProvider mocks={[allMilestonesMock]}>
         <RouterProvider router={router} />
       </VerboseMockedProvider>
     );
@@ -83,7 +83,7 @@ describe('Custom Catergory form', () => {
     );
 
     const { asFragment } = render(
-      <VerboseMockedProvider mocks={[allMilestonesMock]} addTypename={false}>
+      <VerboseMockedProvider mocks={[allMilestonesMock]}>
         <RouterProvider router={router} />
       </VerboseMockedProvider>
     );

--- a/src/features/ModelPlan/ModelToOperations/_components/EditCategoryTitleForm/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/EditCategoryTitleForm/index.test.tsx
@@ -30,7 +30,7 @@ describe('Custom Catergory form', () => {
     );
 
     const { asFragment } = render(
-      <VerboseMockedProvider mocks={[...[...categoryMock]]} addTypename={false}>
+      <VerboseMockedProvider mocks={[...[...categoryMock]]}>
         <RouterProvider router={router} />
       </VerboseMockedProvider>
     );

--- a/src/features/ModelPlan/ModelToOperations/_components/EditMilestoneForm/__snapshots__/index.test.tsx.snap
+++ b/src/features/ModelPlan/ModelToOperations/_components/EditMilestoneForm/__snapshots__/index.test.tsx.snap
@@ -1010,6 +1010,7 @@ exports[`EditMilestoneForm > matches snapshot 1`] = `
                           tabindex="0"
                         >
                           <svg
+                            aria-label="error"
                             class="usa-icon usa-icon--size-3 text-error-dark top-05"
                             focusable="false"
                             height="1em"

--- a/src/features/ModelPlan/ModelToOperations/_components/EditMilestoneForm/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/EditMilestoneForm/index.test.tsx
@@ -58,7 +58,6 @@ describe('EditMilestoneForm', () => {
             ...categoryMock,
             ...allMTOSolutionsMock
           ]}
-          addTypename={false}
         >
           <RouterProvider router={router} />
         </MockedProvider>

--- a/src/features/ModelPlan/ModelToOperations/_components/EditSolutionForm/__snapshots__/index.test.tsx.snap
+++ b/src/features/ModelPlan/ModelToOperations/_components/EditSolutionForm/__snapshots__/index.test.tsx.snap
@@ -661,6 +661,7 @@ exports[`EditSolutionForm Component > renders correctly and matches snapshot 1`]
                             tabindex="0"
                           >
                             <svg
+                              aria-label="error"
                               class="usa-icon usa-icon--size-3 text-error-dark top-05"
                               focusable="false"
                               height="1em"

--- a/src/features/ModelPlan/ModelToOperations/_components/ITSystemsTable/__snapshots__/index.test.tsx.snap
+++ b/src/features/ModelPlan/ModelToOperations/_components/ITSystemsTable/__snapshots__/index.test.tsx.snap
@@ -344,6 +344,7 @@ exports[`ITSystemsTable Component > renders correctly and matches snapshot 1`] =
                       tabindex="0"
                     >
                       <svg
+                        aria-label="error"
                         class="usa-icon usa-icon--size-3 text-error-dark top-05"
                         focusable="false"
                         height="1em"

--- a/src/features/ModelPlan/ModelToOperations/_components/ITSystemsTable/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/ITSystemsTable/index.test.tsx
@@ -35,7 +35,6 @@ describe('ITSystemsTable Component', () => {
     const { asFragment } = render(
       <MockedProvider
         mocks={[...possibleSolutionsMock, ...solutionAndMilestoneMock]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </MockedProvider>

--- a/src/features/ModelPlan/ModelToOperations/_components/LinkSolutionForm/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/LinkSolutionForm/index.test.tsx
@@ -120,7 +120,6 @@ describe('LinkSolutionForm', () => {
           ...categoryMock,
           ...possibleSolutionsMock
         ]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </MockedProvider>

--- a/src/features/ModelPlan/ModelToOperations/_components/MTORiskIndicatorIcon/__snapshots__/index.test.tsx.snap
+++ b/src/features/ModelPlan/ModelToOperations/_components/MTORiskIndicatorIcon/__snapshots__/index.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`MTORiskIndicatorTag Component > renders correctly and matches snapshot 
         tabindex="0"
       >
         <svg
+          aria-label="error"
           class="usa-icon usa-icon--size-3 text-error-dark top-05"
           focusable="false"
           height="1em"

--- a/src/features/ModelPlan/ModelToOperations/_components/MTORiskIndicatorIcon/index.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/MTORiskIndicatorIcon/index.tsx
@@ -23,7 +23,13 @@ export const MTORiskIndicatorTag = ({
   let RiskIcon = <></>;
 
   if (riskIndicator === MtoRiskIndicator.AT_RISK)
-    RiskIcon = <Icon.Error className="text-error-dark top-05" size={3} />;
+    RiskIcon = (
+      <Icon.Error
+        className="text-error-dark top-05"
+        size={3}
+        aria-label="error"
+      />
+    );
 
   if (riskIndicator === MtoRiskIndicator.OFF_TRACK)
     RiskIcon = (

--- a/src/features/ModelPlan/ModelToOperations/_components/MilestoneNoteForm/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/MilestoneNoteForm/index.test.tsx
@@ -29,7 +29,7 @@ describe('MilestoneNoteForm', () => {
   it('renders add form and disables submit when empty', () => {
     render(
       <Provider store={store}>
-        <MockedProvider mocks={[]} addTypename={false}>
+        <MockedProvider mocks={[]}>
           <MilestoneNoteForm {...baseProps} />
         </MockedProvider>
       </Provider>
@@ -53,7 +53,7 @@ describe('MilestoneNoteForm', () => {
   it('matches snapshot', () => {
     const { asFragment } = render(
       <Provider store={store}>
-        <MockedProvider mocks={[]} addTypename={false}>
+        <MockedProvider mocks={[]}>
           <MilestoneNoteForm {...baseProps} />
         </MockedProvider>
       </Provider>

--- a/src/features/ModelPlan/ModelToOperations/_components/MilestoneNotes/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/MilestoneNotes/index.test.tsx
@@ -20,9 +20,7 @@ const renderWithProviders = (ui: React.ReactElement) => {
 
   return render(
     <Provider store={store}>
-      <MockedProvider mocks={[]} addTypename={false}>
-        {ui}
-      </MockedProvider>
+      <MockedProvider mocks={[]}>{ui}</MockedProvider>
     </Provider>
   );
 };

--- a/src/features/ModelPlan/ModelToOperations/_components/MoveSubCategoryForm/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/MoveSubCategoryForm/index.test.tsx
@@ -29,7 +29,7 @@ describe('Custom Catergory form', () => {
     );
 
     const { asFragment } = render(
-      <VerboseMockedProvider mocks={[...[...categoryMock]]} addTypename={false}>
+      <VerboseMockedProvider mocks={[...[...categoryMock]]}>
         <RouterProvider router={router} />
       </VerboseMockedProvider>
     );

--- a/src/features/ModelPlan/ModelToOperations/_components/OptionPanel/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/OptionPanel/index.test.tsx
@@ -394,7 +394,7 @@ describe('MTOOptionsPanel', () => {
     );
 
     render(
-      <MockedProvider mocks={[...mtoTemplateMock]} addTypename={false}>
+      <MockedProvider mocks={[...mtoTemplateMock]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ModelToOperations/_components/RemoveCategoryForm/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/RemoveCategoryForm/index.test.tsx
@@ -31,7 +31,7 @@ describe('Custom Catergory form', () => {
     );
 
     const { asFragment } = render(
-      <VerboseMockedProvider mocks={[...[...categoryMock]]} addTypename={false}>
+      <VerboseMockedProvider mocks={[...[...categoryMock]]}>
         <RouterProvider router={router} />
       </VerboseMockedProvider>
     );

--- a/src/features/ModelPlan/ModelToOperations/_components/SelectSolutionForm/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/SelectSolutionForm/index.test.tsx
@@ -31,7 +31,6 @@ describe('Select a Solution form', () => {
     const { getByText, asFragment } = render(
       <VerboseMockedProvider
         mocks={[...milestoneMock(''), ...allMTOSolutionsMock]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </VerboseMockedProvider>

--- a/src/features/ModelPlan/ModelToOperations/_components/SolutionCard/index.test.tsx
+++ b/src/features/ModelPlan/ModelToOperations/_components/SolutionCard/index.test.tsx
@@ -31,7 +31,7 @@ describe('MTO SolutionCard Component', () => {
     );
 
     const { asFragment, getByText } = render(
-      <MockedProvider mocks={[...possibleSolutionsMock]} addTypename={false}>
+      <MockedProvider mocks={[...possibleSolutionsMock]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/Beneficiaries/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/Beneficiaries/index.test.tsx
@@ -23,7 +23,7 @@ describe('Read Only Model Plan Summary -- Beneficiaries', () => {
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -55,7 +55,7 @@ describe('Read Only Model Plan Summary -- Beneficiaries', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/CRTDLs/__snapshots__/index.test.tsx.snap
+++ b/src/features/ModelPlan/ReadOnly/CRTDLs/__snapshots__/index.test.tsx.snap
@@ -247,7 +247,7 @@ exports[`Read Only CR and TDLs page > matches snapshot 1`] = `
                 <p
                   class="text-bold"
                 >
-                  TDL Status
+                  CR Status
                 </p>
                 <p>
                   Open
@@ -259,7 +259,7 @@ exports[`Read Only CR and TDLs page > matches snapshot 1`] = `
                 <p
                   class="text-bold"
                 >
-                  Issued date
+                  Implementation Date
                 </p>
                 <p>
                   2022-07-30T05:00:00Z

--- a/src/features/ModelPlan/ReadOnly/CRTDLs/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/CRTDLs/index.test.tsx
@@ -41,7 +41,7 @@ describe('Read Only CR and TDLs page', () => {
     );
 
     render(
-      <MockedProvider mocks={echimpCRsAndTDLsMock} addTypename={false}>
+      <MockedProvider mocks={echimpCRsAndTDLsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -75,7 +75,7 @@ describe('Read Only CR and TDLs page', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={echimpCRsAndTDLsMock} addTypename={false}>
+      <MockedProvider mocks={echimpCRsAndTDLsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/DataExchangeapproach/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/DataExchangeapproach/index.test.tsx
@@ -24,7 +24,7 @@ describe('Read view - Data exchange approach', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/Documents/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/Documents/index.test.tsx
@@ -85,7 +85,7 @@ describe('Model Plan Documents page', () => {
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>
@@ -118,7 +118,7 @@ describe('Model Plan Documents page', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>

--- a/src/features/ModelPlan/ReadOnly/GeneralCharacteristics/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/GeneralCharacteristics/index.test.tsx
@@ -24,7 +24,7 @@ describe('Read Only Model Plan Summary -- General Characteristics', () => {
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -54,7 +54,7 @@ describe('Read Only Model Plan Summary -- General Characteristics', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/IDDOCQuestionnaire/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/IDDOCQuestionnaire/index.test.tsx
@@ -26,7 +26,7 @@ describe('Read Only IDDOC Questionnaire', () => {
     );
 
     render(
-      <MockedProvider mocks={iddocQuestionnaireMocks} addTypename={false}>
+      <MockedProvider mocks={iddocQuestionnaireMocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -92,7 +92,7 @@ describe('Read Only IDDOC Questionnaire', () => {
     );
 
     render(
-      <MockedProvider mocks={secondMocks} addTypename={false}>
+      <MockedProvider mocks={secondMocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -140,7 +140,7 @@ describe('Read Only IDDOC Questionnaire', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={iddocQuestionnaireMocks} addTypename={false}>
+      <MockedProvider mocks={iddocQuestionnaireMocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/MTOMilestones/MilestonePanel/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/MTOMilestones/MilestonePanel/index.test.tsx
@@ -36,7 +36,7 @@ describe('MilestonePanel Component', () => {
 
     render(
       <Provider store={store}>
-        <MockedProvider addTypename={false} mocks={milestoneMock('123')}>
+        <MockedProvider mocks={milestoneMock('123')}>
           <RouterProvider router={router} />
         </MockedProvider>
       </Provider>
@@ -79,7 +79,7 @@ describe('MilestonePanel Component', () => {
 
     render(
       <Provider store={store}>
-        <MockedProvider addTypename={false} mocks={noSolutionsMock}>
+        <MockedProvider mocks={noSolutionsMock}>
           <RouterProvider router={router} />
         </MockedProvider>
       </Provider>

--- a/src/features/ModelPlan/ReadOnly/MTOMilestones/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/MTOMilestones/index.test.tsx
@@ -31,10 +31,7 @@ describe('Read view MTO milestones', () => {
     );
 
     render(
-      <MockedProvider
-        mocks={[...mtoMatrixMockFull, ...possibleSolutionsMock]}
-        addTypename={false}
-      >
+      <MockedProvider mocks={[...mtoMatrixMockFull, ...possibleSolutionsMock]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/MTOSolutions/SolutionPanel/__snapshots__/index.test.tsx.snap
+++ b/src/features/ModelPlan/ReadOnly/MTOSolutions/SolutionPanel/__snapshots__/index.test.tsx.snap
@@ -245,6 +245,7 @@ exports[`SolutionPanel Component > renders correctly with solution data 1`] = `
                     tabindex="0"
                   >
                     <svg
+                      aria-label="error"
                       class="usa-icon usa-icon--size-3 text-error-dark top-05"
                       focusable="false"
                       height="1em"
@@ -420,6 +421,7 @@ exports[`SolutionPanel Component > renders correctly with solution data 1`] = `
                   tabindex="0"
                 >
                   <svg
+                    aria-label="error"
                     class="usa-icon usa-icon--size-3 text-error-dark top-05"
                     focusable="false"
                     height="1em"

--- a/src/features/ModelPlan/ReadOnly/MTOSolutions/SolutionPanel/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/MTOSolutions/SolutionPanel/index.test.tsx
@@ -24,7 +24,7 @@ describe('SolutionPanel Component', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider addTypename={false} mocks={[solutionMock('1')]}>
+      <MockedProvider mocks={[solutionMock('1')]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -63,7 +63,7 @@ describe('SolutionPanel Component', () => {
     );
 
     render(
-      <MockedProvider addTypename={false} mocks={[noSolutionsMock]}>
+      <MockedProvider mocks={[noSolutionsMock]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/MTOSolutions/__snapshots__/index.test.tsx.snap
+++ b/src/features/ModelPlan/ReadOnly/MTOSolutions/__snapshots__/index.test.tsx.snap
@@ -375,6 +375,7 @@ exports[`Read view MTO milestones > matches snapshot 1`] = `
                         tabindex="0"
                       >
                         <svg
+                          aria-label="error"
                           class="usa-icon usa-icon--size-3 text-error-dark top-05"
                           focusable="false"
                           height="1em"

--- a/src/features/ModelPlan/ReadOnly/MTOSolutions/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/MTOSolutions/index.test.tsx
@@ -33,7 +33,6 @@ describe('Read view MTO milestones', () => {
     const { asFragment } = render(
       <MockedProvider
         mocks={[...solutionAndMilestoneMock, ...possibleSolutionsMock]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </MockedProvider>

--- a/src/features/ModelPlan/ReadOnly/ModelBasics/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/ModelBasics/index.test.tsx
@@ -28,7 +28,7 @@ describe('Read Only Model Plan Summary -- Model Basics', () => {
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>
@@ -66,7 +66,7 @@ describe('Read Only Model Plan Summary -- Model Basics', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>

--- a/src/features/ModelPlan/ReadOnly/OpsEvalAndLearning/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/OpsEvalAndLearning/index.test.tsx
@@ -25,7 +25,7 @@ describe('Read Only Model Plan Summary -- Operations, Evaluation, and Learning',
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -59,7 +59,7 @@ describe('Read Only Model Plan Summary -- Operations, Evaluation, and Learning',
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/ParticipantsAndProviders/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/ParticipantsAndProviders/index.test.tsx
@@ -26,7 +26,7 @@ describe('Read Only Model Plan Summary -- Participants And Providers', () => {
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -54,7 +54,7 @@ describe('Read Only Model Plan Summary -- Participants And Providers', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/Payments/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/Payments/index.test.tsx
@@ -21,7 +21,7 @@ describe('Read Only Model Plan Summary -- Payment', () => {
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -46,7 +46,7 @@ describe('Read Only Model Plan Summary -- Payment', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/Team/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/Team/index.test.tsx
@@ -21,7 +21,7 @@ describe('Read Only Model Plan Summary -- Model Basics', () => {
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -47,7 +47,7 @@ describe('Read Only Model Plan Summary -- Model Basics', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/Timeline/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/Timeline/index.test.tsx
@@ -26,7 +26,7 @@ describe('Read Only Model Plan Summary -- Model timeline', () => {
     );
 
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>
@@ -54,7 +54,7 @@ describe('Read Only Model Plan Summary -- Model timeline', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>

--- a/src/features/ModelPlan/ReadOnly/_components/FilterView/Banner/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/_components/FilterView/Banner/index.test.tsx
@@ -36,7 +36,7 @@ describe('Filter View Modal', () => {
       }
     );
     render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -71,7 +71,7 @@ describe('Filter View Modal', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/_components/FilterView/BodyContent/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/_components/FilterView/BodyContent/index.test.tsx
@@ -167,7 +167,7 @@ describe('Read Only Filtered View Body Content', () => {
     );
 
     const { getByTestId } = render(
-      <MockedProvider mocks={mock} addTypename={false}>
+      <MockedProvider mocks={mock}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>

--- a/src/features/ModelPlan/ReadOnly/_components/FilterView/Modal/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/_components/FilterView/Modal/index.test.tsx
@@ -54,7 +54,7 @@ describe('Filter View Modal', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/ReadOnly/_components/TitleAndStatus/index.tsx
+++ b/src/features/ModelPlan/ReadOnly/_components/TitleAndStatus/index.tsx
@@ -100,6 +100,7 @@ const TitleAndStatus = ({
                 <Icon.Edit
                   className="margin-right-1 text-primary mint-no-print"
                   data-testid="edit-icon"
+                  aria-hidden
                 />
 
                 <UswdsReactLink

--- a/src/features/ModelPlan/ReadOnly/index.test.tsx
+++ b/src/features/ModelPlan/ReadOnly/index.test.tsx
@@ -49,7 +49,7 @@ describe('Read Only Model Plan Summary', () => {
     );
 
     const { getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>
@@ -105,7 +105,7 @@ describe('Read Only Model Plan Summary', () => {
     );
 
     const { asFragment, getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>
@@ -148,7 +148,7 @@ describe('Status Tag updates', () => {
     );
 
     const { getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>
@@ -180,7 +180,7 @@ describe('Status Tag updates', () => {
     );
 
     const { getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <Provider store={store}>
           <RouterProvider router={router} />
         </Provider>

--- a/src/features/ModelPlan/Status/index.test.tsx
+++ b/src/features/ModelPlan/Status/index.test.tsx
@@ -28,7 +28,7 @@ describe('Model Plan Status Update page', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/Basics/Overview/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/Basics/Overview/index.test.tsx
@@ -80,7 +80,7 @@ describe('Basics overview page', () => {
     );
 
     const { asFragment, getByTestId } = render(
-      <MockedProvider mocks={mocks} addTypename={false} showWarnings>
+      <MockedProvider mocks={mocks} showWarnings>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/Beneficiaries/BeneficiaryIdentification/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/Beneficiaries/BeneficiaryIdentification/index.test.tsx
@@ -77,7 +77,7 @@ describe('Model Plan Beneficiaries', () => {
     );
 
     render(
-      <MockedProvider mocks={beneficiaryMock} addTypename={false}>
+      <MockedProvider mocks={beneficiaryMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -113,7 +113,7 @@ describe('Model Plan Beneficiaries', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={beneficiaryMock} addTypename={false}>
+      <MockedProvider mocks={beneficiaryMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/Beneficiaries/Frequency/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/Beneficiaries/Frequency/index.test.tsx
@@ -89,7 +89,7 @@ describe('Model Plan Beneficiaries', () => {
     );
 
     render(
-      <MockedProvider mocks={beneficiaryMock} addTypename={false}>
+      <MockedProvider mocks={beneficiaryMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -127,7 +127,7 @@ describe('Model Plan Beneficiaries', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={beneficiaryMock} addTypename={false}>
+      <MockedProvider mocks={beneficiaryMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/Beneficiaries/PeopleImpact/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/Beneficiaries/PeopleImpact/index.test.tsx
@@ -70,7 +70,7 @@ describe('Model Plan Beneficiaries', () => {
     );
 
     render(
-      <MockedProvider mocks={beneficiaryMock} addTypename={false}>
+      <MockedProvider mocks={beneficiaryMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -112,7 +112,7 @@ describe('Model Plan Beneficiaries', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={beneficiaryMock} addTypename={false}>
+      <MockedProvider mocks={beneficiaryMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/GeneralCharacteristics/Authority/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/GeneralCharacteristics/Authority/index.test.tsx
@@ -77,7 +77,7 @@ describe('Model Plan Characteristics', () => {
     );
 
     render(
-      <MockedProvider mocks={authorityMock} addTypename={false}>
+      <MockedProvider mocks={authorityMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -117,7 +117,7 @@ describe('Model Plan Characteristics', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={authorityMock} addTypename={false}>
+      <MockedProvider mocks={authorityMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/GeneralCharacteristics/Involvements/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/GeneralCharacteristics/Involvements/index.test.tsx
@@ -69,7 +69,7 @@ describe('Model Plan Characteristics', () => {
     );
 
     render(
-      <MockedProvider mocks={involvementsMock} addTypename={false}>
+      <MockedProvider mocks={involvementsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -109,7 +109,7 @@ describe('Model Plan Characteristics', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={involvementsMock} addTypename={false}>
+      <MockedProvider mocks={involvementsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/GeneralCharacteristics/KeyCharacteristics/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/GeneralCharacteristics/KeyCharacteristics/index.test.tsx
@@ -82,7 +82,7 @@ describe('Model Plan Characteristics', () => {
     );
 
     render(
-      <MockedProvider mocks={keyCharacteristicsMock} addTypename={false}>
+      <MockedProvider mocks={keyCharacteristicsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -124,7 +124,7 @@ describe('Model Plan Characteristics', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={keyCharacteristicsMock} addTypename={false}>
+      <MockedProvider mocks={keyCharacteristicsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/GeneralCharacteristics/ModelRelation/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/GeneralCharacteristics/ModelRelation/index.test.tsx
@@ -155,7 +155,6 @@ describe('Model Plan Characteristics', () => {
           ...modelPlanCollectionMock,
           ...existingModelPlanMock
         ]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </MockedProvider>
@@ -216,7 +215,6 @@ describe('Model Plan Characteristics', () => {
           ...modelPlanCollectionMock,
           ...existingModelPlanMock
         ]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </MockedProvider>

--- a/src/features/ModelPlan/TaskList/GeneralCharacteristics/TargetsAndOptions/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/GeneralCharacteristics/TargetsAndOptions/index.test.tsx
@@ -82,7 +82,7 @@ describe('Model Plan Characteristics', () => {
     );
 
     render(
-      <MockedProvider mocks={targetsAndOptionsMock} addTypename={false}>
+      <MockedProvider mocks={targetsAndOptionsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -120,7 +120,7 @@ describe('Model Plan Characteristics', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={targetsAndOptionsMock} addTypename={false}>
+      <MockedProvider mocks={targetsAndOptionsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/OpsEvalAndLearning/CCWAndQuality/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/OpsEvalAndLearning/CCWAndQuality/index.test.tsx
@@ -87,7 +87,7 @@ describe('Model Plan Ops Eval and Learning CCW and Qualtiy', () => {
     );
 
     render(
-      <MockedProvider mocks={ccwAndQualityMock} addTypename={false}>
+      <MockedProvider mocks={ccwAndQualityMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -125,7 +125,7 @@ describe('Model Plan Ops Eval and Learning CCW and Qualtiy', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={ccwAndQualityMock} addTypename={false}>
+      <MockedProvider mocks={ccwAndQualityMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/OpsEvalAndLearning/DataSharing/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/OpsEvalAndLearning/DataSharing/index.test.tsx
@@ -84,7 +84,7 @@ describe('Model Plan Ops Eval and Learning Data Sharing', () => {
     );
 
     render(
-      <MockedProvider mocks={dataSharingMock} addTypename={false}>
+      <MockedProvider mocks={dataSharingMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -122,7 +122,7 @@ describe('Model Plan Ops Eval and Learning Data Sharing', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={dataSharingMock} addTypename={false}>
+      <MockedProvider mocks={dataSharingMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/OpsEvalAndLearning/Evaluation/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/OpsEvalAndLearning/Evaluation/index.test.tsx
@@ -83,7 +83,7 @@ describe('Model Plan Ops Eval and Learning', () => {
     );
 
     render(
-      <MockedProvider mocks={evaluationMock} addTypename={false}>
+      <MockedProvider mocks={evaluationMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -121,7 +121,7 @@ describe('Model Plan Ops Eval and Learning', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={evaluationMock} addTypename={false}>
+      <MockedProvider mocks={evaluationMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/OpsEvalAndLearning/Learning/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/OpsEvalAndLearning/Learning/index.test.tsx
@@ -82,7 +82,7 @@ describe('Model Plan Ops Eval and Learning - Learning', () => {
     );
 
     render(
-      <MockedProvider mocks={learningMock} addTypename={false}>
+      <MockedProvider mocks={learningMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -122,7 +122,7 @@ describe('Model Plan Ops Eval and Learning - Learning', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={learningMock} addTypename={false}>
+      <MockedProvider mocks={learningMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/OpsEvalAndLearning/Performance/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/OpsEvalAndLearning/Performance/index.test.tsx
@@ -85,7 +85,7 @@ describe('Model Plan Ops Eval and Learning Performance', () => {
     );
 
     render(
-      <MockedProvider mocks={performanceMock} addTypename={false}>
+      <MockedProvider mocks={performanceMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -123,7 +123,7 @@ describe('Model Plan Ops Eval and Learning Performance', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={performanceMock} addTypename={false}>
+      <MockedProvider mocks={performanceMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/OpsEvalAndLearning/Support/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/OpsEvalAndLearning/Support/index.test.tsx
@@ -115,7 +115,7 @@ describe('Model Plan Ops Eval and Learning', () => {
     );
 
     render(
-      <MockedProvider mocks={opsEvalAndLearningMock} addTypename={false}>
+      <MockedProvider mocks={opsEvalAndLearningMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -153,7 +153,7 @@ describe('Model Plan Ops Eval and Learning', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={opsEvalAndLearningMock} addTypename={false}>
+      <MockedProvider mocks={opsEvalAndLearningMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/ParticipantsAndProviders/Communication/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/ParticipantsAndProviders/Communication/index.test.tsx
@@ -83,7 +83,7 @@ describe('Model Plan Communication', () => {
     );
 
     render(
-      <MockedProvider mocks={communicationMock} addTypename={false}>
+      <MockedProvider mocks={communicationMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -121,7 +121,7 @@ describe('Model Plan Communication', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={communicationMock} addTypename={false}>
+      <MockedProvider mocks={communicationMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/ParticipantsAndProviders/Coordination/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/ParticipantsAndProviders/Coordination/index.test.tsx
@@ -87,7 +87,7 @@ describe('Model Plan Coordination', () => {
     );
 
     render(
-      <MockedProvider mocks={coordinationMock} addTypename={false}>
+      <MockedProvider mocks={coordinationMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -125,7 +125,7 @@ describe('Model Plan Coordination', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={coordinationMock} addTypename={false}>
+      <MockedProvider mocks={coordinationMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/ParticipantsAndProviders/ParticipantOptions/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/ParticipantsAndProviders/ParticipantOptions/index.test.tsx
@@ -76,7 +76,7 @@ describe('Model Plan ParticipantsOptions', () => {
     );
 
     render(
-      <MockedProvider mocks={participantOptionsMock} addTypename={false}>
+      <MockedProvider mocks={participantOptionsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -114,7 +114,7 @@ describe('Model Plan ParticipantsOptions', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={participantOptionsMock} addTypename={false}>
+      <MockedProvider mocks={participantOptionsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/ParticipantsAndProviders/Participants/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/ParticipantsAndProviders/Participants/index.test.tsx
@@ -75,7 +75,7 @@ describe('Model Plan Participants and Providers', () => {
     );
 
     render(
-      <MockedProvider mocks={participantsAndProvidersMock} addTypename={false}>
+      <MockedProvider mocks={participantsAndProvidersMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -123,7 +123,7 @@ describe('Model Plan Participants and Providers', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={participantsAndProvidersMock} addTypename={false}>
+      <MockedProvider mocks={participantsAndProvidersMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/ParticipantsAndProviders/ProviderOptions/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/ParticipantsAndProviders/ProviderOptions/index.test.tsx
@@ -94,7 +94,7 @@ describe('Model Plan ProviderOptions', () => {
     );
 
     render(
-      <MockedProvider mocks={providerOptionsMock} addTypename={false}>
+      <MockedProvider mocks={providerOptionsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -134,7 +134,7 @@ describe('Model Plan ProviderOptions', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={providerOptionsMock} addTypename={false}>
+      <MockedProvider mocks={providerOptionsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/Payment/AnticipateDependencies/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/Payment/AnticipateDependencies/index.test.tsx
@@ -77,7 +77,7 @@ describe('Model Plan -- Anticipate Dependencies', () => {
     );
 
     render(
-      <MockedProvider mocks={paymentsMock} addTypename={false}>
+      <MockedProvider mocks={paymentsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -115,7 +115,7 @@ describe('Model Plan -- Anticipate Dependencies', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={paymentsMock} addTypename={false}>
+      <MockedProvider mocks={paymentsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/Payment/BeneficiaryCostSharing/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/Payment/BeneficiaryCostSharing/index.test.tsx
@@ -69,7 +69,7 @@ describe('Model Plan -- BeneficiaryCostSharing', () => {
     );
 
     render(
-      <MockedProvider mocks={paymentsMock} addTypename={false}>
+      <MockedProvider mocks={paymentsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -113,7 +113,7 @@ describe('Model Plan -- BeneficiaryCostSharing', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={paymentsMock} addTypename={false}>
+      <MockedProvider mocks={paymentsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/Payment/ClaimsBasedPayment/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/Payment/ClaimsBasedPayment/index.test.tsx
@@ -81,7 +81,7 @@ describe('Model Plan -- Claims Based Payment', () => {
     );
 
     render(
-      <MockedProvider mocks={paymentsMock} addTypename={false}>
+      <MockedProvider mocks={paymentsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -119,7 +119,7 @@ describe('Model Plan -- Claims Based Payment', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={paymentsMock} addTypename={false}>
+      <MockedProvider mocks={paymentsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/Payment/Complexity/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/Payment/Complexity/index.test.tsx
@@ -82,7 +82,7 @@ describe('Model Plan -- Complexity', () => {
     );
 
     render(
-      <MockedProvider mocks={paymentsMock} addTypename={false}>
+      <MockedProvider mocks={paymentsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -118,7 +118,7 @@ describe('Model Plan -- Complexity', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={paymentsMock} addTypename={false}>
+      <MockedProvider mocks={paymentsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/Payment/FundingSource/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/Payment/FundingSource/index.test.tsx
@@ -89,7 +89,7 @@ describe('Model Plan Payment', () => {
     );
 
     const { getByTestId } = render(
-      <VerboseMockedProvider mocks={paymentMock} addTypename={false}>
+      <VerboseMockedProvider mocks={paymentMock}>
         <RouterProvider router={router} />
       </VerboseMockedProvider>
     );
@@ -128,7 +128,7 @@ describe('Model Plan Payment', () => {
     );
 
     const { asFragment, getByTestId } = render(
-      <VerboseMockedProvider mocks={paymentMock} addTypename={false}>
+      <VerboseMockedProvider mocks={paymentMock}>
         <RouterProvider router={router} />
       </VerboseMockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/Payment/NonClaimsBasedPayment/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/Payment/NonClaimsBasedPayment/index.test.tsx
@@ -82,7 +82,7 @@ describe('Model Plan -- NonClaimsBasedPayment', () => {
     );
 
     render(
-      <MockedProvider mocks={paymentsMock} addTypename={false}>
+      <MockedProvider mocks={paymentsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -114,7 +114,7 @@ describe('Model Plan -- NonClaimsBasedPayment', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={paymentsMock} addTypename={false}>
+      <MockedProvider mocks={paymentsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/PrepareForClearance/Checklist/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/PrepareForClearance/Checklist/index.test.tsx
@@ -60,7 +60,7 @@ describe('Prepare for clearance checklist', () => {
     );
 
     const { user } = setup(
-      <MockedProvider mocks={clearanceMock} addTypename={false}>
+      <MockedProvider mocks={clearanceMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -109,7 +109,7 @@ describe('Prepare for clearance checklist', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={clearanceMock} addTypename={false}>
+      <MockedProvider mocks={clearanceMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/PrepareForClearance/ClearanceReview/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/PrepareForClearance/ClearanceReview/index.test.tsx
@@ -119,7 +119,7 @@ describe('ClearanceReview component', () => {
     );
 
     const { getByTestId } = render(
-      <MockedProvider mocks={clearanceMocks} addTypename={false}>
+      <MockedProvider mocks={clearanceMocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -151,7 +151,7 @@ describe('ClearanceReview component', () => {
     );
 
     const { getByTestId, user } = setup(
-      <MockedProvider mocks={clearanceMocks} addTypename={false}>
+      <MockedProvider mocks={clearanceMocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -185,7 +185,7 @@ describe('ClearanceReview component', () => {
     );
 
     const { asFragment, getByTestId } = render(
-      <MockedProvider mocks={clearanceMocks} addTypename={false}>
+      <MockedProvider mocks={clearanceMocks}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/_components/TaskListSideNav/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/_components/TaskListSideNav/index.test.tsx
@@ -94,7 +94,7 @@ describe('The TaskListSideNavActions', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={[...changeHistoryMock]} addTypename={false}>
+      <MockedProvider mocks={[...changeHistoryMock]}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ModelPlan/TaskList/index.test.tsx
+++ b/src/features/ModelPlan/TaskList/index.test.tsx
@@ -308,7 +308,6 @@ describe('The Model Plan Task List', () => {
       <Provider store={store}>
         <MockedProvider
           mocks={[modelPlanQuery(modelPlan), ...changeHistoryMock]}
-          addTypename={false}
         >
           <RouterProvider router={router} />
         </MockedProvider>
@@ -343,7 +342,6 @@ describe('The Model Plan Task List', () => {
       <Provider store={store}>
         <MockedProvider
           mocks={[modelPlanQuery(modelPlan), ...changeHistoryMock]}
-          addTypename={false}
         >
           <RouterProvider router={router} />
         </MockedProvider>
@@ -386,7 +384,6 @@ describe('The Model Plan Task List', () => {
       <Provider store={store}>
         <MockedProvider
           mocks={[modelPlanQuery(modelPlan), ...changeHistoryMock]}
-          addTypename={false}
         >
           <RouterProvider router={router} />
         </MockedProvider>
@@ -420,7 +417,6 @@ describe('The Model Plan Task List', () => {
       <Provider store={store}>
         <MockedProvider
           mocks={[modelPlanQuery(modelPlan), ...changeHistoryMock]}
-          addTypename={false}
         >
           <RouterProvider router={router} />
         </MockedProvider>
@@ -460,7 +456,6 @@ describe('The Model Plan Task List', () => {
         <Provider store={store}>
           <MockedProvider
             mocks={[modelPlanQuery(modelPlan), ...changeHistoryMock]}
-            addTypename={false}
           >
             <RouterProvider router={router} />
           </MockedProvider>

--- a/src/features/NDA/index.test.tsx
+++ b/src/features/NDA/index.test.tsx
@@ -27,7 +27,7 @@ describe('NDA Page', () => {
         {
           path: '/pre-decisional-notice',
           element: (
-            <MockedProvider addTypename={false}>
+            <MockedProvider>
               <Provider store={store}>
                 <NDA />
               </Provider>
@@ -62,7 +62,7 @@ describe('NDA Page', () => {
         {
           path: '/pre-decisional-notice',
           element: (
-            <MockedProvider addTypename={false}>
+            <MockedProvider>
               <Provider store={store}>
                 <NDA />
               </Provider>
@@ -99,7 +99,7 @@ describe('NDA Page', () => {
         {
           path: '/pre-decisional-notice',
           element: (
-            <MockedProvider addTypename={false}>
+            <MockedProvider>
               <Provider store={store}>
                 <NDA />
               </Provider>

--- a/src/features/Notifications/Home/_components/IncorrectModelStatus.test.tsx
+++ b/src/features/Notifications/Home/_components/IncorrectModelStatus.test.tsx
@@ -34,9 +34,7 @@ describe('Incorrect Model Status in Notifications', () => {
       }
     );
 
-    const { asFragment } = render(
-      <RouterProvider router={router} addTypename={false} />
-    );
+    const { asFragment } = render(<RouterProvider router={router} />);
 
     await waitFor(() => {
       expect(screen.getByTestId('incorrect-model-status')).toBeInTheDocument();

--- a/src/features/Notifications/Home/index.test.tsx
+++ b/src/features/Notifications/Home/index.test.tsx
@@ -101,7 +101,7 @@ describe('Notification Page', () => {
     );
 
     setup(
-      <MockedProvider mocks={notificationsMock} addTypename={false}>
+      <MockedProvider mocks={notificationsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );
@@ -131,7 +131,7 @@ describe('Notification Page', () => {
     );
 
     const { asFragment } = render(
-      <MockedProvider mocks={notificationsMock} addTypename={false}>
+      <MockedProvider mocks={notificationsMock}>
         <RouterProvider router={router} />
       </MockedProvider>
     );

--- a/src/features/ReportsAndAnalytics/index.test.tsx
+++ b/src/features/ReportsAndAnalytics/index.test.tsx
@@ -37,7 +37,6 @@ describe('ReportsAndAnalytics', () => {
     const { asFragment } = render(
       <MockedProvider
         mocks={[...analyticsSummaryMock, ...mtoMilestoneSummaryMock]}
-        addTypename={false}
       >
         <RouterProvider router={router} />
       </MockedProvider>

--- a/src/hooks/useFetchCSVData.tsx
+++ b/src/hooks/useFetchCSVData.tsx
@@ -12,9 +12,9 @@ import {
 } from 'features/ModelPlan/ReadOnly/_components/FilterView/BodyContent/_filterGroupMapping';
 import {
   GetAllModelDataQuery,
-  GetAllModelDataQueryHookResult,
+  GetAllModelDataQueryResult,
   GetAllSingleModelDataQuery,
-  GetAllSingleModelDataQueryHookResult,
+  GetAllSingleModelDataQueryResult,
   ModelShareSection,
   ModelStatus,
   TeamRole,
@@ -539,10 +539,10 @@ type UseFetchCSVData = {
   fetchSingleData: (
     input: string,
     exportSection?: ExportSection
-  ) => Promise<GetAllSingleModelDataQueryHookResult>;
+  ) => Promise<GetAllSingleModelDataQueryResult>;
   fetchAllData: (
     exportSection?: ExportSection
-  ) => Promise<GetAllModelDataQueryHookResult>;
+  ) => Promise<GetAllModelDataQueryResult>;
   setExportSection: (exportSection: ExportSection) => void;
 };
 

--- a/src/hooks/useFetchCSVData.tsx
+++ b/src/hooks/useFetchCSVData.tsx
@@ -555,41 +555,37 @@ const useFetchCSVData = (): UseFetchCSVData => {
   }, []);
 
   // Get data for a single model plan
-  const [fetchSingleData] = useGetAllSingleModelDataLazyQuery({
-    onCompleted: data => {
-      csvFormatter(
-        data.modelPlan ? [data.modelPlan] : [],
-        allPlanTranslation,
-        exportSectionRef.current
-      );
-    }
-  });
+  const [fetchSingleDataQuery] = useGetAllSingleModelDataLazyQuery();
 
   // Get data for all model plans
-  const [fetchAllData] = useGetAllModelDataLazyQuery({
-    onCompleted: data => {
-      csvFormatter(
-        data.modelPlanCollection || [],
-        allPlanTranslation,
-        exportSectionRef.current
-      );
-    }
-  });
+  const [fetchAllDataQuery] = useGetAllModelDataLazyQuery();
 
   return {
     fetchSingleData: useCallback(
       async (id, exportSection) => {
         if (exportSection) setExportSection(exportSection);
-        return fetchSingleData({ variables: { id } });
+        const result = await fetchSingleDataQuery({ variables: { id } });
+        csvFormatter(
+          result.data?.modelPlan ? [result.data.modelPlan] : [],
+          allPlanTranslation,
+          exportSectionRef.current
+        );
+        return result;
       },
-      [fetchSingleData, setExportSection]
+      [fetchSingleDataQuery, setExportSection, allPlanTranslation]
     ),
     fetchAllData: useCallback(
       async exportSection => {
         if (exportSection) setExportSection(exportSection);
-        return fetchAllData();
+        const result = await fetchAllDataQuery();
+        csvFormatter(
+          result.data?.modelPlanCollection || [],
+          allPlanTranslation,
+          exportSectionRef.current
+        );
+        return result;
       },
-      [fetchAllData, setExportSection]
+      [fetchAllDataQuery, setExportSection, allPlanTranslation]
     ),
     setExportSection
   };

--- a/src/i18n/en-US/home/customHome.ts
+++ b/src/i18n/en-US/home/customHome.ts
@@ -194,7 +194,7 @@ const customHome = {
     tbd: 'To be determined'
   },
   noModelsHeading:
-    '<h3>There is no record of any {{status}} models {{article}} this {{type}}.</h3>',
+    'There is no record of any {{status}} models {{article}} this {{type}}.',
   noModelsDescription:
     'If you believe this is an error, please <report>report a problem</report> or email the MINT Team at <email>MINTTeam@cms.hhs.gov</email>.',
   generalStatus,

--- a/src/tests/MockedProvider.tsx
+++ b/src/tests/MockedProvider.tsx
@@ -44,14 +44,7 @@ const VerboseMockedProvider = (props: Props) => {
   // @ts-ignore
   const link = ApolloLink.from([errorLoggingLink, mockLink]);
 
-  return (
-    <MockedProvider
-      {...otherProps}
-      addTypename={false}
-      mocks={mocks}
-      link={link}
-    />
-  );
+  return <MockedProvider {...otherProps} mocks={mocks} link={link} />;
 };
 
 export default VerboseMockedProvider;

--- a/src/tests/mock/mto.ts
+++ b/src/tests/mock/mto.ts
@@ -354,6 +354,7 @@ export const commonMilestonesMock: MockedResponse<
                 categoryName: 'Test Category',
                 subCategoryName: 'Test SubCategory',
                 facilitatedByRole: [],
+                facilitatedByOther: null,
                 description: 'Description 1',
                 commonSolutions: [
                   {
@@ -604,6 +605,8 @@ export const milestoneMock = (
           responsibleComponent: [],
           facilitatedBy: [],
           facilitatedByOther: '',
+          assignedToPlanCollaborator: null,
+          assignedTo: null,
           needBy: '2021-08-01',
           status: MtoMilestoneStatus.COMPLETED,
           riskIndicator: MtoRiskIndicator.AT_RISK,
@@ -1125,6 +1128,7 @@ export const mtoMilestoneSummaryMock: MockedResponse<
                   id: '123',
                   mtoCommonMilestoneID: '123456',
                   name: 'Test Milestone 1',
+                  description: 'Test Milestone 1 description',
                   needBy: '2022-05-12T15:01:39.190679Z',
                   responsibleComponent: [],
                   facilitatedBy: [MtoFacilitator.MODEL_TEAM],
@@ -1162,10 +1166,12 @@ export const mtoMilestoneSummaryMock: MockedResponse<
                   id: '456',
                   mtoCommonMilestoneID: '123456',
                   name: 'Test Milestone 2',
+                  description: 'Test Milestone 2 description',
                   needBy: '2022-05-12T15:01:39.190679Z',
                   responsibleComponent: [],
                   facilitatedBy: [MtoFacilitator.MODEL_TEAM],
                   facilitatedByOther: 'Test Facilitated By Other',
+                  assignedToPlanCollaborator: null,
                   status: MtoMilestoneStatus.NOT_STARTED,
                   riskIndicator: MtoRiskIndicator.ON_TRACK,
                   notes: []

--- a/src/tests/mock/readonly.ts
+++ b/src/tests/mock/readonly.ts
@@ -195,7 +195,8 @@ export const modelTimelineMocks: MockedResponse<
           basics: {
             __typename: 'PlanBasics',
             id: '123',
-            modelType: [ModelType.MANDATORY_NATIONAL]
+            modelType: [ModelType.MANDATORY_NATIONAL],
+            modelTypeOther: 'Other model'
           },
           timeline: modelTimelineData
         }

--- a/src/tests/mock/readonly.ts
+++ b/src/tests/mock/readonly.ts
@@ -121,7 +121,7 @@ const modelBasicsData: GetAllBasicsTypes = {
     CmmiGroup.POLICY_AND_PROGRAMS_GROUP
   ],
   modelType: [ModelType.MANDATORY_NATIONAL],
-  modelTypeOther: 'Other model',
+  modelTypeOther: null,
   problem: 'There is not enough candy',
   goal: 'To get more candy',
   testInterventions: 'The great candy machine',
@@ -196,7 +196,7 @@ export const modelTimelineMocks: MockedResponse<
             __typename: 'PlanBasics',
             id: '123',
             modelType: [ModelType.MANDATORY_NATIONAL],
-            modelTypeOther: 'Other model'
+            modelTypeOther: null
           },
           timeline: modelTimelineData
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,7 +1142,7 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.0", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.2.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.26.10", "@babel/runtime@^7.27.0", "@babel/runtime@^7.27.6", "@babel/runtime@^7.28.4", "@babel/runtime@^7.28.6", "@babel/runtime@^7.29.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.0", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.2.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.26.10", "@babel/runtime@^7.27.0", "@babel/runtime@^7.27.6", "@babel/runtime@^7.28.4", "@babel/runtime@^7.28.6", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.29.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
   integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
@@ -9938,12 +9938,10 @@ i18next-browser-languagedetector@^8.2.1:
   dependencies:
     "@babel/runtime" "^7.23.2"
 
-i18next@^25.10.4:
-  version "25.10.4"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-25.10.4.tgz#42787a089ed062cb8ca8140d9c30de4ca96ada0a"
-  integrity sha512-XsE/6eawy090meuFU0BTY9BtmWr1m9NSwLr0NK7/A04LA58wdAvDsi9WNOJ40Qb1E9NIPbvnVLZEN2fWDd3/3Q==
-  dependencies:
-    "@babel/runtime" "^7.29.2"
+i18next@^26.3.3:
+  version "26.3.3"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-26.3.3.tgz#acab67bb8608deaf01886a1d573dbd6f2c201b9b"
+  integrity sha512-aYVegyBdXSO93CMMihvr47jI7GHSOcIahMpJX+qzUXDzW4xDJf2uenIA+45vDU+YhiVdcfsql70AC9RVdMNrHg==
 
 iconv-lite@0.6.3:
   version "0.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,26 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@apollo/client@^3.13.9", "@apollo/client@^3.7.0":
+"@apollo/client@^3.14.1":
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.14.1.tgz#98931c8feea4a50c89c32ec0c8ffd04ccaa9416f"
+  integrity sha512-SgGX6E23JsZhUdG2anxiyHvEvvN6CUaI4ZfMsndZFeuHPXL3H0IsaiNAhLITSISbeyeYd+CBd9oERXQDdjXWZw==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    "@wry/caches" "^1.0.0"
+    "@wry/equality" "^0.5.6"
+    "@wry/trie" "^0.5.0"
+    graphql-tag "^2.12.6"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.18.0"
+    prop-types "^15.7.2"
+    rehackt "^0.1.0"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.10.3"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.5"
+
+"@apollo/client@^3.7.0":
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.14.0.tgz#eda34b85ee03c6c0828ba21782419c8699feaf0b"
   integrity sha512-0YQKKRIxiMlIou+SekQqdCo0ZTHxOcES+K8vKB53cIDpwABNR0P0yRzPgsbgcj3zRJniD93S/ontsnZsCLZrxQ==


### PR DESCRIPTION
# NOREF

## Description

This PR reduces noisy console output during tests and resolves related React/accessibility warnings by upgrading dependencies and cleaning up test and component patterns.

### Dependency upgrades
- **i18next** `25.10.4` → `26.3.3` — removes the promotional console message that appeared during test runs
- **@apollo/client** `3.13.9` → `3.14.1` — aligns with current Apollo APIs and removes deprecated options

### Apollo Client 3.14 migration
- Removed deprecated `addTypename={false}` from `MockedProvider` / `VerboseMockedProvider` usage across the test suite (~150+ test files)
- Removed the default `addTypename={false}` from `VerboseMockedProvider`
- Replaced deprecated `useLazyQuery` `onCompleted` callbacks in `useFetchCSVData` with async/await result handling
- Updated GraphQL mocks (`src/tests/mock/mto.ts`, `src/tests/mock/readonly.ts`) and snapshots to match Apollo 3.14's default `__typename` behavior

### Accessibility fixes (icon warnings in tests)
- Added `aria-hidden` to decorative icons (mail icons in Key Contact Directory and Solutions Help, edit icon in Read Only title/status)
- Added `aria-label` to meaningful icons (info tooltips in Team Mailbox/Member forms, error/warning icons in MTO risk indicator)

### HTML nesting fix
- Fixed invalid HTML nesting on the Home page "no models" alert by using the USWDS `Alert` component's `heading` / `headingLevel` props instead of embedding an `<h3>` inside the alert body via `Trans`
- Updated the `customHome:noModelsHeading` i18n string to remove the inline `<h3>` tag

## How to test this change

1. Install dependencies: `yarn install`
2. Run the full test suite and confirm console output is cleaner (no i18next promo message, fewer Apollo/accessibility warnings):
   ```bash
   yarn test
   ```
3. Spot-check CSV export still works (uses the refactored useFetchCSVData hook):
    - Open a model plan → Share/Export → export a section as CSV
    - From Reports & Analytics, export all model data
 4. Spot-check UI changes:
    - Home page: Filter to a status/type with no models and confirm the "no models" info alert renders correctly (heading + description, no console HTML nesting warnings)
    - Solutions Help → Generic solution: Confirm mail icons and info tooltip icons render correctly
    - Model Plan → Read Only: Confirm the edit icon next to the title still displays
    - MTO milestones: Confirm at-risk / off-track risk indicator icons still display with tooltips
    
    
 ## PR Author Checklist

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.
- [ ] Updated the [BRUNO Collection](../query_examples/MINT) if necessary.

## PR Reviewer Guidelines

- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.